### PR TITLE
Update Urbit to v1.17

### DIFF
--- a/urbit/docker-compose.yml
+++ b/urbit/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_PORT: 8090
   
   manager:
-    image: mopfelwinrux/urbit-umbrel:v1.16@sha256:dc74c6b4c114d6d5e115a1d21bc95a7fac00054420015383d4ea3e7750af50a5
+    image: mopfelwinrux/urbit-umbrel:v1.16@sha256:2bda68d8e1f83c1e306f43a37b330e339a521dba4b0ccff617dc76b4a0e51975
     ports:
       - "34343:34343"
     volumes:

--- a/urbit/docker-compose.yml
+++ b/urbit/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_PORT: 8090
   
   manager:
-    image: mopfelwinrux/urbit-umbrel:v1.16@sha256:2bda68d8e1f83c1e306f43a37b330e339a521dba4b0ccff617dc76b4a0e51975
+    image: mopfelwinrux/urbit-umbrel:v1.17@sha256:972e8a4c0da892a1ab2c6c31386c3668ad3aff23e72a6ac0b97485472c82e6e3
     ports:
       - "34343:34343"
     volumes:

--- a/urbit/docker-compose.yml
+++ b/urbit/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_PORT: 8090
   
   manager:
-    image: mopfelwinrux/urbit-umbrel:v1.15.0@sha256:f0f908dc1069b606e5fb45b407f9729f84b1f031932b4ddfcc7ca998d0fa90bc
+    image: mopfelwinrux/urbit-umbrel:v1.16:sha256:db8298119357dafee04ff96188d87250c2104d50c357b8b6458ae1cb61b9246a
     ports:
       - "34343:34343"
     volumes:

--- a/urbit/docker-compose.yml
+++ b/urbit/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_PORT: 8090
   
   manager:
-    image: mopfelwinrux/urbit-umbrel:v1.16@sha256:db8298119357dafee04ff96188d87250c2104d50c357b8b6458ae1cb61b9246a
+    image: mopfelwinrux/urbit-umbrel:v1.16@sha256:f8c746b2c85336cbf5049ee88e2fea7c5aaa8d952da2a8a327cbeb0cfea06c41
     ports:
       - "34343:34343"
     volumes:

--- a/urbit/docker-compose.yml
+++ b/urbit/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_PORT: 8090
   
   manager:
-    image: mopfelwinrux/urbit-umbrel:v1.16@sha256:f8c746b2c85336cbf5049ee88e2fea7c5aaa8d952da2a8a327cbeb0cfea06c41
+    image: mopfelwinrux/urbit-umbrel:v1.16@sha256:dc74c6b4c114d6d5e115a1d21bc95a7fac00054420015383d4ea3e7750af50a5
     ports:
       - "34343:34343"
     volumes:

--- a/urbit/docker-compose.yml
+++ b/urbit/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_PORT: 8090
   
   manager:
-    image: mopfelwinrux/urbit-umbrel:v1.16:sha256:db8298119357dafee04ff96188d87250c2104d50c357b8b6458ae1cb61b9246a
+    image: mopfelwinrux/urbit-umbrel:v1.16@sha256:db8298119357dafee04ff96188d87250c2104d50c357b8b6458ae1cb61b9246a
     ports:
       - "34343:34343"
     volumes:

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -37,5 +37,6 @@ submission: https://github.com/getumbrel/umbrel/pull/1246
 releaseNotes: >-
   Updated Urbit binary to v1.16
 
-Use new Vere repo, fix binary extraction
+  Use new Vere repo, fix binary extraction
 
+  This release is functionally equivalent to v1.15 but is built in the new Vere repo using Bazel instead of Nix with a new and improved release pipeline. It marks the successful extraction of the runtime from the Urbit monorepo. It also adds a new AArch64-specific macOS build and removes the Windows build.

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -37,37 +37,4 @@ submission: https://github.com/getumbrel/umbrel/pull/1246
 releaseNotes: >-
   Updated Urbit binary to v1.17
 
-  This release includes a new and improved terminal stack, which is
-  required for compatibility with zuse 416 (urbit-os-v2.130). It remains
-  backwards compatible with the terminal stack as it existed prior to
-  this, but there is one purely visual issue: the prompt may seem to
-  disappear. This should resolve itself once you receive the zuse 416
-  update.
-  
-  Additionally, as of this release, we no longer support Windows
-  platforms. We do not presently have the resources to support non-*nix
-  systems at the level of quality we want to deliver. Notably Windows was
-  already very much a second-class citizen, as apparent from issues like
-  #5822 and others. Windows users may want to run Urbit through WSL
-  instead.
-  
-  Release notes:
-  
-  -   Revamped Urbit’s terminal stack. This release contains the first
-      phase of a longer-running project towards a next-generation terminal
-      experience. Highlights in this release include:
-      
-      -   Support for 2D cursor movement, and by extension 2D screen
-          drawing.
-          
-      -   Minimal mouse-click support.
-      
-      -   Faster pasting of large texts.
-      
-      -   Informal printfs (~&) now get rendered in grey, to visually
-          distinguish them from formal dill output.
-          
-  -   Updated versioning scheme for pre-release binaries.
-  
-  -   The code for the Vere runtime has been moved out of the urbit/urbit
-      repository, and now lives in urbit/vere.
+  Full release notes here: https://github.com/urbit/vere/releases/tag/vere-v1.17

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -35,10 +35,9 @@ torOnly: false
 submitter: ~mopfel-winrux
 submission: https://github.com/getumbrel/umbrel/pull/1246
 releaseNotes: >-
-  Updated Urbit binary to v1.16
-  
-  Arvo 417K
-  
-  Vere 1.16
-  
-  This release is functionally equivalent to v1.15 but is built in the new Vere repo using Bazel instead of Nix with a new and improved release pipeline. It marks the successful extraction of the runtime from the Urbit monorepo. It also adds a new AArch64-specific macOS build and removes the Windows build.
+Updated Urbit binary to v1.16
+
+- Fix URL with vere repo
+
+This release is functionally equivalent to [v1.15](https://github.com/urbit/urbit/releases/tag/urbit-v1.15) but is built in the [new Vere repo](https://github.com/urbit/vere) using [Bazel](https://bazel.build) instead of [Nix](https://nixos.org) with a new and improved release pipeline. It marks the successful extraction of the runtime from the [Urbit monorepo](https://github.com/urbit/urbit). It also adds a new AArch64-specific macOS build and removes the Windows build.
+

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: urbit
 category: Networking
 name: Urbit
-version: "v1.16"
+version: "v1.16-hotfix1"
 tagline: Run Urbit on your Umbrel
 description: >-
   Urbit is a personal server for self-sovereign personal & networked
@@ -35,9 +35,9 @@ torOnly: false
 submitter: ~mopfel-winrux
 submission: https://github.com/getumbrel/umbrel/pull/1246
 releaseNotes: >-
-Updated Urbit binary to v1.16
+  - Updated Urbit binary to v1.16
 
-- Fix URL with vere repo
+  - Fix URL with vere repo
 
-This release is functionally equivalent to [v1.15](https://github.com/urbit/urbit/releases/tag/urbit-v1.15) but is built in the [new Vere repo](https://github.com/urbit/vere) using [Bazel](https://bazel.build) instead of [Nix](https://nixos.org) with a new and improved release pipeline. It marks the successful extraction of the runtime from the [Urbit monorepo](https://github.com/urbit/urbit). It also adds a new AArch64-specific macOS build and removes the Windows build.
-
+  This release is functionally equivalent to [v1.15](https://github.com/urbit/urbit/releases/tag/urbit-v1.15) but is built in the [new Vere repo](https://github.com/urbit/vere) using [Bazel](https://bazel.build) instead of [Nix](https://nixos.org) with a new and improved release pipeline. It marks the successful extraction of the runtime from the [Urbit monorepo](https://github.com/urbit/urbit). It also adds a new AArch64-specific macOS build and removes the Windows build.
+

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: urbit
 category: Networking
 name: Urbit
-version: "v1.16-hotfix2"
+version: "v1.17"
 tagline: Run Urbit on your Umbrel
 description: >-
   Urbit is a personal server for self-sovereign personal & networked
@@ -35,12 +35,34 @@ torOnly: false
 submitter: ~mopfel-winrux
 submission: https://github.com/getumbrel/umbrel/pull/1246
 releaseNotes: >-
-  Updated Urbit binary to v1.16
+  Updated Urbit binary to v1.17
 
-  Use new Vere repo, fix binary extraction
-
-  This release is functionally equivalent to v1.15 but is built in the new
-  Vere repo using Bazel instead of Nix with a new and improved release
-  pipeline. It marks the successful extraction of the runtime from the
-  Urbit monorepo. It also adds a new AArch64-specific macOS build and
-  removes the Windows build.
+  This release includes a new and improved terminal stack, which is
+  required for compatibility with zuse 416 (urbit-os-v2.130). It remains
+  backwards compatible with the terminal stack as it existed prior to
+  this, but there is one purely visual issue: the prompt may seem to
+  disappear. This should resolve itself once you receive the zuse 416
+  update.
+  
+  Additionally, as of this release, we no longer support Windows
+  platforms. We do not presently have the resources to support non-*nix
+  systems at the level of quality we want to deliver. Notably Windows was
+  already very much a second-class citizen, as apparent from issues like
+  #5822 and others. Windows users may want to run Urbit through WSL
+  instead.
+  
+  Release notes:
+  
+  -   Revamped Urbit’s terminal stack. This release contains the first
+      phase of a longer-running project towards a next-generation terminal
+      experience. Previous announcements can be found here[^1] and
+      here[^2]. (And #4463 and #5663.) Highlights in this release include:
+      -   Support for 2D cursor movement, and by extension 2D screen
+          drawing.
+      -   Minimal mouse-click support.
+      -   Faster pasting of large texts.
+      -   Informal printfs (~&) now get rendered in grey, to visually
+          distinguish them from formal dill output.
+  -   Updated versioning scheme for pre-release binaries.
+  -   The code for the Vere runtime has been moved out of the urbit/urbit
+      repository, and now lives in urbit/vere.

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: urbit
 category: Networking
 name: Urbit
-version: "1.15"
+version: "v1.16"
 tagline: Run Urbit on your Umbrel
 description: >-
   Urbit is a personal server for self-sovereign personal & networked
@@ -35,18 +35,4 @@ torOnly: false
 submitter: ~mopfel-winrux
 submission: https://github.com/getumbrel/umbrel/pull/1246
 releaseNotes: >-
-  - v1.15 is a revert to v1.13
-
-  From v1.13:
-
-  - Supports setting the loom size on startup. sizes are specified in exponents of 2, from 1MB (20) to 4GB (32); can differ between processes (--loom and --urth-loom); and can be set for relevant subcommands (meld, pack, next, &c).
-
-  - Improves bit-slice performance (for noun de/serialization and many atom jets) by ensuring that implementation inner loops can be vectorized.
-
-  - Adds the vile command, for exporting the keyfile from a ship
-
-  - Adds the %xray hint, for printing the bytecode of a given expression (ty ~topfet-parmed!)
-
-  - Adds the eval command, for running hoon (from stdin) without booting a ship (ty ~mopfel-winrux!)
-
-  - Adds a better error message when a ship is already running as root (ty ~dinleb-rambep!)
+Updated Urbit binary to v1.16

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: urbit
 category: Networking
 name: Urbit
-version: "v1.16-hotfix1"
+version: "v1.16-hotfix2"
 tagline: Run Urbit on your Umbrel
 description: >-
   Urbit is a personal server for self-sovereign personal & networked
@@ -35,8 +35,7 @@ torOnly: false
 submitter: ~mopfel-winrux
 submission: https://github.com/getumbrel/umbrel/pull/1246
 releaseNotes: >-
-  - Updated Urbit binary to v1.16
+  Updated Urbit binary to v1.16
 
-  - Fix URL with vere repo
+Use new Vere repo, fix binary extraction
 
-  This release is functionally equivalent to v1.15 but is built in the new Vere repo using Bazel instead of Nix with a new and improved release pipeline. It marks the successful extraction of the runtime from the Urbit monorepo. It also adds a new AArch64-specific macOS build and removes the Windows build.

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -39,5 +39,4 @@ releaseNotes: >-
 
   - Fix URL with vere repo
 
-  This release is functionally equivalent to [v1.15](https://github.com/urbit/urbit/releases/tag/urbit-v1.15) but is built in the [new Vere repo](https://github.com/urbit/vere) using [Bazel](https://bazel.build) instead of [Nix](https://nixos.org) with a new and improved release pipeline. It marks the successful extraction of the runtime from the [Urbit monorepo](https://github.com/urbit/urbit). It also adds a new AArch64-specific macOS build and removes the Windows build.
-
+  This release is functionally equivalent to v1.15 but is built in the new Vere repo using Bazel instead of Nix with a new and improved release pipeline. It marks the successful extraction of the runtime from the Urbit monorepo. It also adds a new AArch64-specific macOS build and removes the Windows build.

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -39,4 +39,8 @@ releaseNotes: >-
 
   Use new Vere repo, fix binary extraction
 
-  This release is functionally equivalent to v1.15 but is built in the new Vere repo using Bazel instead of Nix with a new and improved release pipeline. It marks the successful extraction of the runtime from the Urbit monorepo. It also adds a new AArch64-specific macOS build and removes the Windows build.
+  This release is functionally equivalent to v1.15 but is built in the new
+  Vere repo using Bazel instead of Nix with a new and improved release
+  pipeline. It marks the successful extraction of the runtime from the
+  Urbit monorepo. It also adds a new AArch64-specific macOS build and
+  removes the Windows build.

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -36,3 +36,6 @@ submitter: ~mopfel-winrux
 submission: https://github.com/getumbrel/umbrel/pull/1246
 releaseNotes: >-
 Updated Urbit binary to v1.16
+Arvo 417K
+Vere 1.16
+This release is functionally equivalent to v1.15 but is built in the new Vere repo using Bazel instead of Nix with a new and improved release pipeline. It marks the successful extraction of the runtime from the Urbit monorepo. It also adds a new AArch64-specific macOS build and removes the Windows build.

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -35,7 +35,10 @@ torOnly: false
 submitter: ~mopfel-winrux
 submission: https://github.com/getumbrel/umbrel/pull/1246
 releaseNotes: >-
-Updated Urbit binary to v1.16
-Arvo 417K
-Vere 1.16
-This release is functionally equivalent to v1.15 but is built in the new Vere repo using Bazel instead of Nix with a new and improved release pipeline. It marks the successful extraction of the runtime from the Urbit monorepo. It also adds a new AArch64-specific macOS build and removes the Windows build.
+  Updated Urbit binary to v1.16
+  
+  Arvo 417K
+  
+  Vere 1.16
+  
+  This release is functionally equivalent to v1.15 but is built in the new Vere repo using Bazel instead of Nix with a new and improved release pipeline. It marks the successful extraction of the runtime from the Urbit monorepo. It also adds a new AArch64-specific macOS build and removes the Windows build.

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -35,8 +35,6 @@ torOnly: false
 submitter: ~mopfel-winrux
 submission: https://github.com/getumbrel/umbrel/pull/1246
 releaseNotes: >-
-  Updated Urbit binary to v1.17
-
   -   Revamped Urbit’s terminal stack. This release contains the first
       phase of a longer-running project towards a next-generation terminal
       experience. Highlights in this release include:
@@ -52,6 +50,7 @@ releaseNotes: >-
           distinguish them from formal dill output.
           
   -   Updated versioning scheme for pre-release binaries.
+  
   
   -   The code for the Vere runtime has been moved out of the urbit/urbit
       repository, and now lives in urbit/vere.

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -55,14 +55,19 @@ releaseNotes: >-
   
   -   Revamped Urbit’s terminal stack. This release contains the first
       phase of a longer-running project towards a next-generation terminal
-      experience. Previous announcements can be found here[^1] and
-      here[^2]. (And #4463 and #5663.) Highlights in this release include:
+      experience. Highlights in this release include:
+      
       -   Support for 2D cursor movement, and by extension 2D screen
           drawing.
+          
       -   Minimal mouse-click support.
+      
       -   Faster pasting of large texts.
+      
       -   Informal printfs (~&) now get rendered in grey, to visually
           distinguish them from formal dill output.
+          
   -   Updated versioning scheme for pre-release binaries.
+  
   -   The code for the Vere runtime has been moved out of the urbit/urbit
       repository, and now lives in urbit/vere.

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -37,4 +37,23 @@ submission: https://github.com/getumbrel/umbrel/pull/1246
 releaseNotes: >-
   Updated Urbit binary to v1.17
 
+  -   Revamped Urbit’s terminal stack. This release contains the first
+      phase of a longer-running project towards a next-generation terminal
+      experience. Highlights in this release include:
+      
+      -   Support for 2D cursor movement, and by extension 2D screen
+          drawing.
+          
+      -   Minimal mouse-click support.
+      
+      -   Faster pasting of large texts.
+      
+      -   Informal printfs (~&) now get rendered in grey, to visually
+          distinguish them from formal dill output.
+          
+  -   Updated versioning scheme for pre-release binaries.
+  
+  -   The code for the Vere runtime has been moved out of the urbit/urbit
+      repository, and now lives in urbit/vere.
+
   Full release notes here: https://github.com/urbit/vere/releases/tag/vere-v1.17


### PR DESCRIPTION
- Updated Urbit to official v1.17 binary: https://github.com/urbit/vere/releases