### PR TITLE
App Update: LNDg v1.4.0

### DIFF
--- a/lndg/docker-compose.yml
+++ b/lndg/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LNDG_PORT
 
   web:
-    image: ghcr.io/cryptosharks131/lndg:v1.3.1@sha256:b412bc37b6ed07c3c0335fedf409699ce019a928e69a3f6e7af9ffc8adcfcf99
+    image: ghcr.io/cryptosharks131/lndg:v1.4.0@sha256:9b97efa9a4329a4fdaf2025124433b40eb329526e13c73180c472de26bfd43df
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/lndg/umbrel-app.yml
+++ b/lndg/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lndg
 category: Lightning Node Management
 name: LNDg
-version: "1.3.1"
+version: "1.4.0"
 tagline: Analyze and automate your Lightning node management
 description: LNDg is your command center for running a profitable and efficient
   routing node. From quickly viewing your node's health, automated rebalancing,
@@ -22,8 +22,6 @@ path: ""
 defaultUsername: lndg-admin
 deterministicPassword: true
 releaseNotes: >-
-  Address an issue with unknown channels and calculating close fees
-  
-  Fixes an issue in the peer reconnection timer if the connect request results in an error
+  https://github.com/cryptosharks131/lndg/releases/tag/v1.4.0
 submitter: cryptosharks131
 submission: https://github.com/getumbrel/umbrel/pull/1189

--- a/lndg/umbrel-app.yml
+++ b/lndg/umbrel-app.yml
@@ -22,6 +22,18 @@ path: ""
 defaultUsername: lndg-admin
 deterministicPassword: true
 releaseNotes: >-
-  https://github.com/cryptosharks131/lndg/releases/tag/v1.4.0
+  - Additional failed HTLC filter by channel id (click on the alias by in/out)
+  
+  - The AP and AF logs can now be filtered by clicking on an alias name
+  
+  - Auto-adjusting AR target (decrease when potential MPP or failure, increase when successful)
+  
+  - Increasing rapid fire amounts and final rapid fire attempts decreasing until amount too small
+  
+  - Dashboard (only) page refresh every 21 min
+  
+  - Record closing costs for all closures (migrated data to closures table)
+  
+  - And more... Full details can be found here: https://github.com/cryptosharks131/lndg/releases/tag/v1.4.0
 submitter: cryptosharks131
 submission: https://github.com/getumbrel/umbrel/pull/1189


### PR DESCRIPTION
Updates LNDg to v1.4.0
https://github.com/cryptosharks131/lndg/releases/tag/v1.4.0
https://github.com/cryptosharks131/lndg/pkgs/container/lndg/51717530?tag=v1.4.0

Note: LNDg can now be accessed without a password by passing `-nologin` in the docker-compose.yml.