### PR TITLE
Upgrade ItchySats to `0.5.0`

### DIFF
--- a/itchysats/docker-compose.yml
+++ b/itchysats/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8000
 
   web:
-    image: ghcr.io/itchysats/itchysats/taker:0.4.16@sha256:f404ace4baf85b9799bfa709c9481b35fabe22d6dcaf7fb8f664730c09230bc2
+    image: ghcr.io/itchysats/itchysats/taker:0.5.0@sha256:884f2f23756e67dd418aaf1aa2c5fcaf385bec6f37dc8412a02ab870da2168b5
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/itchysats/umbrel-app.yml
+++ b/itchysats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: itchysats
 category: Finance
 name: ItchySats
-version: "0.4.16"
+version: "0.5.0"
 tagline: Peer-2-peer derivatives on Bitcoin
 description: >-
   ItchySats enables peer-2-peer CFD trading on Bitcoin using DLCs
@@ -33,14 +33,15 @@ description: >-
 
 
   1. Minimum position quantity is $100, maximum $1000
-
-  2. The leverage is fixed at 2
-
-
+  
+  
   With 0.4.0 your CFDs are perpetual positions that are extended hourly. This means your CFD position will remain open forever unless you decide to close it. A funding fee is collected hourly when the CFD is extended.
 
 
   With 0.4.8 you can open long and short positions, previously only long positions were possible.
+  
+  
+  With 0.5.0 you can chose from different from leverage. Leverage choices are configured by the maker and might initially be restricted to x1, x2 and x3.
 developer: ItchySats
 website: https://itchysats.network
 dependencies:
@@ -56,3 +57,6 @@ path: ""
 defaultUsername: itchysats
 deterministicPassword: true
 torOnly: false
+releaseNotes: >-
+  Users on versions 0.4.x are still supported for the time being, 0.5.0 is not breaking.
+  However, support for previous protocol version will eventually be discontinued, upgrading is encouraged!


### PR DESCRIPTION
Long was the wait - finally a new ItchySats version!

Note: Users on versions `0.4.x` are still supported for the time being, `0.5.0` is not breaking. However, support for previous protocol version will eventually be discontinued, upgrading is encouraged :)

For detailed changes please refer to the [release changelogs](https://github.com/itchysats/itchysats/releases/).