### PR TITLE
Update ln-markets app to v1.2.4

### DIFF
--- a/lnmarkets/docker-compose.yml
+++ b/lnmarkets/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LNMARKETS_PORT
   
   lnmarkets:
-    image: ghcr.io/ln-markets/umbrel:v1.2.4@sha256:21e236d5b76e8ee4698329a4f1f79a15ebd53ae0972c2827094a752a28f24f34
+    image: ghcr.io/ln-markets/umbrel:v1.2.4@sha256:79b4a3651ee425e63beb50e46058244ba9c1ed6e173e09188de16e463fcab911
     init: true
     user: 1000:1000
     restart: on-failure

--- a/lnmarkets/docker-compose.yml
+++ b/lnmarkets/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LNMARKETS_PORT
   
   lnmarkets:
-    image: ghcr.io/ln-markets/umbrel:v1.2.3@sha256:c11ec6d28d1b1d11d82ae8b33916732686a296beb21c9c3eaee80c823bd2d00f
+    image: ghcr.io/ln-markets/umbrel:v1.2.4@sha256:21e236d5b76e8ee4698329a4f1f79a15ebd53ae0972c2827094a752a28f24f34
     init: true
     user: 1000:1000
     restart: on-failure

--- a/lnmarkets/umbrel-app.yml
+++ b/lnmarkets/umbrel-app.yml
@@ -28,7 +28,7 @@ gallery:
   - 2.jpg
   - 3.jpg
 path: ""
-deterministicPassword: false
+deterministicPassword: true
 submitter: LN Markets
 submission: https://github.com/getumbrel/umbrel/pull/879
 releaseNotes: >-

--- a/lnmarkets/umbrel-app.yml
+++ b/lnmarkets/umbrel-app.yml
@@ -2,20 +2,20 @@ manifestVersion: 1
 id: lnmarkets
 category: Finance
 name: LN Markets
-version: "1.2.3-build-1"
+version: "1.2.4"
 tagline: Trade Bitcoin derivatives on Lightning
 description: >-
   LN Markets is the first Lightning-native Bitcoin derivatives
   trading platform.
 
 
-  LN Markets enables traders to take minimal counterparty risk: you can trade directly from your Lightning wallet for instant and almost costless transactions. Since March 2020, we have processed over $200 million of trading volume, with a median fee of 1 sat for instant P&L delivery to your wallet.
+  LN Markets enables traders to take minimal counterparty risk: you can trade directly from your Lightning wallet for instant and almost costless transactions. Since March 2020, we have processed over $500 million of trading volume, with a median fee of 1 sat for instant P&L delivery to your wallet.
 
 
   This Umbrel App gives you another way to interact with LN Markets: you can directly deposit, withdraw, get trading stats and get instantly connected to your account to take positions as usual. More features may come in the future!
 
 
-  Thank you for your support and let’s keep building the future of finance together!
+  Thank you for your support and let's keep building the future of finance together!
 developer: LN Markets
 website: https://lnmarkets.com
 dependencies:
@@ -28,6 +28,22 @@ gallery:
   - 2.jpg
   - 3.jpg
 path: ""
-deterministicPassword: true
+deterministicPassword: false
 submitter: LN Markets
 submission: https://github.com/getumbrel/umbrel/pull/879
+releaseNotes: >-
+  - Update LN Markets assets in the app store.
+
+  - Removed login page as Umbrel proxy handle it now.
+
+  - Added a loading screen for withdrawals and deposits.
+
+  - Added some metrics to the front (total margin traded, all time PL...).
+
+  - Fix websockets connection.
+
+  - Fix withdraw slider, now works as intended.
+
+  - Fix some typos in modals.
+
+  - Fix CORS policy.


### PR DESCRIPTION
Patchnote [v1.2.4](https://github.com/ln-markets/umbrel/releases/tag/v1.2.4)

Related PRs: https://github.com/getumbrel/umbrel-apps-gallery/pull/14