### PR TITLE
Update Tailscale to v1.26.0

### DIFF
--- a/tailscale/docker-compose.yml
+++ b/tailscale/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   web:
     network_mode: "host" # TODO: We can remove this later with some iptables magic
-    image: tailscale/tailscale:v1.22.1@sha256:a8f3198bccfb3d281735cd99f33537c4023fd18d7aa4bce36cdaa827b1124ba0
+    image: tailscale/tailscale:v1.26.0@sha256:604298baab8cda19e55a73e584f6691f6b73c7502ea99ace2a7079e3a845d3e7
     restart: on-failure
     stop_grace_period: 1m
     command: "sh -c 'tailscale web --listen 0.0.0.0:${APP_TAILSCALE_PORT} & exec tailscaled --tun=userspace-networking'"

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: tailscale
 category: Networking
 name: Tailscale
-version: "1.22.1-build-2"
+version: "1.26.0"
 tagline: Zero config VPN to access your Umbrel from anywhere
 description: >-
   Tailscale is zero config VPN that creates a secure network between


### PR DESCRIPTION
This resolves #24 and updates the Tailscale docker version to v1.26.0., which appears to be the current stable release.

Per this post on where to get the SHA256 checksum from:
https://community.getumbrel.com/t/taproot-how-can-we-help/306/9

And following this change as an example:
https://github.com/getumbrel/umbrel-apps/commit/484b538375ddcd0228bb2b0cd91d8602ca86f30f

Appreciate being able to help out.  If I missed something I should be aware of when submitting pull requests, please let me know!