### PR TITLE
Access docker.sock from within container.

### DIFF
--- a/uptime-kuma/docker-compose.yml
+++ b/uptime-kuma/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     stop_grace_period: 1m
     volumes:
       - ${APP_DATA_DIR}/data/uptime-kuma:/app/data
+      - /var/run/docker.sock:/var/run/docker.sock
     networks:
       default:
         ipv4_address: $APP_UPTIME_KUMA_IP


### PR DESCRIPTION
Most common problem with Umbrel is `lnd` crashes. Enable the ability to check `lnd` uptime and generally most useful feature in Uptime Kuma (docker container monitoring)