### PR TITLE
Update home-assistant to 2023.2.0

### DIFF
--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: homeassistant/home-assistant:2022.11.2@sha256:5e3d2dde141812a4a54c140f3cbf52b9c74168bf25e8560978f499578902a363
+    image: homeassistant/home-assistant:2023.2.0@sha256:dff6ad8d27f40a3c167243f39d9ac4e1177c67b0fd3276be0624673a920664fe
     volumes:
       - ${APP_DATA_DIR}/data:/config
       - ${APP_DATA_DIR}/configuration.yaml:/config/configuration.yaml

--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: homeassistant/home-assistant:2023.2.0@sha256:dff6ad8d27f40a3c167243f39d9ac4e1177c67b0fd3276be0624673a920664fe
+    image: homeassistant/home-assistant:2023.2.0@sha256:a4a9f614a1edcd414d63decd99813a2ff9910d876db1e04641540a0c75d20918
     volumes:
       - ${APP_DATA_DIR}/data:/config
       - ${APP_DATA_DIR}/configuration.yaml:/config/configuration.yaml

--- a/home-assistant/umbrel-app.yml
+++ b/home-assistant/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: home-assistant
 category: Automation
 name: Home Assistant
-version: "2022.11.2"
+version: "2023.2.0"
 tagline: Home automation that puts local control & privacy first
 description: >-
   Open source home automation that puts local control and privacy
@@ -33,6 +33,6 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  Full changelog (for 2022.11.2) can found at: https://www.home-assistant.io/changelogs/core-2022.11
+  Full changelog (for 2023.2.0) can found at: https://www.home-assistant.io/changelogs/core-2023.2
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/9d79cffae608c6a6ab077f859c1c531a581cf926


### PR DESCRIPTION
Dockerhub: https://hub.docker.com/layers/homeassistant/home-assistant/2023.2.0/images/sha256-dff6ad8d27f40a3c167243f39d9ac4e1177c67b0fd3276be0624673a920664fe?context=explore

Changelog: https://www.home-assistant.io/changelogs/core-2023.2 (includes initial release of new voice assistant)