### PR TITLE
All apps should use docker-compose 3.7 manifest version

### DIFF
--- a/core-lightning-rtl/docker-compose.yml
+++ b/core-lightning-rtl/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.7"
 
 services:
   app_proxy:

--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.7"
 
 services:
   app_proxy:

--- a/elements/docker-compose.yml
+++ b/elements/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.7"
 
 services:
   app_proxy:


### PR DESCRIPTION
For certain versions of docker-compose (currently unknown), all docker-compose manifest versions must match otherwise this error can occur during app installation: `Version mismatch: file /data/umbrel/scripts/support/docker-compose.app_proxy.yml specifies version 3.7 but extension file /data/umbrel/app-data/core-lightning/docker-compose.yml uses version 3.8`

Related issue: https://github.com/getumbrel/umbrel-core-lightning/issues/1