### PR TITLE
Update nolooking to v0.2.0-alpha

### DIFF
--- a/nolooking/docker-compose.yml
+++ b/nolooking/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/pj"
   
   server:
-    image: chaincase/nolooking:v0.2.1-alpha@sha256:905b6f8cb89a292e5f0d6cad3b5a093751725cb3d4981e046f9aac67fc201c1b
+    image: chaincase/nolooking:v0.2.1-alpha@sha256:3e1c0d32d86762e07074bdf27b117c61d5400aa1336663f91dd302ff72fd7671
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/nolooking/docker-compose.yml
+++ b/nolooking/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/pj"
   
   server:
-    image: satsale/nolooking:0.1.2@sha256:0e26450f6be181d2392bb51b7ecc69446d782d778622e5634c85f54c62a2fdd2
+    image: chaincase/nolooking:v0.2.1-alpha@sha256:905b6f8cb89a292e5f0d6cad3b5a093751725cb3d4981e046f9aac67fc201c1b
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/nolooking/umbrel-app.yml
+++ b/nolooking/umbrel-app.yml
@@ -16,7 +16,16 @@ description: >-
 
   Please note that nolooking is still in early development. By using nolooking, you hold all responsibility for any loss of funds or other grievances which may arise. We are rapidly iterating on this product, feedback and contributions are strongly appreciated.
 releaseNotes: >-
-  - Allow access to /pj without Umbrel authentication
+  - 0.2.1-alpha (2022-11-22)
+      Fetch quote and lease inbound lightning channel via payjoin output.
+      Automate anchor deposit field (removed). Use rustls.
+      New style with random colors to replace halloween theme.
+
+  - 0.1.0-build-2 (2022-11-15)
+    - Allow access to /pj without Umbrel authentication.
+
+  - 0.1.0 (2022-11-5)
+    - Initial app submission.
 developer: nolooking
 website: https://nolooking.chaincase.app
 dependencies:

--- a/nolooking/umbrel-app.yml
+++ b/nolooking/umbrel-app.yml
@@ -16,16 +16,11 @@ description: >-
 
   Please note that nolooking is still in early development. By using nolooking, you hold all responsibility for any loss of funds or other grievances which may arise. We are rapidly iterating on this product, feedback and contributions are strongly appreciated.
 releaseNotes: >-
-  - 0.2.1-alpha (2022-11-22)
-      Fetch quote and lease inbound lightning channel via payjoin output.
-      Automate anchor deposit field (removed). Use rustls.
-      New style with random colors to replace halloween theme.
-
-  - 0.1.0-build-2 (2022-11-15)
-    - Allow access to /pj without Umbrel authentication.
-
-  - 0.1.0 (2022-11-5)
-    - Initial app submission.
+  - Fetch quote and lease inbound lightning channel via payjoin output.
+  
+  - Automate anchor deposit field (removed). Use rustls.
+  
+  - New style with random colors to replace halloween theme.
 developer: nolooking
 website: https://nolooking.chaincase.app
 dependencies:

--- a/nolooking/umbrel-app.yml
+++ b/nolooking/umbrel-app.yml
@@ -2,8 +2,8 @@ manifestVersion: 1
 id: nolooking
 category: Lightning Node Management 
 name: nolooking
-version: "0.1.0-build-2"
-tagline: Use PayJoin to open channels for your lightning node
+version: "0.2.1-alpha"
+tagline: Open all your channels in one transaction
 description: >-
   Nolooking leverages Pay-to-Endpoint (payjoin) to negotiate a channel open for your lightning node, initiated by any BIP78 supporting wallet.
 
@@ -28,7 +28,7 @@ gallery:
   - 1.jpg
   - 2.jpg
   - 3.jpg
-path: "/pj"
+path: "/"
 defaultUsername: ""
 defaultPassword: ""
 submitter: nolooking


### PR DESCRIPTION
Built for docker here: https://github.com/DanGould/nolooking/actions/runs/3509289629, but renamed so the hash doesn't match. From here on out we're building on tag @chaincase-app/nolooking