### PR TITLE
Update Jellyfin ports in docker-compose.yml

### DIFF
--- a/jellyfin/docker-compose.yml
+++ b/jellyfin/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     ports:
       # Service auto-discovery
       - 7359:7359/udp
+      - 1900:1900/udp
     networks:
       default:
         ipv4_address: $APP_JELLYFIN_IP


### PR DESCRIPTION
proposing adding additional 1900 port for Jellyfin, as some users are having trouble with scanning media libraries DLNA/UPnP