### PR TITLE
Pi hole pre-install hook to disable systemd-resolved's DNS Stub Listener

### DIFF
--- a/pi-hole/hooks/pre-install
+++ b/pi-hole/hooks/pre-install
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RESOLVED_SERVICE_NAME="systemd-resolved"
+RESOLVED_CONF_FILE="/etc/systemd/resolved.conf"
+
+# Check if the 'systemd-resolved' service is running
+if ! systemctl is-active --quiet service "${RESOLVED_SERVICE_NAME}"; then
+	echo "Service '${RESOLVED_SERVICE_NAME}' is not running"
+	exit
+fi
+
+# Check if the DNS Stub Listener is running
+if cat "${RESOLVED_CONF_FILE}" | grep --quiet "^DNSStubListener=no$"; then
+	echo "DNSStubListener already turned off"
+	exit
+fi
+
+echo "Turning off the DNS Stub Listener"
+
+# Turn off DNSStubListener within config file
+sed -r -i.orig 's/#?DNSStubListener=yes/DNSStubListener=no/g' "${RESOLVED_CONF_FILE}"
+
+# Remove active resolv.conf which would have
+# localhost (systemd-resolved's DNS listener) as the DNS resolver
+rm -f /etc/resolv.conf
+
+# Create a symlink between systemd-resolved's upstream resolv.conf
+# and the OS's resolv.conf
+ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
+
+echo "Restart service '${RESOLVED_SERVICE_NAME}'"
+systemctl restart "${RESOLVED_SERVICE_NAME}"

--- a/pi-hole/umbrel-app.yml
+++ b/pi-hole/umbrel-app.yml
@@ -1,4 +1,4 @@
-manifestVersion: 1
+manifestVersion: 1.1
 id: pi-hole
 category: Networking
 name: Pi-hole


### PR DESCRIPTION
Platforms using systemd-resolved's DNS Stub Listener (which listens on 53/UDP) will cause the installation of Pi-Hole to fail (as it requires port 53/UDP). This PR adds a pre-install hook to detect if such service is being used and is listening, and to then disable this, and then have the OS use systemd-resolved's upstream resolv.conf file for DNS resolution.