### PR TITLE
Update LnVisualizer to v0.0.25

### DIFF
--- a/ln-visualizer/docker-compose.yml
+++ b/ln-visualizer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   web:
-    image: maxkotlan/ln-visualizer-web:v0.0.23@sha256:4f43a46bae95245e7c271416b5ebadff2384a03b2ee9a9b3d3aea44043a9ce99
+    image: maxkotlan/ln-visualizer-web:v0.0.25@sha256:c349a106a6fb69c6d56301ae87f9844687a5ec28df9a104fb0b7585a67264092
     init: true
     restart: on-failure
     stop_grace_period: 1m
@@ -18,7 +18,7 @@ services:
         ipv4_address: "${APP_LN_VISUALIZER_WEB_IP}"
 
   api:
-    image: maxkotlan/ln-visualizer-api:v0.0.23@sha256:db7916921d9a5d354038715fb9b5f4256369192660f2989bbd49276ccaf3eb7e
+    image: maxkotlan/ln-visualizer-api:v0.0.25@sha256:839a53dd2fe230743cdc6edcd34811b7ec41644f433e8d52777482df57a72408
     init: true
     restart: on-failure
     stop_grace_period: 1m

--- a/ln-visualizer/umbrel-app.yml
+++ b/ln-visualizer/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ln-visualizer
 category: Explorers
 name: LnVisualizer
-version: "0.0.23"
+version: "0.0.25"
 tagline: View the Lightning Network from your node's perspective
 description:
   Your Lightning node is continuously receiving, storing, and transmitting graph information.

--- a/ln-visualizer/umbrel-app.yml
+++ b/ln-visualizer/umbrel-app.yml
@@ -3,6 +3,16 @@ id: ln-visualizer
 category: Explorers
 name: LnVisualizer
 version: "0.0.25"
+releaseNotes: >-
+  - Initial sync performance improvements
+
+  - New control to filter node by feature bits
+
+  - New dropdown for filtering by node network type (tor vs clearnet)
+
+  - Redesigned statistics window. Now it will calculate min/max/total/average for both the entire network and for subgraph being viewed.
+
+  - New settings dropdown to normalize channel color to min/max range of subgraph
 tagline: View the Lightning Network from your node's perspective
 description:
   Your Lightning node is continuously receiving, storing, and transmitting graph information.


### PR DESCRIPTION
new features:

- initial sync performance improvements
- can filter by node feature bits
- filter dropdown for node network type (onion vs clearnet)
- new statistics window. Will calculate min/max/total/average for both the entire network and for subgraph being viewed.
- new mode to normalize channel color to min/max range of subgraph