### PR TITLE
lightning-terminal: bump version to v0.8.0-alpha

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LIGHTNING_TERMINAL_PORT
 
   web:
-    image: lightninglabs/lightning-terminal:v0.7.1-alpha@sha256:e1108f3b5d8e42ecf6a60832cbc49bcfbbfc11a94ba762cfa855f16cbf35d591
+    image: lightninglabs/lightning-terminal:v0.8.0-alpha@sha256:2533a567181d26c6faa6d8c8226bb3844aa78eb7de74cdcb1530e83bd56f3ca6
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: Lightning Node Management
 name: Lightning Terminal
-version: "0.7.1-alpha"
+version: "0.8.0-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -49,3 +49,6 @@ gallery:
 path: ""
 defaultUsername: ""
 deterministicPassword: true
+releaseNotes: >-
+  This release of Lightning Terminal (LiT) includes updates to the
+  versions of the packaged subsystems including LND, Loop and Pool.

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -50,5 +50,8 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
+  Lightning v0.15.1-beta is required for this to function!
+
+
   This release of Lightning Terminal (LiT) includes updates to the
   versions of the packaged subsystems including LND, Loop and Pool.


### PR DESCRIPTION
Hey y'all! New Litd release is out. It bundles LND v0.15.1-beta along with some Loop & Pool updates

https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.8.0-alpha