### PR TITLE
gitea 1.15.2 -> 1.16.8

### DIFF
--- a/gitea/docker-compose.yml
+++ b/gitea/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: gitea/gitea:1.15.2-rootless@sha256:6caabcf0e1a21a2d885f44c8f19693ce44ec3d443e2116f86a2937db453566a8
+    image: gitea/gitea:1.16.8-rootless@sha256:8a6ad22694c76122ae075af1153a544577724c45cb45af44963aa78dc179cc46
     user: "1000:1000"
     restart: on-failure
     ports:

--- a/gitea/umbrel-app.yml
+++ b/gitea/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: gitea
 category: Development
 name: Gitea
-version: "1.15.2"
+version: "1.16.8"
 tagline: A painless self-hosted Git service
 description: >-
   Gitea is a painless self-hosted Git service. It is similar to


### PR DESCRIPTION
[Release Notes](https://github.com/go-gitea/gitea/releases/tag/v1.16.8)
```
umbrel@umbrel-dev:~/umbrel $ docker pull gitea/gitea:1.16.8-rootless
1.16.8-rootless: Pulling from gitea/gitea
edd30f0f1704: Pull complete
57e9c18c8891: Pull complete
94a5a21730ad: Pull complete
8f48dc79d0bd: Pull complete
5b366ceb4c52: Pull complete
16a5fdff2fc7: Pull complete
25eb8a29c989: Pull complete
0051788b8333: Pull complete
58073f6457f3: Pull complete
Digest: sha256:8a6ad22694c76122ae075af1153a544577724c45cb45af44963aa78dc179cc46
Status: Downloaded newer image for gitea/gitea:1.16.8-rootless
docker.io/gitea/gitea:1.16.8-rootless
```

Tested upgrade and fresh install on ARM64 (pi)