### PR TITLE
Update Jam to v0.1.1

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   jam:
-    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.0-clientserver-v0.9.8@sha256:4067e86e97b4342ee27021b31de8b31394d640e066f850acbcf4fc9e72c56302
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.1-clientserver-v0.9.8@sha256:0b17e193c12b44323e8a815994457f69e0e8ee1299702e6fca7e8547352eafea
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -25,8 +25,6 @@ services:
       jm_rpc_user: $APP_BITCOIN_RPC_USER
       jm_rpc_password: "${APP_BITCOIN_RPC_PASS}"
       jm_rpc_wallet_file: jam_default
-      jm_max_cj_fee_abs: 300000 # in sats
-      jm_max_cj_fee_rel: 0.0003 # 0.03%
     networks:
       default:
         ipv4_address: $APP_JAM_IP

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jam
 category: Finance
 name: Jam
-version: "0.1.0"
+version: "0.1.1"
 tagline: Your sats. Your privacy. Your profit.
 description: >-
   Jam is a user-interface for JoinMarket with focus on
@@ -13,19 +13,15 @@ description: >-
 
   The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 releaseNotes: >-
-  - Update application flow to align with recent scheduler changes
+  - Basic fee settings
 
-  - New top-level menu item: Sweep
+  - Display fee summary on Send page
 
-  - Show active offers directly in Jam
+  - Randomize mandatory fee config values on restarts
 
-  - Highlight your offers in the in-app Orderbook
+  - Show sum of selected utxos in Jar details view
 
-  - Easier debugging: retrieve JoinMarket logs directly in Jam
-
-  - Abort a collaborative transaction as a taker
-
-  - And last but not least: we added some flavor! Jars are now named and colored
+  - Display transaction ID on successful direct-send
 developer: JoinMarket WebUI Organisation
 website: https://jamapp.org
 dependencies:

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -19,7 +19,7 @@ releaseNotes: >-
 
   - Randomize mandatory fee config values on restarts
 
-  - Show sum of selected utxos in Jar details view
+  - Show sum of selected UTXOs in Jar details view
 
   - Display transaction ID on successful direct-send
 developer: JoinMarket WebUI Organisation


### PR DESCRIPTION
This version includes:
- Jam: [v0.1.1](https://github.com/joinmarket-webui/jam/releases/tag/v0.1.1)
- joinmarket-clientserver: [v0.9.8](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.8)

All notable changes of the UI can be seen in the [Jam v0.1.1 changelog](https://github.com/joinmarket-webui/jam/blob/v0.1.1/CHANGELOG.md)

Updates to the image:
- feat: randomize mandatory fee config values [#66](https://github.com/joinmarket-webui/jam-docker/pull/66) 