### PR TITLE
Update Jam to v0.1.0

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   jam:
-    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.10-clientserver-v0.9.6@sha256:4287ebb5d7d9bda7acdc77662df7adf0b6e7a5974a39a314c3ec0e85336ec1d5
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.0-clientserver-v0.9.8@sha256:4067e86e97b4342ee27021b31de8b31394d640e066f850acbcf4fc9e72c56302
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -3,7 +3,7 @@ id: jam
 category: Finance
 name: Jam
 version: "0.1.0"
-tagline: A user-friendly UI for JoinMarket
+tagline: Your sats. Your privacy. Your profit.
 description: >-
   Jam is a user-interface for JoinMarket with focus on
   user-friendliness.

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jam
 category: Finance
 name: Jam
-version: "0.0.10"
+version: "0.1.0"
 tagline: A user-friendly UI for JoinMarket
 description: >-
   Jam is a user-interface for JoinMarket with focus on
@@ -13,15 +13,19 @@ description: >-
 
   The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 releaseNotes: >-
-  - In-app Orderbook
+  - Update application flow to align with recent scheduler changes
 
-  - Improved Earn Report
+  - New top-level menu item: Sweep
 
-  - Address-reuse warnings
+  - Show active offers directly in Jam
 
-  - Human-readable locktime for Fidelity Bonds
+  - Highlight your offers in the in-app Orderbook
 
-  - And, last but not least: the famed UTXO drill-down view
+  - Easier debugging: retrieve JoinMarket logs directly in Jam
+
+  - Abort a collaborative transaction as a taker
+
+  - And last but not least: we added some flavor! Jars are now named and colored
 developer: JoinMarket WebUI Organisation
 website: https://jamapp.org
 dependencies:


### PR DESCRIPTION
This version includes:
- Jam: [v0.1.0](https://github.com/joinmarket-webui/jam/releases/tag/v0.1.0)
- joinmarket-clientserver: [v0.9.8](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.8)

All notable changes of the UI can be seen in the [Jam v0.1.0 changelog](https://github.com/joinmarket-webui/jam/blob/v0.1.0/CHANGELOG.md)

Updates to the image:
- fix: run tor daemon with distinct user https://github.com/joinmarket-webui/jam-docker/pull/61
- fix: make sure non-descriptor wallet is created https://github.com/joinmarket-webui/jam-docker/pull/58 
- fix: remove conditional autostart handling https://github.com/joinmarket-webui/jam-docker/pull/56 
- feat: serve logs https://github.com/joinmarket-webui/jam-docker/pull/51