### PR TITLE
Update jam v0.0.10

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   jam:
-    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.9-clientserver-v0.9.6@sha256:f36da8ed2f75b8db8dca34783b1e1ed11d0048270140b1c2cc072b15191e6b6c
+    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.9-clientserver-v0.9.6@sha256:4287ebb5d7d9bda7acdc77662df7adf0b6e7a5974a39a314c3ec0e85336ec1d5
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -17,8 +17,6 @@ services:
       RESTORE_DEFAULT_CONFIG: "true"
       REMOVE_LOCK_FILES: "true"
       ENSURE_WALLET: "true"
-      APP_USER: umbrel
-      APP_PASSWORD: "${APP_PASSWORD}"
       jm_network: $APP_BITCOIN_NETWORK
       jm_rpc_host: $APP_BITCOIN_NODE_IP
       jm_rpc_port: $APP_BITCOIN_RPC_PORT

--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -19,18 +19,12 @@ services:
       ENSURE_WALLET: "true"
       APP_USER: umbrel
       APP_PASSWORD: "${APP_PASSWORD}"
-      jm_tor_control_host: $TOR_PROXY_IP
-      jm_tor_control_port: 29051
-      jm_onion_socks5_host: $TOR_PROXY_IP
-      jm_onion_socks5_port: $TOR_PROXY_PORT
-      jm_socks5_host: $TOR_PROXY_IP
-      jm_socks5_port: $TOR_PROXY_PORT
+      jm_network: $APP_BITCOIN_NETWORK
       jm_rpc_host: $APP_BITCOIN_NODE_IP
       jm_rpc_port: $APP_BITCOIN_RPC_PORT
       jm_rpc_user: $APP_BITCOIN_RPC_USER
       jm_rpc_password: "${APP_BITCOIN_RPC_PASS}"
       jm_rpc_wallet_file: jam_default
-      jm_network: $APP_BITCOIN_NETWORK
       jm_max_cj_fee_abs: 300000 # in sats
       jm_max_cj_fee_rel: 0.0003 # 0.03%
     networks:

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jam
 category: Finance
 name: Jam
-version: "0.0.9"
+version: "0.0.10"
 tagline: A user-friendly UI for JoinMarket
 description: >-
   Jam is a user-interface for JoinMarket with focus on


### PR DESCRIPTION
This version includes:
- Jam: [v0.0.10](https://github.com/joinmarket-webui/jam/releases/tag/v0.0.10)
- joinmarket-clientserver: [v0.9.6](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.6)

All notable changes of the UI can be seen in the [Jam v0.0.10 changelog](https://github.com/joinmarket-webui/jam/blob/v0.0.10/CHANGELOG.md)

Updates to the image:
- opt-in for basic authentication
- run local tor daemon



