### PR TITLE
Update LNBits to latest version

### DIFF
--- a/lnbits/docker-compose.yml
+++ b/lnbits/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LNBITS_PORT
       PROXY_AUTH_ADD: "false"
   web:
-    image: lnbitsdocker/lnbits-legend:0.8.0@sha256:3426e326bac347d09b4e018780cb1ecd8e5eac35851383d476076769ab4a9b2e
+    image: lnbitsdocker/lnbits-legend:0.9.3@sha256:5e72d925f41c91b1b37e5b55fc10bd07a0eaf52c7cd70aa0486fe02115a4fb4d
     user: 1000:1000
     init: true
     restart: on-failure

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lnbits
 category: Finance
 name: LNbits
-version: "0.8.0"
+version: "0.9.3"
 tagline: Multi-user wallet management system
 description: >-
   LNbits is a simple multi-user and account system for Lightning

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -27,3 +27,13 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: >-
+   - Bugfix: Important payment logic fix
+   - Bugfix: pending (stuck) payment fix
+   - Bugfix: Reuse DB connections for faster boot
+   - New Feature: Onchain Wallet, includes support for HWW connected over serial https://lnbits.github.io/hardware-wallet/installer/
+   - New Feature: Boltcard Extension, create and manage LNURL tap and pay NFC cards
+   - New Feature: Invoices, Extension for creating formal invoices tor goods/services
+   - New Feature: Onchain Wallet (formally known as Watch Only), scrapes for funds and gives total balance + allow psbt construction
+   - New Feature: SCRUB extension, pushes payments going to a wallet to an LNURLpay or LNaddress
+   - New Feature: Point of Sale extension can now accept tips


### PR DESCRIPTION
This PR updates LNBits to the latest version available on Docker Hub, v0.9.3. LNBits has released important security updates.