### PR TITLE
Update Lnvisualizer to 0.0.26

### DIFF
--- a/ln-visualizer/docker-compose.yml
+++ b/ln-visualizer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   web:
-    image: maxkotlan/ln-visualizer-web:v0.0.25@sha256:c349a106a6fb69c6d56301ae87f9844687a5ec28df9a104fb0b7585a67264092
+    image: maxkotlan/ln-visualizer-web:v0.0.26@sha256:704dadfc6869c660c87010f9837a269786d6576788b1c1ea983e7d77b456a45b
     init: true
     restart: on-failure
     stop_grace_period: 1m
@@ -18,13 +18,14 @@ services:
         ipv4_address: "${APP_LN_VISUALIZER_WEB_IP}"
 
   api:
-    image: maxkotlan/ln-visualizer-api:v0.0.25@sha256:839a53dd2fe230743cdc6edcd34811b7ec41644f433e8d52777482df57a72408
+    image: maxkotlan/ln-visualizer-api:v0.0.26@sha256:818357452e3a16682b1abd3bc513b30c313703f6fd6e26d6e0c15267a248138b
     init: true
     restart: on-failure
     stop_grace_period: 1m
     user: 1000:1000
     volumes:
-      - "${APP_LIGHTNING_NODE_DATA_DIR}:/lnd:ro"
+      - "${APP_LIGHTNING_NODE_DATA_DIR}/tls.cert:/lnd/tls.cert:ro"
+      - "${APP_LIGHTNING_NODE_DATA_DIR}/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/readonly.macaroon:/lnd/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/readonly.macaroon:ro"
     environment:
       LND_CERT_FILE: "/lnd/tls.cert"
       LND_MACAROON_FILE: "/lnd/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/readonly.macaroon"

--- a/ln-visualizer/umbrel-app.yml
+++ b/ln-visualizer/umbrel-app.yml
@@ -2,17 +2,12 @@ manifestVersion: 1
 id: ln-visualizer
 category: Explorers
 name: LnVisualizer
-version: "0.0.25"
+version: "0.0.26"
 releaseNotes: >-
-  - Initial sync performance improvements
+  - new channel color mapping modes. can map channel color by fee-rate, base-fee, cltv-delta, max-htlc, min-htlc
 
-  - New control to filter node by feature bits
+  - new color range ui menu
 
-  - New dropdown for filtering by node network type (tor vs clearnet)
-
-  - Redesigned statistics window. Now it will calculate min/max/total/average for both the entire network and for subgraph being viewed.
-
-  - New settings dropdown to normalize channel color to min/max range of subgraph
 tagline: View the Lightning Network from your node's perspective
 description:
   Your Lightning node is continuously receiving, storing, and transmitting graph information.


### PR DESCRIPTION
A few visible changes:
  - new channel color mapping modes. can map channel color by fee-rate, base-fee, cltv-delta, max-htlc, min-htlc
  - new color range ui menu

Also better container security. Only include cert and readonly macaroon in container.