### PR TITLE
Upgrade ItchySats to 0.4.21

### DIFF
--- a/itchysats/docker-compose.yml
+++ b/itchysats/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8000
 
   web:
-    image: ghcr.io/itchysats/itchysats/taker:0.4.16@sha256:f404ace4baf85b9799bfa709c9481b35fabe22d6dcaf7fb8f664730c09230bc2
+    image: ghcr.io/itchysats/itchysats/taker:0.4.21@sha256:289164deb159c735af48cfe1332653e803b69485129ac7727aaf37de3dd6a3f5
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/itchysats/umbrel-app.yml
+++ b/itchysats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: itchysats
 category: Finance
 name: ItchySats
-version: "0.4.16"
+version: "0.4.21"
 tagline: Peer-2-peer derivatives on Bitcoin
 description: >-
   ItchySats enables peer-2-peer CFD trading on Bitcoin using DLCs


### PR DESCRIPTION
## 0.4.21 - 2022-06-27

### Added

- Allow maker to provide extended private key as argument when starting. This key will be used to derive the internal wallet according to (Bip84)[https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki]
- Added new HTTP endpoint to manually trigger a wallet sync under `/api/sync`
- Added manual wallet sync button to the UI to allow the user to trigger a manual sync
- Added new endpoint to maker and taker to get the daemon version under `/api/version`
- Added an info box in taker-ui to show if a new version is available

### Changed

- Migrate away from JSON blobs in the DB to a more normalized database for RolloverCompleted events
- Use sled database for wallet. The wallet file is stored in your data-dir as either `maker-wallet` for the maker and `taker-wallet` for the taker respectively
- Rollover using the `libp2p` connection
- Improve the rollover protocol for resilience. Allow rollovers from a previous `commit-txid` and record a snapshot of the complete fee after each rollover
- Collaborative settlement using the `libp2p` connection
- Improve the collaborative settlement protocol for resilience. Exchange signatures to allow the taker to publish the collaborative settlement transaction at the end of the protocol.

### Fixed

- An issue where the stored revoke commit adaptor signature was not stored correctly. We now correctly pick the adaptor signature from the previous `Dlc`.

## 0.4.20 - 2022-05-26

## 0.4.19 - 2022-05-25

### Added

- A QR code for the ItchySats wallet that can be scanned to retrieve the current address.
- `ITCHYSATS_ENV` variable that defines different environment of running ItchySats (Umbrel, RaspiBlitz, Docker, Binary)

### Changed

- The API for retrieving offers now returns `leverage_details` which is a set of leverages including pre-computed values for margin, liquidation price and initial funding fee.
- Taker can choose a leverage provided the maker offers a selection of leverage.
- Rollback that a second connection of a taker would steal the old connection
- The rollover protocol is handled over the libp2p connection. The maker supports both legacy and libp2p requests for rolling over.

### Fixed

- An issue where the maker's libp2p ping actor panicked upon startup.
- An issue where fees were not handled correctly in `maia` that could result in invalid transactions.

## 0.4.17 - 2022-05-23

- Culling old DLC data from database, i.e. we remove old DLC data which is not needed anymore. This reduces the db size and is more efficient when loading