### PR TITLE
Update Electrs to v0.9.10

### DIFF
--- a/electrs/docker-compose.yml
+++ b/electrs/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         ipv4_address: $APP_ELECTRS_IP
   
   electrs:
-    image: getumbrel/electrs:v0.9.9@sha256:c2b9691f8a0b6f027cbcbc37a4c85ec6b28916bee4d0666ec30f75b034280f58
+    image: getumbrel/electrs:v0.9.10@sha256:7b64bf93f2137fcd040fc512a302abda17dd1b4cad8181a14fa34c15361f1334
     restart: always
     environment:
       ELECTRS_LOG_FILTERS: "INFO"

--- a/electrs/umbrel-app.yml
+++ b/electrs/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: electrs
 category: Finance
 name: Electrs
-version: "0.9.9"
+version: "0.9.10"
 tagline: A simple and efficient Electrum Server
 description: >
   Run your personal Electrum server and connect your Electrum-compatible wallet,
@@ -30,44 +30,12 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >
-  0.9.9 (Jul 12 2022)
-
-  - Update dependencies (anyhow, crossbeam-channel, crossbeam-utils, regex, serde, serde from , serde_json, signal-hook)
+  - Update dependencies (bitcoin, bitcoincore-rpc, tiny_http, serde_json, env_logger)
   
-  - Don't log scripthash (#737)
-
-
-  0.9.8 (Jun 3 2022)
-
-  - Update dependencies (serde_json, serde, bitcoin, bitcoincore-rpc, rayon, log)
+  - Fix mempool fee rate formatting (#761)
   
-  - Support new Electrum release getbalance response format (#717)
-
-
-  0.9.7 (Apr 30 2022)
-
-  - Add build matrix to test all features in CI (#706)
+  - Allow configuring signet p2p magic (#762, #768)
   
-  - Install and run cargo-bloat in CI (#705)
-  
-  - Add guide for other Ubuntu & Debian releases to compile and install librocksdb (#696)
-  
-  - Update dependencies (anyhow, log, crossbeam-channel, rayon)
-
-
-  0.9.6 (Mar 4 2022)
-  
-  - Allow skipping default config files (#686)
-  
-  - Update dependencies (anyhow, serde-json)
-
-
-  0.9.5 (Feb 4 2022)
-
-  - Update dependencies (serde-json, serde, tempfile, crossbeam-channel)
-  
-  - Fix txid index collision handling (#653)
-  
-  - Use bitcoincore_rpc's getblockchaininfo implementation (#656)
+  - Don't panic in case of an invalid block header height (#786)
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/242


### PR DESCRIPTION
Tested on `arm64` and `amd64`.

Tested:
- Umbrel App (frontend)
- Mempool
- BTC RPC Explorer
- Sparrow Wallet (MacOS)

Release notes: https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#0910-nov-3-2022