### PR TITLE
Update Jam to v0.1.3

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   jam:
-    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.2-clientserver-v0.9.8@sha256:c23fdf063d6221bc923fb1ad025c4e51b0b2f18968d3664e1f3964f43f51cd09
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.3-clientserver-v0.9.8@sha256:5cc26732bb3a868c454be8568cc425065b04b07eda63baad24a4d9c44971bb5c
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: jam
 category: Finance
 name: Jam
-version: "0.1.2"
+version: "0.1.3"
 tagline: Your sats. Your privacy. Your profit.
 description: >-
   Jam is a user-interface for JoinMarket with focus on
@@ -13,7 +13,11 @@ description: >-
 
   The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 releaseNotes: >-
-  - Display error message if backend is unreachable
+  - Quickly review/adapt fee settings before sweeping
+
+  - Improved readability of Orderbook
+
+  - Wait for bitcoind to accept RPC calls
 developer: JoinMarket WebUI Organisation
 website: https://jamapp.org
 dependencies:


### PR DESCRIPTION
This version includes:
- Jam: [v0.1.3](https://github.com/joinmarket-webui/jam/releases/tag/v0.1.3)
- joinmarket-clientserver: [v0.9.8](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.8)

All notable changes of the UI can be seen in the [Jam v0.1.3 changelog](https://github.com/joinmarket-webui/jam/blob/v0.1.3/CHANGELOG.md)

Updates to the image:
- feat: wait for `bitcoind` to accept RPC calls [#76](https://github.com/joinmarket-webui/jam-docker/pull/76)