### PR TITLE
lightning-terminal: bump version to v0.8.2-alpha

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LIGHTNING_TERMINAL_PORT
 
   web:
-    image: lightninglabs/lightning-terminal:v0.8.0-alpha@sha256:2533a567181d26c6faa6d8c8226bb3844aa78eb7de74cdcb1530e83bd56f3ca6
+    image: lightninglabs/lightning-terminal:v0.8.2-alpha@sha256:cbada72ec70fadd0106c7173a8b1f9eefa2be8c0aa480a0f1e416116f1d73930
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: Lightning Node Management
 name: Lightning Terminal
-version: "0.8.0-alpha"
+version: "0.8.2-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -50,10 +50,7 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  Lightning v0.15.1-beta is required for this to function!
-
-
-  This release of Lightning Terminal (LiT) includes updates to the
-  versions of the packaged subsystems including LND, Loop and Pool.
+  This release of Lightning Terminal (LiT) updates the packaged 
+  version of LND to v0.15.3-beta.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
Hey y'all! 

Here to update Litd to v0.8.2-alpha which contains the latest version of LND (v0.15.3-beta

https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.8.2-alpha)