### PR TITLE
fix: samourai-server app depends on electrs

### DIFF
--- a/samourai-server/umbrel-app.yml
+++ b/samourai-server/umbrel-app.yml
@@ -20,6 +20,7 @@ developer: Samourai
 website: https://samouraiwallet.com
 dependencies:
   - bitcoin
+  - electrs
 repo: https://github.com/louneskmt/umbrel-samourai-dojo/tree/v1.16.1-umbrel
 support: https://t.me/SamouraiWallet
 port: 3005


### PR DESCRIPTION
Samourai Server depends on electrs (local indexer).

https://github.com/getumbrel/umbrel-apps/blob/642a4bd52a2cfbb2431a84b1e9ea1b9a8b9d2273/samourai-server/docker-compose.yml#L80-L84
