### PR TITLE
Samourai server Web UI port change

### DIFF
--- a/samourai-server/umbrel-app.yml
+++ b/samourai-server/umbrel-app.yml
@@ -23,7 +23,7 @@ dependencies:
   - electrs
 repo: https://github.com/louneskmt/umbrel-samourai-dojo/tree/v1.16.1-umbrel
 support: https://t.me/SamouraiWallet
-port: 3005
+port: 3021
 gallery:
   - 1.jpg
   - 2.jpg

--- a/samourai-server/umbrel-app.yml
+++ b/samourai-server/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: samourai-server
 category: Wallet Servers
 name: Samourai Server
-version: "1.16.1"
+version: "1.16.1-hotfix-1"
 tagline: Your private backing server for Samourai Wallet
 description: >-
   Samourai Server is an exclusive Umbrel app that runs Samourai Dojo


### PR DESCRIPTION
Due a port conflict (port 3005) between Samourai Server's Web UI and Plex Companion, the port number for Samourai Server will be changed to 3021 as we cannot change the port number for these Plex Companion apps.