### PR TITLE
2022 08 18 krystal bull update

### DIFF
--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -7,12 +7,11 @@ services:
       APP_PORT: 3001
   web:
     image: bitcoinscala/oracle-server-ui:1.9.2-9a14a58e-SNAPSHOT
-    entrypoint: ["/opt/docker/bin/bitcoin-s-oracle-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]   
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
     volumes:
-      - ${APP_DATA_DIR}/data/oracleserver:/home/bitcoin-s/.bitcoin-s
+      - ${APP_DATA_DIR}/data/oracleserver:/bitcoin-s
       - ${APP_DATA_DIR}/data/log:/log
     environment:
       LOG_PATH: "/log/"
@@ -28,6 +27,7 @@ services:
       - oracleserver
   oracleserver:
     image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-198-f65b483d-SNAPSHOT
+    entrypoint: ["/opt/docker/bin/bitcoin-s-oracle-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]   
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -28,6 +28,7 @@ services:
   oracleserver:
     image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-164-2dad9f57-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-oracle-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
+    user: "1000:1000"
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data/oracleserver:/home/bitcoin-s/.bitcoin-s

--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       APP_PORT: 3001
   web:
     image: bitcoinscala/oracle-server-ui:1.9.2-9a14a58e-SNAPSHOT
+    entrypoint: ["/opt/docker/bin/bitcoin-s-oracle-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]   
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -5,8 +5,9 @@ services:
     environment:
       APP_HOST: $APP_KRYSTAL_BULL_IP
       APP_PORT: 3001
+  
   web:
-    image: bitcoinscala/oracle-server-ui:1.9.3@sha256:b11c4cc48c126e80bae0c63b263add838b315dea56689954e5e771aa9d3ac0fd
+    image: bitcoinscala/oracle-server-ui:1.9.3@sha256:82eacff09b2a5b7f8bcc5ab61353861cf6674af0164df8c011e102ac501d77c4
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -25,8 +26,9 @@ services:
         ipv4_address: $APP_KRYSTAL_BULL_IP
     depends_on: 
       - oracleserver
+  
   oracleserver:
-    image: bitcoinscala/bitcoin-s-oracle-server:1.9.3@sha256:ee3fee0469666b98e29dc753745b29668c640ed16e9abc06e251ff87001822b2
+    image: bitcoinscala/bitcoin-s-oracle-server:1.9.3@sha256:fd1d1460bc3299422bcf30b5b694514a812f6986e549c690e04a5393b0d8e7b0
     entrypoint: ["/opt/docker/bin/bitcoin-s-oracle-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]   
     user: "1000:1000"
     restart: on-failure

--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       - oracleserver
   oracleserver:
     image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-184-288918d7-SNAPSHOT
-    entrypoint: ["/opt/docker/bin/bitcoin-s-oracle-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_HOST: $APP_KRYSTAL_BULL_IP
       APP_PORT: 3001
   web:
-    image: bitcoinscala/oracle-server-ui:1.9.2-7fe71420-SNAPSHOT
+    image: bitcoinscala/oracle-server-ui:1.9.3@sha256:b11c4cc48c126e80bae0c63b263add838b315dea56689954e5e771aa9d3ac0fd
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -26,7 +26,7 @@ services:
     depends_on: 
       - oracleserver
   oracleserver:
-    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-206-dac65ca8-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-oracle-server:1.9.3@sha256:ee3fee0469666b98e29dc753745b29668c640ed16e9abc06e251ff87001822b2
     entrypoint: ["/opt/docker/bin/bitcoin-s-oracle-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]   
     user: "1000:1000"
     restart: on-failure

--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_HOST: $APP_KRYSTAL_BULL_IP
       APP_PORT: 3001
   web:
-    image: bitcoinscala/oracle-server-ui:1.9.2-9a14a58e-SNAPSHOT
+    image: bitcoinscala/oracle-server-ui:1.9.2-ceb19a36-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -26,7 +26,7 @@ services:
     depends_on: 
       - oracleserver
   oracleserver:
-    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-198-f65b483d-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-201-945b3914-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-oracle-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]   
     user: "1000:1000"
     restart: on-failure

--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3001
   web:
     image: bitcoinscala/oracle-server-ui:1.9.2-9a14a58e-SNAPSHOT
-    entrypoint: ["/opt/docker/bin/bitcoin-s-oracle-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]   
+    entrypoint: ["/opt/docker/bin/bitcoin-s-oracle-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]   
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -16,7 +16,7 @@ services:
       - ${APP_DATA_DIR}/data/log:/log
     environment:
       LOG_PATH: "/log/"
-      BITCOIN_S_HOME: "/home/bitcoin-s/.bitcoin-s/"
+      BITCOIN_S_HOME: "/bitcoin-s/"
       ORACLE_SERVER_API_URL: "http://${APP_KRYSTAL_BULL_SERVER_IP}:9998/"
       TOR_PROXY: socks5://${TOR_PROXY_IP}:${TOR_PROXY_PORT}
       DEFAULT_UI_PASSWORD: "none"
@@ -27,14 +27,15 @@ services:
     depends_on: 
       - oracleserver
   oracleserver:
-    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-184-288918d7-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-198-f65b483d-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     volumes:
-      - ${APP_DATA_DIR}/data/oracleserver:/home/bitcoin-s/.bitcoin-s
+      - ${APP_DATA_DIR}/data/oracleserver:/bitcoin-s
     environment:
       BITCOIN_S_KEYMANAGER_ENTROPY: $APP_SEED
       BITCOIN_S_ORACLE_RPC_PASSWORD: $APP_PASSWORD
+      DISABLE_JLINK: "1"
     networks:
       default:
         ipv4_address: $APP_KRYSTAL_BULL_SERVER_IP

--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_HOST: $APP_KRYSTAL_BULL_IP
       APP_PORT: 3001
   web:
-    image: bitcoinscala/oracle-server-ui:1.9.2-1cd65c60-SNAPSHOT
+    image: bitcoinscala/oracle-server-ui:1.9.2-d2ce1a9e-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -26,7 +26,7 @@ services:
     depends_on: 
       - oracleserver
   oracleserver:
-    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-164-2dad9f57-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-181-068187c9-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-oracle-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure

--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_HOST: $APP_KRYSTAL_BULL_IP
       APP_PORT: 3001
   web:
-    image: bitcoinscala/oracle-server-ui:1.9.2-f44ad4a4-SNAPSHOT@sha256:aa128ad3e4134585390127c092bad09d1632055108f459c248048246c1cabab7
+    image: bitcoinscala/oracle-server-ui:1.9.2-1cd65c60-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -26,7 +26,8 @@ services:
     depends_on: 
       - oracleserver
   oracleserver:
-    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-42-83cff9a4-SNAPSHOT@sha256:bbe1673878fe44e1a1554279e049f24e81a4f771e81928d59d2add236734d350
+    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-164-2dad9f57-SNAPSHOT
+    entrypoint: ["/opt/docker/bin/bitcoin-s-oracle-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data/oracleserver:/home/bitcoin-s/.bitcoin-s

--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     depends_on: 
       - oracleserver
   oracleserver:
-    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-181-068187c9-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-184-288918d7-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-oracle-server", "--datadir", "/home/bitcoin-s/.bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "1000:1000"
     restart: on-failure

--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_HOST: $APP_KRYSTAL_BULL_IP
       APP_PORT: 3001
   web:
-    image: bitcoinscala/oracle-server-ui:1.9.2-ceb19a36-SNAPSHOT
+    image: bitcoinscala/oracle-server-ui:1.9.2-7fe71420-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -26,7 +26,7 @@ services:
     depends_on: 
       - oracleserver
   oracleserver:
-    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-201-945b3914-SNAPSHOT
+    image: bitcoinscala/bitcoin-s-oracle-server:1.9.2-206-dac65ca8-SNAPSHOT
     entrypoint: ["/opt/docker/bin/bitcoin-s-oracle-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]   
     user: "1000:1000"
     restart: on-failure

--- a/krystal-bull/docker-compose.yml
+++ b/krystal-bull/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_HOST: $APP_KRYSTAL_BULL_IP
       APP_PORT: 3001
   web:
-    image: bitcoinscala/oracle-server-ui:1.9.2-d2ce1a9e-SNAPSHOT
+    image: bitcoinscala/oracle-server-ui:1.9.2-9a14a58e-SNAPSHOT
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/krystal-bull/umbrel-app.yml
+++ b/krystal-bull/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: krystal-bull
 category: Finance
 name: Krystal Bull
-version: "1.9.2-f44ad4a4"
+version: "1.9.3"
 tagline: Become an oracle and create Bitcoin bets
 description: >-
   Krystal Bull allows you to become a Bitcoin oracle. An oracle
@@ -18,7 +18,8 @@ description: >-
 
   WARNING: This version of Krystal Bull is an early alpha release for testing. It's not secure, please don't use it for anything serious.
 releaseNotes: >-
-  Auto login
+  Export staking address private key
+
 developer: SuredBits
 website: https://suredbits.com/
 dependencies: []


### PR DESCRIPTION
This updates Krystal Bull for the 1.9.3 release of bitcoin-s. 

This modifies some configurations on our umbrel deployment as we are no longer specify the [USER id in our docker images](https://github.com/bitcoin-s/bitcoin-s/pull/4601)

I still need to test this with a fresh umbrel install.