### PR TITLE
Update Bitfeed to v2.3.4

### DIFF
--- a/bitfeed/docker-compose.yml
+++ b/bitfeed/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   web:
-    image: ghcr.io/bitfeed-project/bitfeed-client:v2.3.3@sha256:f1caade65b546fc2feb0c5cabc9054758a0a9d5fb81ece1c3a7e543b9f4e848c
+    image: ghcr.io/bitfeed-project/bitfeed-client:v2.3.4@sha256:5d57477e69a789d547b1c6c441e0ff49e2f5ed46bf4b5ab9ca9f5403f385e926
     restart: on-failure
     stop_grace_period: 1m
     depends_on:
@@ -21,7 +21,7 @@ services:
         ipv4_address: $APP_BITFEED_IP
 
   api:
-    image: ghcr.io/bitfeed-project/bitfeed-server:v2.3.3@sha256:f57ac6a3f6b40de692cdd4c2905beba117b80918336e81bf2f383854afd67c29
+    image: ghcr.io/bitfeed-project/bitfeed-server:v2.3.4@sha256:e38a2e07389cf6d0c519e856291e535fdd10a1e50143d528c82bfe0baf06894f
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/bitfeed/docker-compose.yml
+++ b/bitfeed/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   web:
-    image: ghcr.io/bitfeed-project/bitfeed-client:v2.2.1@sha256:70c89d49d20ba3da21c648c259f45a4b89e06bfe1d97374a092dce6f891d03c6
+    image: ghcr.io/bitfeed-project/bitfeed-client:v2.3.3@sha256:f1caade65b546fc2feb0c5cabc9054758a0a9d5fb81ece1c3a7e543b9f4e848c
     restart: on-failure
     stop_grace_period: 1m
     depends_on:
@@ -21,7 +21,7 @@ services:
         ipv4_address: $APP_BITFEED_IP
 
   api:
-    image: ghcr.io/bitfeed-project/bitfeed-server:v2.2.1@sha256:60eae8109d3d6a377aec8a954f93b6be9ee48de717c9ab5810c2a5afcf688554
+    image: ghcr.io/bitfeed-project/bitfeed-server:v2.3.3@sha256:f57ac6a3f6b40de692cdd4c2905beba117b80918336e81bf2f383854afd67c29
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -34,6 +34,7 @@ services:
       BITCOIN_RPC_PORT: "$APP_BITCOIN_RPC_PORT"
       BITCOIN_RPC_USER: "$APP_BITCOIN_RPC_USER"
       BITCOIN_RPC_PASS: "$APP_BITCOIN_RPC_PASS"
+      TARGET: "umbrel"
       RPC_POOLS: "1"
       RPC_POOL_SIZE: "16"
       LOG_LEVEL: "info"

--- a/bitfeed/umbrel-app.yml
+++ b/bitfeed/umbrel-app.yml
@@ -2,17 +2,17 @@ manifestVersion: 1
 id: bitfeed
 category: Explorers
 name: Bitfeed
-version: "2.2.1"
-tagline: A live visualization of your node's mempool
+version: "2.3.3"
+tagline: A beautiful mempool visualizer and block explorer
 description: >-
-  A self-hosted version of Bitfeed - the open source mempool & block
-  visualizer available at https://bits.monospace.live.
+  A self-hosted version of Bitfeed - the open source mempool visualizer & block
+  explorer available at https://bitfeed.live.
 
 
   Watch as new transactions drop into your node's mempool, before being packaged into newly mined blocks.
 
 
-  Monitor Bitcoin network activity, explore the composition of the latest block, or simply enjoy a soothing Bitcoin screensaver.
+  Monitor Bitcoin network activity, explore blocks and transactions, or simply enjoy a soothing Bitcoin screensaver.
 developer: Mononaut
 website: https://monospace.live
 dependencies:

--- a/bitfeed/umbrel-app.yml
+++ b/bitfeed/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bitfeed
 category: Explorers
 name: Bitfeed
-version: "2.3.3"
+version: "2.3.4"
 tagline: A beautiful mempool visualizer and block explorer
 description: >-
   A self-hosted version of Bitfeed - the open source mempool visualizer & block


### PR DESCRIPTION
Changes since v2.2.1:

- Visualize transactions replaced/dropped from the mempool.
- Block explorer functionality: look up past blocks and transactions.
- Substantially reduced CPU load on start up.
- Smoother, fancier graphics