### PR TITLE
Add version to docker-compose.yml

### DIFF
--- a/nitter/docker-compose.yml
+++ b/nitter/docker-compose.yml
@@ -1,3 +1,5 @@
+version: "3.7"
+
 services:
   app_proxy:
     environment:


### PR DESCRIPTION
Nitter's docker-compose.yml file was missing a version docker-compose interprits as version 1. This then leads to a version mismatch error when combining multiple compose files.