### PR TITLE
Update Kollider to v1.0.7

### DIFF
--- a/kollider/docker-compose.yml
+++ b/kollider/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       LND_ZMQ_SUB_ADDRESS: "tcp://kollider_ws_1:5556"
 
   ws:
-    image: kolliderhq/kollider-ws-client:v1.0.7@sha256:7136a6b25b452c93ed2762f5ab00e6a6d9a76d586c1eb1bdf962bee684135cd5
+    image: kolliderhq/kollider-ws-client:v1.0.7@sha256:8a68f15a8f15ce4957629f02346d3202e685781f2af026ab2c1c028179b42830
     init: true
     user: 1000:1000
     restart: on-failure
@@ -35,7 +35,7 @@ services:
       KOLLIDER_ZMQ_HEDGER_SUB_ADDRESS: "tcp://kollider_backend_1:5559"
 
   web:
-    image: kolliderhq/kollider-lite-app:v1.0.7@sha256:fd8b116d5b6e82686fd71f5d41206157e5a311b96587ff5ec14f01c24a13fd94
+    image: kolliderhq/kollider-lite-app:v1.0.7@sha256:e459ae26485c52fb2967d7e9c2afeca19b51845c8f4739d02feda9e01db3037a
     init: true
     user: 1000:1000
     restart: on-failure

--- a/kollider/docker-compose.yml
+++ b/kollider/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     environment:
       APP_HOST: kollider_web_1
       APP_PORT: 3000
-  
+
   backend:
-    image: kolliderhq/kollider-lite-backend:v1.0.6@sha256:5558948e716fe31956ef1e3985aede704b0bcd9b3af2532395c8774cffdf1666
+    image: kolliderhq/kollider-lite-backend:v1.0.7@sha256:b50c548f32022cc32e3b4a10e8c686414f4b31311771ae14c4fbaea40feedb44
     init: true
     user: 1000:1000
     restart: on-failure
@@ -18,9 +18,9 @@ services:
     environment:
       LND_IP: $APP_LIGHTNING_NODE_IP
       LND_ZMQ_SUB_ADDRESS: "tcp://kollider_ws_1:5556"
-  
+
   ws:
-    image: kolliderhq/kollider-ws-client:v1.0.6@sha256:05f3d1ddf9949b377788e442a1050457559291a50510f5d6dfa66a28c283a80a
+    image: kolliderhq/kollider-ws-client:v1.0.7@sha256:05f3d1ddf9949b377788e442a1050457559291a50510f5d6dfa66a28c283a80a
     init: true
     user: 1000:1000
     restart: on-failure
@@ -33,9 +33,9 @@ services:
       KOLLIDER_ZMQ_SUB_ADDRESS: "tcp://kollider_backend_1:5557"
       KOLLIDER_ZMQ_HEDGER_ADDRESS: "tcp://kollider_backend_1:5558"
       KOLLIDER_ZMQ_HEDGER_SUB_ADDRESS: "tcp://kollider_backend_1:5559"
-  
+
   web:
-    image: kolliderhq/kollider-lite-app:v1.0.6@sha256:f5bbbea86ed4d03c9a7c66527edbcda05228986ba5721e65c08a885edb74151a
+    image: kolliderhq/kollider-lite-app:v1.0.7@sha256:f5bbbea86ed4d03c9a7c66527edbcda05228986ba5721e65c08a885edb74151a
     init: true
     user: 1000:1000
     restart: on-failure

--- a/kollider/docker-compose.yml
+++ b/kollider/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       LND_ZMQ_SUB_ADDRESS: "tcp://kollider_ws_1:5556"
 
   ws:
-    image: kolliderhq/kollider-ws-client:v1.0.7@sha256:05f3d1ddf9949b377788e442a1050457559291a50510f5d6dfa66a28c283a80a
+    image: kolliderhq/kollider-ws-client:v1.0.7@sha256:7136a6b25b452c93ed2762f5ab00e6a6d9a76d586c1eb1bdf962bee684135cd5
     init: true
     user: 1000:1000
     restart: on-failure
@@ -35,7 +35,7 @@ services:
       KOLLIDER_ZMQ_HEDGER_SUB_ADDRESS: "tcp://kollider_backend_1:5559"
 
   web:
-    image: kolliderhq/kollider-lite-app:v1.0.7@sha256:f5bbbea86ed4d03c9a7c66527edbcda05228986ba5721e65c08a885edb74151a
+    image: kolliderhq/kollider-lite-app:v1.0.7@sha256:fd8b116d5b6e82686fd71f5d41206157e5a311b96587ff5ec14f01c24a13fd94
     init: true
     user: 1000:1000
     restart: on-failure

--- a/kollider/umbrel-app.yml
+++ b/kollider/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: kollider
 category: Finance
 name: Kollider
-version: "1.0.6"
+version: "1.0.7"
 tagline: Lightning-fast derivative trading
 description: >-
   Kollider lets you instantly trade perpetual contracts with low fees

--- a/kollider/umbrel-app.yml
+++ b/kollider/umbrel-app.yml
@@ -29,6 +29,8 @@ gallery:
   - 3.jpg
 path: ""
 deterministicPassword: true
+releaseNotes: >
+  - Update python dependency pyzmq to fix raspberry pi crash
 torOnly: false
 submitter: Kollider
 submission: https://github.com/getumbrel/umbrel/pull/1221


### PR DESCRIPTION
This fixes a bug on the arm version where pyzmq cannot connect to a hostname. Due to the recent change from hardcoded IPs to hostnames, this broke the Kollider app for some users.