### PR TITLE
Torq v0.16.3

### DIFF
--- a/torq/docker-compose.yml
+++ b/torq/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 7028
 
   web:
-    image: lncapital/torq:0.15.4@sha256:05fa6f2282d7c90da19cdc32b9d3e7df967678566951558200c801606ed8d67e
+    image: lncapital/torq:0.16.3@sha256:452e22ce391fc1b98f61ed98bb5cfd439ce689713cfb73ae38555575163a2535
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/torq/umbrel-app.yml
+++ b/torq/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: torq
 category: Lightning Node Management
 name: Torq
-version: "v0.15.4"
+version: "v0.16.3"
 tagline: Capital management for routing nodes on the lightning network
 description: >-
   Operating a routing node requires managing capital efficiently. If you look past the technical challenges, what you are trying to do is stack sats and support the network by routing liquidity. No matter your motivation, efficiently managing your capital is essential.
@@ -43,7 +43,12 @@ gallery:
   - 3.jpg
   - 4.jpg
 releaseNotes: >-
-  This release contains bug fixes and new network select feature allowing user to select between mainnet and the other testnets.
+  This release fixes excessive memory consumption when importing invoices and drifting channel balances.
+  New features:
+  Tags! You can now tag channels and nodes!
+  Navigate using the flow diagram!
+  Quicker inspection of channels from both the forwards and channels page using pop out modal.
+  Update and close channels from the forwards page
 path: ""
 defaultUsername: ""
 deterministicPassword: true

--- a/torq/umbrel-app.yml
+++ b/torq/umbrel-app.yml
@@ -44,10 +44,15 @@ gallery:
   - 4.jpg
 releaseNotes: >-
   This release fixes excessive memory consumption when importing invoices and drifting channel balances.
+
   New features:
+
   Tags! You can now tag channels and nodes!
+
   Navigate using the flow diagram!
+
   Quicker inspection of channels from both the forwards and channels page using pop out modal.
+
   Update and close channels from the forwards page
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
Bump Torq to v0.16.3: 

New features:

- Tags! You can now tag channels and nodes!
- Tags can be seen on the channels, forwards and channel inspection pages.
- Navigate using the flow diagram!
- Quicker inspection of channels from both the forwards and channels page using pop out modal.
- Update and close channels from the forwards page
- New Channel table columns for remote node stats.
- New default views for the forwards and channels tables
- Navigate time using the arrow keys on the forwards table, summary page and channel inspect page

Bug fixes:

- Fix bug preventing routing policy updates
- Corrected bug causing the channel balance in the channels table page to be incorrect
- Importing pending open/closing channels properly
- Fetching missing channel ids from vector
- Updating "Import Failed Payments" is now persisted correctly.
- Fixed memory leak when importing invoices
- Channel events are now showing correctly on the channels page
- Channel events are correctly labeled with short channel ID

Tested on a real Raspberry PI