### PR TITLE
Disclaimer on torrent apps

### DIFF
--- a/simple-torrent/umbrel-app.yml
+++ b/simple-torrent/umbrel-app.yml
@@ -28,6 +28,8 @@ description: >-
   - Protocol Handler to magnet:
 
   - Magnet RSS subscribing supported
+
+  - !IMPORTANT! - SimpleTorrent downloads torrents over the Clearnet, NOT USING TOR.  
 developer: Preston
 website: https://github.com/boypt
 dependencies: []

--- a/transmission/umbrel-app.yml
+++ b/transmission/umbrel-app.yml
@@ -15,6 +15,8 @@ description: >-
 
   
   We don't bundle toolbars, pop-up ads, flash ads, twitter tools, or anything else. It doesn't hold some features back for a payware version. We don't track our users. Our website and forums have no third-party ads or analytics.
+  
+  !IMPORTANT! - Transmission downloads torrents over the Clearnet, NOT USING TOR.  
 developer: Transmission
 website: https://transmissionbt.com/
 dependencies: []


### PR DESCRIPTION
Torrent Apps don't have any info stating that they download over clearnet. This is confusing for users and has led to multiple questions in the telegram group.

I sent also an [issue](https://github.com/getumbrel/umbrel-apps/issues/380) describing the underlying problem in the Umbre-apps repo