### PR TITLE
lightning-terminal: bump version to v0.8.4-alpha

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LIGHTNING_TERMINAL_PORT
 
   web:
-    image: lightninglabs/lightning-terminal:v0.8.3-alpha@sha256:467a4e73b1bc1dd64e32ee75bea5d2343a5b500efa97d61205da18eeb4768723
+    image: lightninglabs/lightning-terminal:v0.8.3-alpha@sha256:9765cc72ba48949c6eb4e6effa9ca827c8a45153ed930b605907046051c39b6f
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: Lightning Node Management
 name: Lightning Terminal
-version: "0.8.3-alpha"
+version: "0.8.4-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -51,6 +51,6 @@ defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
   This release of Lightning Terminal (LiT) updates the packaged 
-  version of LND to v0.15.4-beta.
+  version of LND to v0.15.5-beta and of Faraday to v0.2.9-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
Hey y'all, here is the new Litd release https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.8.4-alpha