### PR TITLE
Added PROXY_AUTH_ADD: "false"

### DIFF
--- a/sparkkiosk/docker-compose.yml
+++ b/sparkkiosk/docker-compose.yml
@@ -3,7 +3,8 @@ version: "3.7"
 services:
   app_proxy:
     environment:
-      APP_HOST: $APP_SPARKKIOSK_IP
+      PROXY_AUTH_ADD: "false"
+	  APP_HOST: $APP_SPARKKIOSK_IP
       APP_PORT: 21214
 
   web:

--- a/sparkkiosk/docker-compose.yml
+++ b/sparkkiosk/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app_proxy:
     environment:
       PROXY_AUTH_ADD: "false"
-	  APP_HOST: $APP_SPARKKIOSK_IP
+      APP_HOST: $APP_SPARKKIOSK_IP
       APP_PORT: 21214
 
   web:

--- a/sparkkiosk/umbrel-app.yml
+++ b/sparkkiosk/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: sparkkiosk
 category: Finance
 name: Sparkkiosk
-version: "1.0.0"
+version: "1.0.0-build-2"
 tagline: Minimal LNURL kiosk
 description: >-
   Use sparkkiosk to enable lightning payments from printed QR codes


### PR DESCRIPTION
Service needs to be publicly accessible to return LNURLS - thus disabling umbrel default password protection setting PROXY_AUTH_ADD: "false" - still uses the password generated by umbrel.