### PR TITLE
2022 08 16 suredbits wallet update

### DIFF
--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -31,10 +31,11 @@ services:
   
   walletserver:
     image: bitcoinscala/bitcoin-s-server:1.9.2-160-85c01f7a-SNAPSHOT
+    entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:0"
     restart: on-failure
     volumes:
-      - ${APP_DATA_DIR}/data/wallet:/home/demiourgos728/.bitcoin-s
+      - ${APP_DATA_DIR}/data/wallet:/home/bitcoin-s/.bitcoin-s
     environment:
       BITCOIN_S_NODE_MODE: "bitcoind"
       BITCOIN_S_NETWORK: $APP_BITCOIN_NETWORK

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3002
 
   web:
-    image: bitcoinscala/wallet-server-ui:1.9.2-d2ce1a9e-SNAPSHOT
+    image: bitcoinscala/wallet-server-ui:1.9.2-9a14a58e-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-160-85c01f7a-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-server:1.9.2-164-2dad9f57-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     restart: on-failure
     stop_grace_period: 1m
     volumes:
-      - bitcoin-s-backend-datadir:/home/bitcoin-s/.bitcoin-s
-      - bitcoin-s-frontend-log:/log
+      - ${APP_DATA_DIR}/data/wallet:/home/bitcoin-s/.bitcoin-s
+      - ${APP_DATA_DIR}/data/log:/home/bitcoin-s/.bitcoin-s
     environment:
       LOG_PATH: "/log/"
       BITCOIN_S_HOME: "/home/bitcoin-s/.bitcoin-s/"
@@ -31,11 +31,11 @@ services:
   
   walletserver:
     image: bitcoinscala/bitcoin-s-server:1.9.2-196-c266ba84-SNAPSHOT
-    entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
+    entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure
     volumes:
-      - bitcoin-s-backend-datadir:/home/bitcoin-s/.bitcoin-s
+      - ${APP_DATA_DIR}/data/wallet:/bitcoin-s
     environment:
       BITCOIN_S_NODE_MODE: "bitcoind"
       BITCOIN_S_NETWORK: $APP_BITCOIN_NETWORK
@@ -58,22 +58,3 @@ services:
     networks:
       default:
         ipv4_address: $APP_SUREDBITS_WALLET_SERVER_IP
-
-
-volumes:
-  bitcoin-s-backend-datadir:
-    name: "bitcoin-s-backend-datadir"
-    driver: local
-    external: false
-    driver_opts:
-      o: bind
-      type: none
-      device: ${APP_DATA_DIR}/data/wallet
-  bitcoin-s-frontend-log:
-    name: "bitcoin-s-frontend-log"
-    driver: local
-    external: false
-    driver_opts:
-      o: bind
-      type: none
-      device: ${APP_DATA_DIR}/data/log

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-187-02f525fd-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-server:1.9.2-195-2cae3f80-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-178-2c2e03b2-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-server:1.9.2-183-2001e86a-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure
@@ -52,6 +52,7 @@ services:
       BITCOIN_S_BITCOIND_PASSWORD: $APP_BITCOIN_RPC_PASS
       BITCOIN_S_SERVER_RPC_PASSWORD: $APP_PASSWORD
       JAVA_OPTS: "-Xmx756m"
+      DISABLE_JLINK: "1"
     ports:
       - "$APP_SUREDBITS_WALLET_P2P_PORT:$APP_SUREDBITS_WALLET_P2P_PORT"
     networks:

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3002
 
   web:
-    image: bitcoinscala/wallet-server-ui:1.9.2-7fe71420-SNAPSHOT
+    image: bitcoinscala/wallet-server-ui:1.9.3@sha256:027f98c3447cec20fc4a75113e11447d8756133df0832edee4566daa591a7153
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-206-dac65ca8-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-server:1.9.3@sha256:f874c4547631aacb84921b34c521d63eca2bc5924e4e2b45b30250c84a9f84a1
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-195-2cae3f80-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-server:1.9.2-196-c266ba84-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3002
 
   web:
-    image: bitcoinscala/wallet-server-ui:1.9.2-9a14a58e-SNAPSHOT
+    image: bitcoinscala/wallet-server-ui:1.9.2-ceb19a36-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-198-f65b483d-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-server:1.9.2-201-945b3914-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   web:
     image: bitcoinscala/wallet-server-ui:1.9.2-1cd65c60-SNAPSHOT
-    user: "1000:1000"
+    user: "1001:1000"
     restart: on-failure
     stop_grace_period: 1m
     volumes:
@@ -31,7 +31,7 @@ services:
   
   walletserver:
     image: bitcoinscala/bitcoin-s-server:1.9.2-159-1b19872a-SNAPSHOT
-    user: "1000:1000"
+    user: "1001:1000"
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data/wallet:/home/bitcoin-s/.bitcoin-s

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   web:
     image: bitcoinscala/wallet-server-ui:1.9.2-1cd65c60-SNAPSHOT
-    user: "1001:1000"
+    user: "1000:1001"
     restart: on-failure
     stop_grace_period: 1m
     volumes:
@@ -31,7 +31,7 @@ services:
   
   walletserver:
     image: bitcoinscala/bitcoin-s-server:1.9.2-159-1b19872a-SNAPSHOT
-    user: "1001:1000"
+    user: "1000:1001"
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data/wallet:/home/demiourgos728/.bitcoin-s

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     user: "1001:1000"
     restart: on-failure
     volumes:
-      - ${APP_DATA_DIR}/data/wallet:/home/bitcoin-s/.bitcoin-s
+      - ${APP_DATA_DIR}/data/wallet:/home/demiourgos728/.bitcoin-s
     environment:
       BITCOIN_S_NODE_MODE: "bitcoind"
       BITCOIN_S_NETWORK: $APP_BITCOIN_NETWORK

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   web:
     image: bitcoinscala/wallet-server-ui:1.9.2-1cd65c60-SNAPSHOT
-    user: "1001:1000"
+    user: "1000:0"
     restart: on-failure
     stop_grace_period: 1m
     volumes:
@@ -31,7 +31,7 @@ services:
   
   walletserver:
     image: bitcoinscala/bitcoin-s-server:1.9.2-159-1b19872a-SNAPSHOT
-    user: "1001:1000"
+    user: "1000:0"
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data/wallet:/home/demiourgos728/.bitcoin-s

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-164-2dad9f57-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-server:1.9.2-165-eb132782-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3002
 
   web:
-    image: bitcoinscala/wallet-server-ui:1.9.2-ceb19a36-SNAPSHOT
+    image: bitcoinscala/wallet-server-ui:1.9.2-7fe71420-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-201-945b3914-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-server:1.9.2-206-dac65ca8-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   web:
     image: bitcoinscala/wallet-server-ui:1.9.2-1cd65c60-SNAPSHOT
-    user: "1000:1001"
+    user: "1001:1000"
     restart: on-failure
     stop_grace_period: 1m
     volumes:
@@ -31,7 +31,7 @@ services:
   
   walletserver:
     image: bitcoinscala/bitcoin-s-server:1.9.2-159-1b19872a-SNAPSHOT
-    user: "1000:1001"
+    user: "1001:1000"
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data/wallet:/home/demiourgos728/.bitcoin-s

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   web:
     image: bitcoinscala/wallet-server-ui:1.9.2-1cd65c60-SNAPSHOT
-    user: "1000:0"
+    user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
     volumes:
@@ -32,7 +32,7 @@ services:
   walletserver:
     image: bitcoinscala/bitcoin-s-server:1.9.2-160-85c01f7a-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
-    user: "1000:0"
+    user: "1000:1000"
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data/wallet:/home/bitcoin-s/.bitcoin-s

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     restart: on-failure
     stop_grace_period: 1m
     volumes:
-      - ${APP_DATA_DIR}/data/wallet:/home/bitcoin-s/.bitcoin-s
-      - ${APP_DATA_DIR}/data/log:/home/bitcoin-s/.bitcoin-s
+      - ${APP_DATA_DIR}/data/wallet:/bitcoin-s
+      - ${APP_DATA_DIR}/data/log:/log
     environment:
       LOG_PATH: "/log/"
       BITCOIN_S_HOME: "/bitcoin-s"

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ${APP_DATA_DIR}/data/log:/log
     environment:
       LOG_PATH: "/log/"
-      BITCOIN_S_HOME: "/bitcoin-s"
+      BITCOIN_S_HOME: "/bitcoin-s/"
      #MEMPOOL_API_URL: "http://umbrel.local:${APP_MEMPOOL_PORT}/api"
       WALLET_SERVER_API_URL: "http://${APP_SUREDBITS_WALLET_SERVER_IP}:9999/"
       WALLET_SERVER_WS: "ws://${APP_SUREDBITS_WALLET_SERVER_IP}:19999/events"

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-196-c266ba84-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-server:1.9.2-198-f65b483d-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-159-1b19872a-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-server:1.9.2-160-85c01f7a-SNAPSHOT
     user: "1000:0"
     restart: on-failure
     volumes:

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-167-713ee75d-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-server:1.9.2-176-a0eb0824-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3002
 
   web:
-    image: bitcoinscala/wallet-server-ui:1.9.2-1cd65c60-SNAPSHOT
+    image: bitcoinscala/wallet-server-ui:1.9.2-d2ce1a9e-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-176-a0eb0824-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-server:1.9.2-178-2c2e03b2-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     restart: on-failure
     stop_grace_period: 1m
     volumes:
-      - ${APP_DATA_DIR}/data/wallet:/home/bitcoin-s/.bitcoin-s
-      - ${APP_DATA_DIR}/data/log:/log
+      - bitcoin-s-backend-datadir:/home/bitcoin-s/.bitcoin-s
+      - bitcoin-s-frontend-log:/log
     environment:
       LOG_PATH: "/log/"
       BITCOIN_S_HOME: "/home/bitcoin-s/.bitcoin-s/"
@@ -35,7 +35,7 @@ services:
     user: "1000:1000"
     restart: on-failure
     volumes:
-      - ${APP_DATA_DIR}/data/wallet:/home/bitcoin-s/.bitcoin-s
+      - bitcoins-s-backend-datadir:/home/bitcoin-s/.bitcoin-s
     environment:
       BITCOIN_S_NODE_MODE: "bitcoind"
       BITCOIN_S_NETWORK: $APP_BITCOIN_NETWORK
@@ -58,3 +58,22 @@ services:
     networks:
       default:
         ipv4_address: $APP_SUREDBITS_WALLET_SERVER_IP
+
+
+volumes:
+  bitcoin-s-backend-datadir:
+    name: "bitcoin-s-backend-datadir"
+    driver: local
+    external: false
+    driver_opts:
+      o: bind
+      type: none
+      device: ${APP_DATA_DIR}/data/wallet
+  bitcoin-s-frontend-log:
+    name: "bitcoin-s-frontend-log"
+    driver: local
+    external: false
+    driver_opts:
+      o: bind
+      type: none
+      device: ${APP_DATA_DIR}/data/log

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3002
 
   web:
-    image: bitcoinscala/wallet-server-ui:1.9.3@sha256:027f98c3447cec20fc4a75113e11447d8756133df0832edee4566daa591a7153
+    image: bitcoinscala/wallet-server-ui:1.9.3@sha256:dfbded611403fb03dac45fe915320079933e8f864e0942b7fb3ddea017e2b8dd
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.3@sha256:f874c4547631aacb84921b34c521d63eca2bc5924e4e2b45b30250c84a9f84a1
+    image: bitcoinscala/bitcoin-s-server:1.9.3@sha256:db995d23ed6cd5a31de5fffe06c6edff5c420c77b63440169c41c2016c89993c
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3002
 
   web:
-    image: bitcoinscala/wallet-server-ui:1.9.2-f44ad4a4-SNAPSHOT@sha256:61d0f156202314cdfe00e184affa72f98c23fa79b8c9f56eed93f5802b0c2f82
+    image: bitcoinscala/wallet-server-ui:1.9.2-1cd65c60-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-66-b16a8ca6-SNAPSHOT@sha256:bde3cbb50c4e5e8e4a5f28ae90e84718f093506e4f8ae6e9c3d0894bd7e102f5
+    image: bitcoinscala/bitcoin-s-server:1.9.2-159-1b19872a-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   web:
     image: bitcoinscala/wallet-server-ui:1.9.2-1cd65c60-SNAPSHOT
-    user: "1000:1000"
+    user: "1000:0"
     restart: on-failure
     stop_grace_period: 1m
     volumes:
@@ -32,7 +32,7 @@ services:
   walletserver:
     image: bitcoinscala/bitcoin-s-server:1.9.2-160-85c01f7a-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
-    user: "1000:1000"
+    user: "1000:0"
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data/wallet:/home/bitcoin-s/.bitcoin-s

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -30,8 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-183-2001e86a-SNAPSHOT
-    entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
+    image: bitcoinscala/bitcoin-s-server:1.9.2-184-288918d7-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-165-eb132782-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-server:1.9.2-167-713ee75d-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - walletserver
   
   walletserver:
-    image: bitcoinscala/bitcoin-s-server:1.9.2-184-288918d7-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-server:1.9.2-187-02f525fd-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     user: "1000:1000"
     restart: on-failure
     volumes:
-      - bitcoins-s-backend-datadir:/home/bitcoin-s/.bitcoin-s
+      - bitcoin-s-backend-datadir:/home/bitcoin-s/.bitcoin-s
     environment:
       BITCOIN_S_NODE_MODE: "bitcoind"
       BITCOIN_S_NETWORK: $APP_BITCOIN_NETWORK

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -31,6 +31,7 @@ services:
   
   walletserver:
     image: bitcoinscala/bitcoin-s-server:1.9.2-187-02f525fd-SNAPSHOT
+    entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ${APP_DATA_DIR}/data/log:/home/bitcoin-s/.bitcoin-s
     environment:
       LOG_PATH: "/log/"
-      BITCOIN_S_HOME: "/home/bitcoin-s/.bitcoin-s/"
+      BITCOIN_S_HOME: "/bitcoin-s"
      #MEMPOOL_API_URL: "http://umbrel.local:${APP_MEMPOOL_PORT}/api"
       WALLET_SERVER_API_URL: "http://${APP_SUREDBITS_WALLET_SERVER_IP}:9999/"
       WALLET_SERVER_WS: "ws://${APP_SUREDBITS_WALLET_SERVER_IP}:19999/events"

--- a/suredbits-wallet/umbrel-app.yml
+++ b/suredbits-wallet/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: suredbits-wallet
 category: Finance
 name: Suredbits Wallet
-version: "1.9.2-f44ad4a4"
+version: "1.9.3"
 tagline: A universal DLC wallet
 description: >-
   The Suredbits Wallet is your one stop shop for building Discreet
@@ -14,10 +14,8 @@ description: >-
 
   WARNING: This is an Alpha software, don't put too much money in.
 releaseNotes: >-
-  Fixes blockchain parsing bugs with Taproot transactions.
-  Add ability to backup mnemonic seed for wallet.
-  Optimizations around wallet server startup.
-
+  Websocket events for fee rate changes, rescans, blockchain sync
+  Optimizations for the DLC wallet
 developer: Suredbits
 website: https://suredbits.com
 dependencies:

--- a/suredbits-wallet/umbrel-app.yml
+++ b/suredbits-wallet/umbrel-app.yml
@@ -13,8 +13,9 @@ description: >-
 
 
   WARNING: This is an Alpha software, don't put too much money in.
-releaseNotes: >-
+releaseNotes: >
   Websocket events for fee rate changes, rescans, blockchain sync
+  
   Optimizations for the DLC wallet
 developer: Suredbits
 website: https://suredbits.com


### PR DESCRIPTION
We are about to cut a 1.9.3 for the Suredbits Wallet.

This modifies some configurations on our umbrel deployment as we are no longer specify the [USER id in our docker images](https://github.com/bitcoin-s/bitcoin-s/pull/4601)

I still need to test this with a fresh umbrel install.