### PR TITLE
skip node auth for whoogle searches

### DIFF
--- a/whoogle-search/docker-compose.yml
+++ b/whoogle-search/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       APP_HOST: $APP_WHOOGLE_SEARCH_IP
       APP_PORT: $APP_WHOOGLE_SEARCH_PORT
-
+      PROXY_AUTH_ADD: "false"
   web:
     image: benbusby/whoogle-search:0.7.4@sha256:8526a3272d992ea2c240919b8b5dafee2b37eab28af7df4f175054ef29d8b65d
     restart: on-failure


### PR DESCRIPTION
IMO doesn't make sense to have to authenticate into my node to run searches