### PR TITLE
Fix Tailscale

### DIFF
--- a/tailscale/exports.sh
+++ b/tailscale/exports.sh
@@ -1,2 +1,6 @@
 export APP_TAILSCALE_IP="10.21.21.80"
 export APP_TAILSCALE_PORT="8240"
+
+echo "Manually patching app script"
+# We need to do this because waiting for Tor HS fails due to being unable to resolve the (disabled for Tailscale) app proxy
+sed -i 's/^  wait_for_tor_hs/  [[ "${app}" != "tailscale"  ]] \&\& wait_for_tor_hs/g' "${UMBREL_ROOT}/scripts/app"

--- a/tailscale/exports.sh
+++ b/tailscale/exports.sh
@@ -1,6 +1,21 @@
 export APP_TAILSCALE_IP="10.21.21.80"
 export APP_TAILSCALE_PORT="8240"
 
-echo "Manually patching app script"
-# We need to do this because waiting for Tor HS fails due to being unable to resolve the (disabled for Tailscale) app proxy
-sed -i 's/^  wait_for_tor_hs/  [[ "${app}" != "tailscale"  ]] \&\& wait_for_tor_hs/g' "${UMBREL_ROOT}/scripts/app"
+# Detect we are running in a tailscale install
+if ! cat "${UMBREL_ROOT}/db/user.json" | grep '"tailscale"'
+then
+
+    # Only patch unmodified v0.5.0 app script to prevent infinite loop or making weird changes to future app scripts
+    if sha256sum "${UMBREL_ROOT}/scripts/app" | grep 43d41ead6963780289e381a172ea346603e36ae650f9e5c878e93aa5c1f78e15
+    then
+        echo "Detected Tailscale install, we need to patch the install script so this doesn't fail!"
+
+        echo "Patching app script..."
+        sed -i 's/^  wait_for_tor_hs/  [[ "${app}" != "tailscale"  ]] \&\& wait_for_tor_hs/g' "${UMBREL_ROOT}/scripts/app"
+
+        echo "Attempting new install after patch"
+        "${UMBREL_ROOT}/scripts/app" install tailscale
+
+        exit # this kills the original install script process
+    fi
+fi

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: tailscale
 category: Networking
 name: Tailscale
-version: "1.22.1"
+version: "1.22.1-build-2"
 tagline: Zero config VPN to access your Umbrel from anywhere
 description: >-
   Tailscale is zero config VPN that creates a secure network between


### PR DESCRIPTION
Detects a Tailscale install failure right before it happens, abuses exports.sh to execute a patch script that runs on the host, patches up the install script, reruns the install command with the patched CLI, and then terminates execution of bad install process.