### PR TITLE
Migrate contents of Simple torrent downloads directory to Umbrel's shared downloads directory

### DIFF
--- a/simple-torrent/docker-compose.yml
+++ b/simple-torrent/docker-compose.yml
@@ -15,5 +15,5 @@ services:
       --config-path /config/simple-torrent.json
     volumes:
       - ${APP_DATA_DIR}/data/torrents:/torrents
-      - ${APP_DATA_DIR}/data/downloads:/downloads
+      - ${UMBREL_ROOT}/data/storage/downloads:/downloads
       - ${APP_DATA_DIR}/data/config:/config

--- a/simple-torrent/hooks/pre-start
+++ b/simple-torrent/hooks/pre-start
@@ -49,6 +49,13 @@ if [[ "$(ls -l "${LOCAL_DOWNLOADS_DIR}" | wc -l)" -gt "1" ]]; then
 	mv --verbose "${LOCAL_DOWNLOADS_DIR}/"* "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}"
 fi
 
+# Check if the local downloads directory is now empty
+if [[ "$(ls -l "${LOCAL_DOWNLOADS_DIR}" | wc -l)" -gt "1" ]]; then
+	echo "Failed to migrate local downloads directory: ${LOCAL_DOWNLOADS_DIR}"
+	echo "This directory still contains files/folders..."
+	exit
+fi
+
 rm -rf "${LOCAL_DOWNLOADS_DIR}"
 
 echo "Local downloads directory successfully migrated"

--- a/simple-torrent/hooks/pre-start
+++ b/simple-torrent/hooks/pre-start
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DATA_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)"
+UMBREL_ROOT="${APP_DATA_DIR}/../.."
+
+UMBREL_DATA_DIR="${UMBREL_ROOT}/data"
+UMBREL_DATA_STORAGE_DIR="${UMBREL_DATA_DIR}/storage"
+UMBREL_DATA_STORAGE_DOWNLOADS_DIR="${UMBREL_DATA_STORAGE_DIR}/downloads"
+DESIRED_OWNER="1000:1000"
+
+if [[ ! -d "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}" ]]; then
+	mkdir -p "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}"
+fi
+
+simpletorrent_correct_permission() {
+	local -r path="${1}"
+
+	if [[ -d "${path}" ]]; then
+		owner=$(stat -c "%u:%g" "${path}")
+
+		if [[ "${owner}" != "${DESIRED_OWNER}" ]]; then
+			chown "${DESIRED_OWNER}" "${path}"
+		fi
+	fi
+}
+
+simpletorrent_correct_permission "${UMBREL_DATA_DIR}"
+simpletorrent_correct_permission "${UMBREL_DATA_STORAGE_DIR}"
+simpletorrent_correct_permission "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}"
+
+# Migrate existing installations to use the shared downloads directory
+LOCAL_DOWNLOADS_DIR="${APP_DATA_DIR}/data/downloads"
+
+if [[ ! -d "${LOCAL_DOWNLOADS_DIR}" ]]; then
+	echo "No local download directory found. Skipping migration..."
+	exit
+fi
+

--- a/simple-torrent/hooks/pre-start
+++ b/simple-torrent/hooks/pre-start
@@ -4,6 +4,8 @@ set -euo pipefail
 APP_DATA_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)"
 UMBREL_ROOT="${APP_DATA_DIR}/../.."
 
+# We need to ensure Umbrel's shared download folder
+# exists and is owned by the correct user
 UMBREL_DATA_DIR="${UMBREL_ROOT}/data"
 UMBREL_DATA_STORAGE_DIR="${UMBREL_DATA_DIR}/storage"
 UMBREL_DATA_STORAGE_DOWNLOADS_DIR="${UMBREL_DATA_STORAGE_DIR}/downloads"
@@ -37,7 +39,7 @@ if [[ ! -d "${LOCAL_DOWNLOADS_DIR}" ]]; then
 	exit
 fi
 
-# Move contents of local downloads folder to Umbrel shared downloads folder
+# Move contents of local downloads folder to Umbrel's shared downloads folder
 rsync -vau --remove-source-files --exclude=".*" "${LOCAL_DOWNLOADS_DIR}/" "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}/"
 
 rm -rf "${LOCAL_DOWNLOADS_DIR}"

--- a/simple-torrent/hooks/pre-start
+++ b/simple-torrent/hooks/pre-start
@@ -44,7 +44,7 @@ if [[ ! -d "${LOCAL_DOWNLOADS_DIR}" ]]; then
 fi
 
 # Check if local downloads is not empty
-if [[ "$(ls -A "${LOCAL_DOWNLOADS_DIR}")" ]]; then
+if [[ "$(ls -l "${LOCAL_DOWNLOADS_DIR}" | wc -l)" -gt "1" ]]; then
 	# Move contents of local downloads folder to Umbrel's shared downloads folder
 	mv --verbose "${LOCAL_DOWNLOADS_DIR}/"* "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}"
 fi

--- a/simple-torrent/hooks/pre-start
+++ b/simple-torrent/hooks/pre-start
@@ -33,7 +33,7 @@ simpletorrent_correct_permission "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}"
 LOCAL_DOWNLOADS_DIR="${APP_DATA_DIR}/data/downloads"
 
 if [[ ! -d "${LOCAL_DOWNLOADS_DIR}" ]]; then
-	echo "No local download directory found. Skipping migration..."
+	echo "No local downloads directory found. Skipping migration..."
 	exit
 fi
 
@@ -41,3 +41,5 @@ fi
 rsync -vau --remove-source-files --exclude=".*" "${LOCAL_DOWNLOADS_DIR}/" "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}/"
 
 rm -rf "${LOCAL_DOWNLOADS_DIR}"
+
+echo "Local downloads directory successfully migrated"

--- a/simple-torrent/hooks/pre-start
+++ b/simple-torrent/hooks/pre-start
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# The purpose of this pre-start hook is to migrate
+# the local downloads folder for existing installations
+# to Umbrel's shared downloads folder
+
 APP_DATA_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)"
 UMBREL_ROOT="${APP_DATA_DIR}/../.."
 
@@ -39,8 +43,11 @@ if [[ ! -d "${LOCAL_DOWNLOADS_DIR}" ]]; then
 	exit
 fi
 
-# Move contents of local downloads folder to Umbrel's shared downloads folder
-mv --verbose "${LOCAL_DOWNLOADS_DIR}/"* "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}"
+# Check if local downloads is not empty
+if [[ "$(ls -A "${LOCAL_DOWNLOADS_DIR}")" ]]; then
+	# Move contents of local downloads folder to Umbrel's shared downloads folder
+	mv --verbose "${LOCAL_DOWNLOADS_DIR}/"* "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}"
+fi
 
 rm -rf "${LOCAL_DOWNLOADS_DIR}"
 

--- a/simple-torrent/hooks/pre-start
+++ b/simple-torrent/hooks/pre-start
@@ -40,7 +40,7 @@ if [[ ! -d "${LOCAL_DOWNLOADS_DIR}" ]]; then
 fi
 
 # Move contents of local downloads folder to Umbrel's shared downloads folder
-rsync -vau --remove-source-files --exclude=".*" "${LOCAL_DOWNLOADS_DIR}/" "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}/"
+mv --verbose "${LOCAL_DOWNLOADS_DIR}/"* "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}"
 
 rm -rf "${LOCAL_DOWNLOADS_DIR}"
 

--- a/simple-torrent/hooks/pre-start
+++ b/simple-torrent/hooks/pre-start
@@ -39,3 +39,5 @@ fi
 
 # Move contents of local downloads folder to Umbrel shared downloads folder
 rsync -vau --remove-source-files --exclude=".*" "${LOCAL_DOWNLOADS_DIR}/" "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}/"
+
+rm -rf "${LOCAL_DOWNLOADS_DIR}"

--- a/simple-torrent/hooks/pre-start
+++ b/simple-torrent/hooks/pre-start
@@ -37,3 +37,5 @@ if [[ ! -d "${LOCAL_DOWNLOADS_DIR}" ]]; then
 	exit
 fi
 
+# Move contents of local downloads folder to Umbrel shared downloads folder
+rsync -vau --remove-source-files "${LOCAL_DOWNLOADS_DIR}/" "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}/"

--- a/simple-torrent/hooks/pre-start
+++ b/simple-torrent/hooks/pre-start
@@ -38,4 +38,4 @@ if [[ ! -d "${LOCAL_DOWNLOADS_DIR}" ]]; then
 fi
 
 # Move contents of local downloads folder to Umbrel shared downloads folder
-rsync -vau --remove-source-files "${LOCAL_DOWNLOADS_DIR}/" "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}/"
+rsync -vau --remove-source-files --exclude=".*" "${LOCAL_DOWNLOADS_DIR}/" "${UMBREL_DATA_STORAGE_DOWNLOADS_DIR}/"

--- a/simple-torrent/umbrel-app.yml
+++ b/simple-torrent/umbrel-app.yml
@@ -1,4 +1,4 @@
-manifestVersion: 1
+manifestVersion: 1.1
 id: simple-torrent
 category: Networking
 name: SimpleTorrent
@@ -42,5 +42,7 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 torOnly: false
+permissions:
+  - STORAGE_DOWNLOADS
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/b12c581ae14255c2087fc8e2f0e7014a351a363b

--- a/simple-torrent/umbrel-app.yml
+++ b/simple-torrent/umbrel-app.yml
@@ -29,7 +29,7 @@ description: >-
 
   - Magnet RSS subscribing supported
 releaseNotes: >-
-  - SimpleTorrent now utilizes the shared downloads folder that can be accessed by other apps on Umbrel, such as Jellyfin, FileBrowser, Transmission, Plex, and more.
+  - SimpleTorrent now utilizes the shared downloads folder that can be accessed by other apps on Umbrel, such as Jellyfin, File Browser, Transmission, Plex, and more.
 developer: Preston
 website: https://github.com/boypt
 dependencies: []

--- a/simple-torrent/umbrel-app.yml
+++ b/simple-torrent/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: simple-torrent
 category: Networking
 name: SimpleTorrent
-version: "1.3.9"
+version: "1.3.9-hotfix-1"
 tagline: Download torrents with your Umbrel
 description: >-
   SimpleTorrent is a a self-hosted remote torrent client that starts
@@ -28,6 +28,8 @@ description: >-
   - Protocol Handler to magnet:
 
   - Magnet RSS subscribing supported
+releaseNotes: >-
+  - Migrate downloads from local (app) directory to Umbrel's shared downloads directory
 developer: Preston
 website: https://github.com/boypt
 dependencies: []


### PR DESCRIPTION
This PR adds a migration using a `pre-start` hook to migrate existing installations to use Umbrel's shared downloads directory.

Tested the following cases:
- Creating Umbrel's shared downloads directory if it does not exist
- Migrating an existing install with downloads (tested with 10GB dummy data)
- Migrating an existing install with no downloads
- App restart after migration to ensure it does not run again

Closes #349 