### PR TITLE
Add proxy auth whitelist for nolooking

### DIFF
--- a/nolooking/docker-compose.yml
+++ b/nolooking/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
       APP_HOST: nolooking_server_1
       APP_PORT: 4444
+      PROXY_AUTH_WHITELIST: "/pj"
   
   server:
     image: satsale/nolooking:0.1.2@sha256:0e26450f6be181d2392bb51b7ecc69446d782d778622e5634c85f54c62a2fdd2

--- a/nolooking/umbrel-app.yml
+++ b/nolooking/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: nolooking
 category: Lightning Node Management 
 name: nolooking
-version: "0.1.0"
+version: "0.1.0-build-2"
 tagline: Use PayJoin to open channels for your lightning node
 description: >-
   Nolooking leverages Pay-to-Endpoint (payjoin) to negotiate a channel open for your lightning node, initiated by any BIP78 supporting wallet.
@@ -16,7 +16,7 @@ description: >-
 
   Please note that nolooking is still in early development. By using nolooking, you hold all responsibility for any loss of funds or other grievances which may arise. We are rapidly iterating on this product, feedback and contributions are strongly appreciated.
 releaseNotes: >-
-  v0.1.0 -- Initial Halloween alpha release - many more features to come!
+  - Allow access to /pj without Umbrel authentication
 developer: nolooking
 website: https://nolooking.chaincase.app
 dependencies:


### PR DESCRIPTION
From what I can tell, this auth is adding some protection to the payjoin endpoints.

Results in wallets giving messages like:
```
2022-11-10 00:59:48,027 ERROR Error parsing received PSBT
com.sparrowwallet.drongo.psbt.PSBTParseException: Provided string is not a PSBT
```

I think we should remove this auth for now, to fix the app, and inform users to keep their onion private? (Worst they can do is open channels)