### PR TITLE
Update Jam to v0.0.6

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   jam:
-    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.5-clientserver-v0.9.5@sha256:5fbbc766b25449e87f5fffb689d236b0a0c9b6332c1cb75478bcbc7225d04ad9
+    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.6-clientserver-v0.9.6@sha256:a4b9a40125585d09f61539085d85846bf26a9fde5755627b163d1a29bf8bf61c
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jam
 category: Finance
 name: Jam
-version: "0.0.5"
+version: "0.0.6"
 tagline: A user-friendly UI for JoinMarket
 description: >-
   Jam is a user-interface for JoinMarket with focus on


### PR DESCRIPTION
This version includes:
- joinmarket-webui: [v0.0.6](https://github.com/joinmarket-webui/joinmarket-webui/releases/tag/v0.0.6)
- joinmarket-clientserver: [v0.9.6](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.6)

All notable changes of the UI can be seen in the [Jam v0.0.6 changelog](https://github.com/joinmarket-webui/joinmarket-webui/blob/v0.0.6/CHANGELOG.md)

Updates to the image:
- increase api request timeout from 60sec to 5min [#34](https://github.com/joinmarket-webui/joinmarket-webui-docker/pull/34)
- update to default config for v0.9.6 [#32](https://github.com/joinmarket-webui/joinmarket-webui-docker/pull/32)