### PR TITLE
Update specter desktop app to v1.12.0

### DIFF
--- a/specter-desktop/docker-compose.yml
+++ b/specter-desktop/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_SPECTER_DESKTOP_PORT
 
   web:
-    image: lncm/specter-desktop:v1.8.1@sha256:0fab344245e0b3fb27b8d62a74e2503e53d1a51ab8b9c8a6170f975bf880a70a
+    image: lncm/specter-desktop:v1.12.0@sha256:4559e857f525edae43e9a17f338c92b94f3df2b5df927802b6e0c0d97d2a38e5
     stop_signal: SIGINT
     restart: on-failure
     stop_grace_period: 1m

--- a/specter-desktop/umbrel-app.yml
+++ b/specter-desktop/umbrel-app.yml
@@ -43,3 +43,23 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: >-
+  - Feature: add faucet and exfund extensions #1820 (Stepan Snigirev)
+
+  - Feature: Dev tools - Adding full python access via javascript for developers #1842 (relativisticelectron)
+
+  - UIUX: Complete overhaul of the tooltips used in Specter Desktop #1813 (Manolis Mandrapilias)
+
+  - UIUX: Easier adding and deleting of recipients #1782 (relativisticelectron)
+
+  - UIUX: Optimize tx-table for mobile screen #1804 (relativisticelectron)
+
+  - Mobile: Some extra height in mobile browsers #1827 (relativisticelectron)
+
+  - Bugfix: Allow mouse selection during address label editing for Firefox #1825 (relativisticelectron)
+
+  - Bugfix: Another broken html part and b tag #1823 (relativisticelectron)
+
+  - Bugfix: Fiat price in address table not visible #1836 (relativisticelectron)
+
+  - And many other bugfixes...

--- a/specter-desktop/umbrel-app.yml
+++ b/specter-desktop/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: specter-desktop
 category: Finance
 name: Specter Desktop
-version: "1.8.1"
+version: "1.12.0"
 tagline: Multisig with hardware wallets made easy
 description: >-
   Specter Desktop connects to the Bitcoin Core running on your Umbrel


### PR DESCRIPTION
This will update specter desktop to the latest available v1.12.0 including many new features