### PR TITLE
Update Jam to v0.0.9

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,15 +7,16 @@ services:
       APP_PORT: 80
 
   jam:
-    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.8-clientserver-v0.9.6@sha256:f86c4b2546d0f1e7d5c87e6ac597023d671bdb77270008b8aee91c2658b75992
+    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.9-clientserver-v0.9.6@sha256:f36da8ed2f75b8db8dca34783b1e1ed11d0048270140b1c2cc072b15191e6b6c
     restart: on-failure
     stop_grace_period: 1m
     init: true
     volumes:
       - ${APP_DATA_DIR}/data/joinmarket:/root/.joinmarket
     environment:
-      ENSURE_WALLET: 1
-      RESTORE_DEFAULT_CONFIG: 1
+      RESTORE_DEFAULT_CONFIG: "true"
+      REMOVE_LOCK_FILES: "true"
+      ENSURE_WALLET: "true"
       APP_USER: umbrel
       APP_PASSWORD: "${APP_PASSWORD}"
       jm_tor_control_host: $TOR_PROXY_IP

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jam
 category: Finance
 name: Jam
-version: "0.0.8"
+version: "0.0.9"
 tagline: A user-friendly UI for JoinMarket
 description: >-
   Jam is a user-interface for JoinMarket with focus on


### PR DESCRIPTION
This version includes:
- joinmarket-webui: [v0.0.9](https://github.com/joinmarket-webui/joinmarket-webui/releases/tag/v0.0.9)
- joinmarket-clientserver: [v0.9.6](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.6)

All notable changes of the UI can be seen in the [Jam v0.0.9 changelog](https://github.com/joinmarket-webui/joinmarket-webui/blob/v0.0.9/CHANGELOG.md)

Updates to the image:
- [remove leftover wallet lockfiles](https://github.com/getumbrel/umbrel-apps/pull/52#issuecomment-1169784192) before startup

As [mentioned in the latest PR](https://github.com/getumbrel/umbrel-apps/pull/52#pullrequestreview-1022603593) and what came up during a conversation with @nevets963, we are still tracking "removing Basic Auth" (https://github.com/joinmarket-webui/joinmarket-webui-docker/issues/42) and "using own Tor daemon" (https://github.com/joinmarket-webui/joinmarket-webui-docker/issues/43) which did not make it into this version, but will be included in the next version.