### PR TITLE
App Update: Photoprism to 221105

### DIFF
--- a/photoprism/docker-compose.yml
+++ b/photoprism/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       # More details here: https://docs.photoprism.app/user-guide/sync/webdav/#server-url
       PROXY_AUTH_WHITELIST: "/originals/*,/import/*"
   web:
-    image: photoprism/photoprism:20220121@sha256:8dd9e8e5290c8bf648d0e91ea8ef81038ffc8800ebf6322417682a0342e04065
+    image: photoprism/photoprism:221105-bullseye@sha256:52f2cfb9f46aec44dd2dec87c78ca121cc6fd174510db1ac371072c527f86558
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: "1m"

--- a/photoprism/docker-compose.yml
+++ b/photoprism/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       # More details here: https://docs.photoprism.app/user-guide/sync/webdav/#server-url
       PROXY_AUTH_WHITELIST: "/originals/*,/import/*"
   web:
-    image: photoprism/photoprism:20210925@sha256:238e6955804d82097d08f0e4318835721f46bd844f9065a38aa7d112ab72906e
+    image: photoprism/photoprism:20220121@sha256:8dd9e8e5290c8bf648d0e91ea8ef81038ffc8800ebf6322417682a0342e04065
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: "1m"

--- a/photoprism/umbrel-app.yml
+++ b/photoprism/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: photoprism
 category: Files
 name: PhotoPrism
-version: "20220121"
+version: "221105-bullseye"
 tagline: Self-host your photo and video library
 description: >-
   PhotoPrism® is a privately hosted app for browsing, organizing, and
@@ -38,25 +38,21 @@ gallery:
   - 2.jpg
   - 3.jpg
 path: ""
-defaultUsername: ""
+defaultUsername: "admin"
 deterministicPassword: true
 torOnly: false
 releaseNotes: >-
-  New features:
+   New features:
   
-  - We've generated missing translations with the help of DeepL and Google Translate. Native speakers are invited to help us improve those if needed. [Learn how to contribute](https://docs.photoprism.app/developer-guide/translations/).
+  - This service release provides UX improvements for the photo editing dialog and includes the latest translations contributed by our community. 
+
+ What's new?
+ 
+  - UX: Improved layout of form fields in photo edit dialog
   
-  What is new?
+  - Account: Disabled "gender" dropdown when busy or in demo mode
   
-  - https://github.com/photoprism/photoprism/discussions/1921#discussioncomment-2005493
-  
-  - Photos: https://github.com/photoprism/photoprism/issues/1961
-  
-  - People: https://github.com/photoprism/photoprism/issues/1957
-  
-  - Moments: https://github.com/photoprism/photoprism/issues/1953
-  
-  - Translations: https://github.com/photoprism/photoprism/commit/f7b82f616d73ed2f61e0195e31d5029ca1bda3b6
+  - Translations: Updated Estonian, Hungarian, and Russian
   
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/bf4c6f127f1fcf4dbe8eea55729502dfb34278e9

--- a/photoprism/umbrel-app.yml
+++ b/photoprism/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: photoprism
 category: Files
 name: PhotoPrism
-version: "221105-bullseye"
+version: "221105"
 tagline: Self-host your photo and video library
 description: >-
   PhotoPrism® is a privately hosted app for browsing, organizing, and
@@ -42,17 +42,14 @@ defaultUsername: "admin"
 deterministicPassword: true
 torOnly: false
 releaseNotes: >-
-   New features:
-  
-  - This service release provides UX improvements for the photo editing dialog and includes the latest translations contributed by our community. 
+  What's new?
 
- What's new?
+  - UX: Photo editing dialog and includes the latest translations contributed by our community
  
   - UX: Improved layout of form fields in photo edit dialog
   
   - Account: Disabled "gender" dropdown when busy or in demo mode
   
   - Translations: Updated Estonian, Hungarian, and Russian
-  
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/bf4c6f127f1fcf4dbe8eea55729502dfb34278e9

--- a/photoprism/umbrel-app.yml
+++ b/photoprism/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: photoprism
 category: Files
 name: PhotoPrism
-version: "20210925-build-2"
+version: "20220121"
 tagline: Self-host your photo and video library
 description: >-
   PhotoPrism® is a privately hosted app for browsing, organizing, and
@@ -41,5 +41,22 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 torOnly: false
+releaseNotes: >-
+  New features:
+  
+  - We've generated missing translations with the help of DeepL and Google Translate. Native speakers are invited to help us improve those if needed. [Learn how to contribute](https://docs.photoprism.app/developer-guide/translations/).
+  
+  What is new?
+  
+  - https://github.com/photoprism/photoprism/discussions/1921#discussioncomment-2005493
+  
+  - Photos: https://github.com/photoprism/photoprism/issues/1961
+  
+  - People: https://github.com/photoprism/photoprism/issues/1957
+  
+  - Moments: https://github.com/photoprism/photoprism/issues/1953
+  
+  - Translations: https://github.com/photoprism/photoprism/commit/f7b82f616d73ed2f61e0195e31d5029ca1bda3b6
+  
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/bf4c6f127f1fcf4dbe8eea55729502dfb34278e9


### PR DESCRIPTION
### Note
After this version, Photoprism started to separate their images based on OS/Arch. Unless we use the `latest` tag for the image I don't really know how we could proceed to keep this application up-to-date. 

See Docker Hub : https://hub.docker.com/r/photoprism/photoprism/tags