### PR TITLE
Update Jam to v0.0.8

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   jam:
-    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.6-clientserver-v0.9.6@sha256:a4b9a40125585d09f61539085d85846bf26a9fde5755627b163d1a29bf8bf61c
+    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.8-clientserver-v0.9.6@sha256:f86c4b2546d0f1e7d5c87e6ac597023d671bdb77270008b8aee91c2658b75992
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jam
 category: Finance
 name: Jam
-version: "0.0.6"
+version: "0.0.8"
 tagline: A user-friendly UI for JoinMarket
 description: >-
   Jam is a user-interface for JoinMarket with focus on


### PR DESCRIPTION
This version includes:
- joinmarket-webui: [v0.0.8](https://github.com/joinmarket-webui/joinmarket-webui/releases/tag/v0.0.8)
- joinmarket-clientserver: [v0.9.6](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.6)

All notable changes of the UI can be seen in the [Jam v0.0.8 changelog](https://github.com/joinmarket-webui/joinmarket-webui/blob/v0.0.8/CHANGELOG.md)