### PR TITLE
Update LN Markets to v1.2.5

### DIFF
--- a/lnmarkets/docker-compose.yml
+++ b/lnmarkets/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LNMARKETS_PORT
   
   lnmarkets:
-    image: ghcr.io/ln-markets/umbrel:v1.2.4@sha256:79b4a3651ee425e63beb50e46058244ba9c1ed6e173e09188de16e463fcab911
+    image: ghcr.io/ln-markets/umbrel:v1.2.5@sha256:6c608ceca28a74983c2da814ca352016ee6acefdc97187e48f9c737fa1b874eb
     init: true
     user: 1000:1000
     restart: on-failure

--- a/lnmarkets/umbrel-app.yml
+++ b/lnmarkets/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lnmarkets
 category: Finance
 name: LN Markets
-version: "1.2.4"
+version: "1.2.5"
 tagline: Trade Bitcoin derivatives on Lightning
 description: >-
   LN Markets is the first Lightning-native Bitcoin derivatives
@@ -32,18 +32,4 @@ deterministicPassword: true
 submitter: LN Markets
 submission: https://github.com/getumbrel/umbrel/pull/879
 releaseNotes: >-
-  - Update LN Markets assets in the app store.
-
-  - Removed login page as Umbrel proxy handle it now.
-
-  - Added a loading screen for withdrawals and deposits.
-
-  - Added some metrics to the front (total margin traded, all time PL...).
-
-  - Fix websockets connection.
-
-  - Fix withdraw slider, now works as intended.
-
-  - Fix some typos in modals.
-
-  - Fix CORS policy.
+  - Remove deposit amount limitations


### PR DESCRIPTION
Patchnote: [v1.2.5](https://github.com/ln-markets/umbrel/releases/tag/v1.2.5)

Tested on `arm64` !