### PR TITLE
Update Lightning to use LND v0.15.4-beta

### DIFF
--- a/lightning/docker-compose.yml
+++ b/lightning/docker-compose.yml
@@ -39,7 +39,7 @@ services:
 
   lnd:
     hostname: "${DEVICE_DOMAIN_NAME}" # Needed so LND can generate a valid cert
-    image: lightninglabs/lnd:v0.15.3-beta@sha256:93b4055bf4fb040907587bdf806c5bc6d42bd21b5b90f26df0c86471c8245ca8
+    image: lightninglabs/lnd:v0.15.4-beta@sha256:f5b19812ab7d28faa350838dac4bb88e7fcf9ae905e44d3539be41a97b80ca23
     command: "${APP_LIGHTNING_COMMAND}"
     user: 1000:1000
     restart: on-failure

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: lightning
 category: Finance
 name: Lightning Node
-version: "0.15.3-beta"
+version: "0.15.4-beta"
 tagline: Run your personal Lightning Network node
 description: >-
   Run your personal Lightning Network node, and join the future of Bitcoin today.
@@ -22,15 +22,7 @@ description: >-
 
   An official app from Umbrel.
 releaseNotes: >-
-  - Bugfix: A bug has been fixed where the responder of a zero-conf channel could forget about the channel after a hard-coded 2016 blocks.
-
-  - Bugfix: A bug where LND wouldn't send a ChannelUpdate during a channel open has been fixed.
-
-  - Bugfix: A bug has been fixed that caused fee estimation to be incorrect for taproot inputs when using the SendOutputs call.
-
-  - Bugfix: A bug has been fixed that could cause lnd to underpay for co-op close transaction when or both of the outputs used a P2TR addresss.
-
-  - Taproot: Add p2tr address type to account import.
+  - This is an emergency hot fix release to fix a bug that can cause lnd nodes to be unable to parse certain transactions that have a very large number of witness inputs.
 developer: Umbrel
 website: https://umbrel.com
 dependencies:


### PR DESCRIPTION
Tested on `arm64` and `amd64` with real sats.