### PR TITLE
Add umbrel-hosted Mempool block explorer to Thunderhub

### DIFF
--- a/thunderhub/docker-compose.yml
+++ b/thunderhub/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       ACCOUNT_CONFIG_PATH: "/data/thubConfig.yaml"
       YML_ENV_1: "$APP_LIGHTNING_NODE_IP:$APP_LIGHTNING_NODE_GRPC_PORT"
       TOR_PROXY_SERVER: "socks://$TOR_PROXY_IP:$TOR_PROXY_PORT"
+      MEMPOOL_URL: "http://$APP_DOMAIN:$APP_MEMPOOL_PORT"
     networks:
       default:
         ipv4_address: $APP_THUNDERHUB_IP

--- a/thunderhub/umbrel-app.yml
+++ b/thunderhub/umbrel-app.yml
@@ -17,6 +17,7 @@ developer: Anthony Potdevin
 website: https://apotdevin.com
 dependencies:
   - lightning
+  - mempool
 repo: https://github.com/apotdevin/thunderhub
 support: https://t.me/thunderhub
 port: 3000


### PR DESCRIPTION
This PR replaces part of https://github.com/getumbrel/umbrel/pull/1213 and will add support for a locally hosted mempool instance increasing the privacy of the node and its users.