### PR TITLE
Update BTCPay Server to use direct postgres nbx connection

### DIFF
--- a/btcpay-server/docker-compose.yml
+++ b/btcpay-server/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       BTCPAY_BTCEXPLORERURL: "http://$APP_BTCPAY_SERVER_NBXPLORER_IP:32838"
       BTCPAY_BTCLIGHTNING: "type=lnd-rest;server=https://$APP_LIGHTNING_NODE_IP:$APP_LIGHTNING_NODE_REST_PORT/;macaroonfilepath=/lnd/data/chain/bitcoin/$APP_BITCOIN_NETWORK/admin.macaroon;allowinsecure=true"
       BTCPAY_SOCKSENDPOINT: $TOR_PROXY_IP:$TOR_PROXY_PORT
+      BTCPAY_EXPLORERPOSTGRES: User ID=postgres;Host=$APP_BTCPAY_SERVER_DB_IP;Port=5432;Application Name=nbxplorer;MaxPoolSize=20;Database=nbxplorer$APP_BITCOIN_NETWORK
     networks:
       default:
         ipv4_address: $APP_BTCPAY_SERVER_IP

--- a/btcpay-server/umbrel-app.yml
+++ b/btcpay-server/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: btcpay-server
 category: Finance
 name: BTCPay Server
-version: "1.6.12"
+version: "1.6.12-hotfix-1"
 tagline: Accept Bitcoin payments with 0 fees & no 3rd party
 description: >-
   BTCPay Server is a payment processor that allows you to receive
@@ -34,6 +34,9 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >
+  - Use optimization to directly connect to the nbx db for faster querying and better dashboard functionality
+  
+
   1.6.12 is out!
 
 


### PR DESCRIPTION
A few versions ago, we introduced optimizations to btcpay to directly connect to the nbx db for faster querying and better dashboard functionality.