### PR TITLE
Bump Torq to v0.15.4

### DIFF
--- a/torq/docker-compose.yml
+++ b/torq/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 7028
 
   web:
-    image: lncapital/torq:0.15.2@sha256:33559669f9d3f942f8e603f948ebdef7b6f20a06475f49ce3e25e90b4680fdac
+    image: lncapital/torq:0.15.4@sha256:05fa6f2282d7c90da19cdc32b9d3e7df967678566951558200c801606ed8d67e
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/torq/umbrel-app.yml
+++ b/torq/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: torq
 category: Lightning Node Management
 name: Torq
-version: "v0.15.2"
+version: "v0.15.4"
 tagline: Capital management for routing nodes on the lightning network
 description: >-
   Operating a routing node requires managing capital efficiently. If you look past the technical challenges, what you are trying to do is stack sats and support the network by routing liquidity. No matter your motivation, efficiently managing your capital is essential.
@@ -43,7 +43,7 @@ gallery:
   - 3.jpg
   - 4.jpg
 releaseNotes: >-
-  This release contains fixes to the data collection logic as well as showing web ui while Torq is bootstrapping.
+  This release contains bug fixes and new network select feature allowing user to select between mainnet and the other testnets.
 path: ""
 defaultUsername: ""
 deterministicPassword: true


### PR DESCRIPTION
Apologies that we only released a week ago but we got a few nice bug fixes in and a new network toggle for changing between mainnet and the various test nets which keeps the data segregated for those who use Torq with a testnet node as well as a main net node.

Tested on a real RaspberryPi