### PR TITLE
Update Jam to v0.1.4

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   web:
-    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.3-clientserver-v0.9.8@sha256:5cc26732bb3a868c454be8568cc425065b04b07eda63baad24a4d9c44971bb5c
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.4-clientserver-v0.9.8@sha256:0c7ea1a7d6d9eb8256c5f76753e7425b405ede58f597b04059dd804def60914a
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: jam
 category: Finance
 name: Jam
-version: "0.1.3"
+version: "0.1.4"
 tagline: Your sats. Your privacy. Your profit.
 description: >-
   Jam is a user-interface for JoinMarket with focus on
@@ -13,11 +13,11 @@ description: >-
 
   The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 releaseNotes: >-
-  - Quickly review/adapt fee settings before sweeping
+  - Speed up initial page load
 
-  - Improved readability of Orderbook
+  - Ability to spend (expired) fidelity bond
 
-  - Wait for bitcoind to accept RPC calls
+  - Improved settings page with subsections
 developer: JoinMarket WebUI Organisation
 website: https://jamapp.org
 dependencies:


### PR DESCRIPTION
This version includes:
- Jam: [v0.1.4](https://github.com/joinmarket-webui/jam/releases/tag/v0.1.4)
- joinmarket-clientserver: [v0.9.8](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.8)

All notable changes of the UI can be seen in the [Jam v0.1.4 changelog](https://github.com/joinmarket-webui/jam/blob/v0.1.4/CHANGELOG.md)