### PR TITLE
app submission: plex media server

### DIFF
--- a/plex/docker-compose.yml
+++ b/plex/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: $APP_PLEX_IP
+      APP_PORT: $APP_PLEX_PORT
+
+  server:
+    image: ghcr.io/linuxserver/plex:version-1.28.1.6104-788f82488
+    user: "1000:1000"
+    restart: on-failure
+    environment:
+      - PUID=1001
+      - PGID=100
+      - VERSION=docker
+    volumes:
+      - ${APP_DATA_DIR}/downloads:/downloads
+    networks:
+      default:
+        ipv4_address: $APP_PLEX_IP

--- a/plex/exports.sh
+++ b/plex/exports.sh
@@ -1,0 +1,2 @@
+export APP_PLEX_IP="10.21.21.48"
+export APP_PLEX_PORT="32400"

--- a/plex/umbrel-app.yml
+++ b/plex/umbrel-app.yml
@@ -1,0 +1,22 @@
+manifestVersion: 1
+id: plex
+category: Files
+name: Plex
+version: "1.28.1.6104-788f82488"
+tagline: Watch anytime, anywhere with the Plex app.
+description: >-
+  Plex is an American streaming media service and a client–server media player platform, made by Plex, Inc. The Plex Media Server organizes video, audio, and photos from a user's collections and from online services, and streams it to the players. The official clients and unofficial third-party clients run on mobile devices, smart TVs, streaming boxes, and in web apps.
+developer: Plex
+website: https://plex.tv
+dependencies: []
+repo: https://github.com/plexinc/pms-docker
+support: https://github.com/plexinc/pms-docker/issues
+port: 32400
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+torOnly: false


### PR DESCRIPTION
# App Submission

I was surprised that Plex was not already available on umbrel, as I saw chatter in an old reddit thread that it was coming soon. I have been using Plex on my umbrel device and it works seamlessly with SimpleTorrent downloads. I have been using my roku, Safari on my mac, and the iOS app clients and have not experienced any lag or issues on raspberry pi 4.

### App name

Plex

### 256x256 SVG icon

![plex](https://user-images.githubusercontent.com/4824042/186286514-085dbebd-b3c2-4d1e-9873-52a641de7218.png)

...

### Gallery images

![plex1](https://user-images.githubusercontent.com/4824042/186286695-fbcc27b9-0eac-46f4-8b4e-6d1f8314fe59.png)
![plex2](https://user-images.githubusercontent.com/4824042/186286703-d325931d-7135-40e4-9dc6-eb2338c9858d.jpeg)
![plex3](https://user-images.githubusercontent.com/4824042/186286714-efb1e0be-e0f2-4440-968b-f4fec277c1ef.png)
...


### I have tested my app on:
- [ ] [Umbrel dev environment](https://github.com/getumbrel/umbrel-dev)
- [x] [Umbrel OS on a Raspberry Pi 4](https://github.com/getumbrel/umbrel-os)
- [ ] [Custom Umbrel install on Linux](https://github.com/getumbrel/umbrel#-installation)
