### PR TITLE
Upgrade IPFS Podcasting to v0.6

### DIFF
--- a/ipfs-podcasting/docker-compose.yml
+++ b/ipfs-podcasting/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_IPFS_PODCASTING_PORT
 
   web:
-    image: ipfspodcasting/podcastnode:v0.5@sha256:aa56c571494323f210677ad4291ffead0fff31a1da1544766557e54b413f43d0
+    image: ipfspodcasting/podcastnode:v0.6
     init: true
     restart: on-failure
     stop_grace_period: 1m

--- a/ipfs-podcasting/docker-compose.yml
+++ b/ipfs-podcasting/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_IPFS_PODCASTING_PORT
 
   web:
-    image: ipfspodcasting/podcastnode:v0.6
+    image: ipfspodcasting/podcastnode:v0.6@sha256:773d7c34d452764be973e8bc495990ec47f8042287493997784198c64e924393
     init: true
     restart: on-failure
     stop_grace_period: 1m

--- a/ipfs-podcasting/umbrel-app.yml
+++ b/ipfs-podcasting/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ipfs-podcasting
 category: Files
 name: IPFS Podcasting
-version: "0.5"
+version: "0.6"
 tagline: Crowd-host podcasts over IPFS
 description: |-
   Turn your Umbrel into an IPFS node for self-hosting, crowd-hosting, and archiving of your favorite podcasts to the IPFS network.


### PR DESCRIPTION
Pushed a new v0.6 docker image. Thought I saw an app store update (automatically) during testing, but my Umbrels (arm & amd) haven't displayed a notification to update to 0.6.