### PR TITLE
Update Jam to v0.1.2

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   jam:
-    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.1-clientserver-v0.9.8@sha256:0b17e193c12b44323e8a815994457f69e0e8ee1299702e6fca7e8547352eafea
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.2-clientserver-v0.9.8@sha256:c23fdf063d6221bc923fb1ad025c4e51b0b2f18968d3664e1f3964f43f51cd09
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: jam
 category: Finance
 name: Jam
-version: "0.1.1"
+version: "0.1.2"
 tagline: Your sats. Your privacy. Your profit.
 description: >-
   Jam is a user-interface for JoinMarket with focus on
@@ -13,15 +13,7 @@ description: >-
 
   The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 releaseNotes: >-
-  - Basic fee settings
-
-  - Display fee summary on Send page
-
-  - Randomize mandatory fee config values on restarts
-
-  - Show sum of selected UTXOs in Jar details view
-
-  - Display transaction ID on successful direct-send
+  - Display error message if backend is unreachable
 developer: JoinMarket WebUI Organisation
 website: https://jamapp.org
 dependencies:


### PR DESCRIPTION
This version includes:
- Jam: [v0.1.2](https://github.com/joinmarket-webui/jam/releases/tag/v0.1.2)
- joinmarket-clientserver: [v0.9.8](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.8)

All notable changes of the UI can be seen in the [Jam v0.1.2 changelog](https://github.com/joinmarket-webui/jam/blob/v0.1.2/CHANGELOG.md)

Updates to the image:
- fix: ensure jm working dir exists [#68](https://github.com/joinmarket-webui/jam-docker/pull/68)
- feat(init): use dinit instead of supervisor [#69 ](https://github.com/joinmarket-webui/jam-docker/pull/69)