### PR TITLE
Enable RPC middleware in LND

### DIFF
--- a/lightning/data/lnd/lnd.conf
+++ b/lightning/data/lnd/lnd.conf
@@ -6,3 +6,6 @@ accept-amp=1
 
 [Bitcoin]
 bitcoin.defaultchanconfs=2
+
+[rpcmiddleware]
+rpcmiddleware.enable=true

--- a/lightning/exports.sh
+++ b/lightning/exports.sh
@@ -21,6 +21,9 @@ BIN_ARGS+=( "--tlsautorefresh" )
 # lnd.conf for existing users via a migration.
 BIN_ARGS+=( "--accept-amp" )
 
+# Lightning Terminal (litd) now requires this flag to be set or it will not startup
+BIN_ARGS+=( "--rpcmiddleware.enable" )
+
 # [Bitcoind]
 BIN_ARGS+=( "--bitcoind.rpchost=${APP_BITCOIN_NODE_IP}" )
 BIN_ARGS+=( "--bitcoind.rpcuser=${APP_BITCOIN_RPC_USER}" )

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: lightning
 category: Finance
 name: Lightning Node
-version: "0.15.4-beta"
+version: '0.15.4-beta-build-2'
 tagline: Run your personal Lightning Network node
 description: >-
   Run your personal Lightning Network node, and join the future of Bitcoin today.
@@ -36,7 +36,7 @@ gallery:
   - 3.jpg
   - 4.jpg
   - 5.jpg
-path: ""
-defaultPassword: ""
+path: ''
+defaultPassword: ''
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/b0ba869953d024595bac84b8987de34aee561392

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: lightning
 category: Finance
 name: Lightning Node
-version: '0.15.4-beta-build-2'
+version: "0.15.4-beta-build-2"
 tagline: Run your personal Lightning Network node
 description: >-
   Run your personal Lightning Network node, and join the future of Bitcoin today.
@@ -36,7 +36,7 @@ gallery:
   - 3.jpg
   - 4.jpg
   - 5.jpg
-path: ''
-defaultPassword: ''
+path: ""
+defaultPassword: ""
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/b0ba869953d024595bac84b8987de34aee561392

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -22,7 +22,7 @@ description: >-
 
   An official app from Umbrel.
 releaseNotes: >-
-  - This is an emergency hot fix release to fix a bug that can cause lnd nodes to be unable to parse certain transactions that have a very large number of witness inputs.
+  - Enable RPC middleware in LND
 developer: Umbrel
 website: https://umbrel.com
 dependencies:


### PR DESCRIPTION
The next major release of Lightning Terminal will require the `--rpcmiddleware.enabled` flag to be set in order to use some new features we've been working on. `litd` will not startup without this flag being set. I am preemptively opening this PR before that release in order to have the LND dependency in order.

More details on what this flag does can be found at https://github.com/lightningnetwork/lnd/pull/5101.

