### PR TITLE
Bump Oak Node to v0.3.3

### DIFF
--- a/oak-node/docker-compose.yml
+++ b/oak-node/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_OAK_NODE_PORT
 
   web:
-    image: oak-node.net/oak:v0.3.2@sha256:ed6dc77c36032b036b7182b02305b76312fa6c89c7cafc6047cb59d32ab1e507
+    image: oak-node.net/oak:v0.3.3@sha256:484ef07889cf2eab5db85c4feecc94fc5e86c76e17ae658bd5aa11972db5678d
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/oak-node/umbrel-app.yml
+++ b/oak-node/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: oak-node
 category: Finance
 name: Oak Node
-version: "0.3.2"
+version: "0.3.3"
 tagline: Do more with your LND node
 description: >-
   Oak Node gives you Scheduled Payments. Now you can send sats to a Lightning Address on a schedule. 
@@ -11,10 +11,10 @@ description: >-
 
   Oak Node also includes an optional bot module for more advanced users.
 releaseNotes: >-
-  This update adds a Nostr bot, which lets you issue commands to your Oak Node from any Nostr client.
+  This update brings charts for your Scheduled Payments, showing you at a glance how many sats are scheduled to go, when, and to whom.
   
   
-  It also brings support for sending to Lightning Addresses on tor, as well as other smaller fixes and improvements.
+  It also brings several improvements to the Nostr bot, as well as other smaller fixes.
 developer: Carlos
 website: https://oak-node.net
 dependencies:


### PR DESCRIPTION
Two main changes:

* charts for the Scheduled Payments view
* for the Nostr bot, users can now change the pubkey from the Oak Node UI

Tested in a VM and on a raspi.