### PR TITLE
App Update: HomeAssistant to 2022.11.2

### DIFF
--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: homeassistant/home-assistant:2022.10.5@sha256:090d8cbd6f8675984ca1ca9d357d8aca97101c61f93f221e339731a702160887
+    image: homeassistant/home-assistant:2022.11.2@sha256:5e3d2dde141812a4a54c140f3cbf52b9c74168bf25e8560978f499578902a363
     volumes:
       - ${APP_DATA_DIR}/data:/config
       - ${APP_DATA_DIR}/configuration.yaml:/config/configuration.yaml

--- a/home-assistant/umbrel-app.yml
+++ b/home-assistant/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: home-assistant
 category: Automation
 name: Home Assistant
-version: "2022.10.5"
+version: "2022.11.2"
 tagline: Home automation that puts local control & privacy first
 description: >-
   Open source home automation that puts local control and privacy
@@ -33,6 +33,6 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  Full changelog (for 2022.10) can found at: https://www.home-assistant.io/changelogs/core-2022.10
+  Full changelog (for 2022.11.2) can found at: https://www.home-assistant.io/changelogs/core-2022.11
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/9d79cffae608c6a6ab077f859c1c531a581cf926


### PR DESCRIPTION
**Docker Hub :** https://hub.docker.com/layers/homeassistant/home-assistant/2022.11.2/images/sha256-c2c94019e2e9ba4616cccfd5f9abe223f725f984358dc4fd6f6472caa6cb75be?context=explore
**Changelog :** https://www.home-assistant.io/changelogs/core-2022.11

Tested on Linux VM ✅ 