### PR TITLE
Allow LND to connect to Bitcoin Core on other networks

### DIFF
--- a/lightning/exports.sh
+++ b/lightning/exports.sh
@@ -25,7 +25,7 @@ BIN_ARGS+=( "--accept-amp" )
 BIN_ARGS+=( "--rpcmiddleware.enable" )
 
 # [Bitcoind]
-BIN_ARGS+=( "--bitcoind.rpchost=${APP_BITCOIN_NODE_IP}" )
+BIN_ARGS+=( "--bitcoind.rpchost=${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_RPC_PORT}" )
 BIN_ARGS+=( "--bitcoind.rpcuser=${APP_BITCOIN_RPC_USER}" )
 BIN_ARGS+=( "--bitcoind.rpcpass=${APP_BITCOIN_RPC_PASS}" )
 BIN_ARGS+=( "--bitcoind.zmqpubrawblock=tcp://${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_ZMQ_RAWBLOCK_PORT}" )

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: lightning
 category: Finance
 name: Lightning Node
-version: "0.15.5-beta"
+version: "0.15.5-beta-patch-1"
 tagline: Run your personal Lightning Network node
 description: >-
   Run your personal Lightning Network node, and join the future of Bitcoin today.
@@ -22,7 +22,12 @@ description: >-
 
   An official app from Umbrel.
 releaseNotes: >-
-  Bug Fixes:
+  Umbrel patch:
+
+    - LND will now connect to Bitcoin Core on other networks e.g.testnet
+
+    
+  LND Bug Fixes:
 
   - A Taproot related key tweak issue was fixed in btcd that affected remote signing setups.
 

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -23,10 +23,8 @@ description: >-
   An official app from Umbrel.
 releaseNotes: >-
   Umbrel patch:
-
     - LND will now connect to Bitcoin Core on other networks e.g.testnet
 
-    
   LND Bug Fixes:
 
   - A Taproot related key tweak issue was fixed in btcd that affected remote signing setups.

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -23,7 +23,7 @@ description: >-
   An official app from Umbrel.
 releaseNotes: >-
   Umbrel patch:
-    - LND will now connect to Bitcoin Core on other networks e.g.testnet
+    - LND will now connect to Bitcoin Core on other networks e.g. testnet
 
   LND Bug Fixes:
 


### PR DESCRIPTION
Currently LND assumes the RPC port depending on the network that is in use. The previous Bitcoin update uses port `8332` for RPC for all networks. This PR makes use the `$APP_BITCOIN_RPC_PORT` env. var. that is exported by the Bitcoin app.