### PR TITLE
Update Krystal Bull images to include autologin

### DIFF
--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       BITCOIN_S_HOME: "/home/bitcoin-s/.bitcoin-s/"
       ORACLE_SERVER_API_URL: "http://${APP_KRYSTAL_BULL_SERVER_IP}:9998/"
       TOR_PROXY: socks5://${TOR_PROXY_IP}:${TOR_PROXY_PORT}
-      DEFAULT_UI_PASSWORD: $APP_PASSWORD
+      DEFAULT_UI_PASSWORD: "none"
       BITCOIN_S_ORACLE_RPC_PASSWORD: $APP_PASSWORD
     networks:
       default:

--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_HOST: $APP_KRYSTAL_BULL_IP
       APP_PORT: 3001
   web:
-    image: bitcoinscala/oracle-server-ui:1.9.2@sha256:9b92f448cae7de4044f9a69df3a873f3fce6d27282b1a227c555a26210a063c9
+    image: bitcoinscala/oracle-server-ui:1.9.2-f44ad4a4-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -26,7 +26,7 @@ services:
     depends_on: 
       - oracleserver
   oracleserver:
-    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2@sha256:a702308a3134be24cc5612b5255afb66f0296ca932bcd65f4faf96487de4a6e3
+    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-42-83cff9a4-SNAPSHOT
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data/oracleserver:/home/bitcoin-s/.bitcoin-s

--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_HOST: $APP_KRYSTAL_BULL_IP
       APP_PORT: 3001
   web:
-    image: bitcoinscala/oracle-server-ui:1.9.2-f44ad4a4-SNAPSHOT
+    image: bitcoinscala/oracle-server-ui:1.9.2-f44ad4a4-SNAPSHOT@sha256:aa128ad3e4134585390127c092bad09d1632055108f459c248048246c1cabab7
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -26,7 +26,7 @@ services:
     depends_on: 
       - oracleserver
   oracleserver:
-    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-42-83cff9a4-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-42-83cff9a4-SNAPSHOT@sha256:bbe1673878fe44e1a1554279e049f24e81a4f771e81928d59d2add236734d350
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data/oracleserver:/home/bitcoin-s/.bitcoin-s

--- a/krystal-bull/umbrel-app.yml
+++ b/krystal-bull/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: krystal-bull
 category: Finance
 name: Krystal Bull
-version: "1.9.2"
+version: "1.9.2-f44ad4a4"
 tagline: Become an oracle and create Bitcoin bets
 description: >-
   Krystal Bull allows you to become a Bitcoin oracle. An oracle

--- a/krystal-bull/umbrel-app.yml
+++ b/krystal-bull/umbrel-app.yml
@@ -17,6 +17,8 @@ description: >-
 
 
   WARNING: This version of Krystal Bull is an early alpha release for testing. It's not secure, please don't use it for anything serious.
+releaseNotes: >-
+  Auto login
 developer: SuredBits
 website: https://suredbits.com/
 dependencies: []


### PR DESCRIPTION
Updates Krystal Bull docker images to include autologin functionality

The backend image:
https://hub.docker.com/layers/249479785/bitcoinscala/bitcoin-s-oracle-server/1.9.2-42-83cff9a4-SNAPSHOT/images/sha256-ca622219d3502f6970ae920b3c26ed05011de867d51fdb864d9df32914a2bbc1?context=repo

the frontend image: 
https://hub.docker.com/layers/249503207/bitcoinscala/oracle-server-ui/1.9.2-f44ad4a4-SNAPSHOT/images/sha256-1338a36213803e98330d844b4ef877d7e56a149394a985f76f29ff25d016fb04?context=repo