### PR TITLE
Update Jam to v0.1.5

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   web:
-    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.4-clientserver-v0.9.8@sha256:0c7ea1a7d6d9eb8256c5f76753e7425b405ede58f597b04059dd804def60914a
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.5-clientserver-v0.9.9@sha256:c8bf944000eb8b3b5666ac037440a4904f9c3baa8665c52081a9e5092d6bd275
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -24,7 +24,7 @@ releaseNotes: >-
   - Coin Control: Quick freeze/unfreeze utxos
 
   - Coin Control: Show jar total amount in detail view
-developer: JoinMarket WebUI Organisation
+developer: JoinMarket WebUI Org.
 website: https://jamapp.org
 dependencies:
   - bitcoin
@@ -39,5 +39,5 @@ path: ""
 defaultUsername: umbrel
 defaultPassword: ""
 deterministicPassword: true
-submitter: JoinMarket WebUI Organisation
+submitter: JoinMarket WebUI Org.
 submission: https://github.com/getumbrel/umbrel/pull/1216

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: jam
 category: Finance
 name: Jam
-version: "0.1.4"
+version: "0.1.5"
 tagline: Your sats. Your privacy. Your profit.
 description: >-
   Jam is a user-interface for JoinMarket with focus on
@@ -13,11 +13,17 @@ description: >-
 
   The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 releaseNotes: >-
-  - Speed up initial page load
+  - Fees: Allow min tx fee of 1sat/vbyte
 
-  - Ability to spend (expired) fidelity bond
+  - Fees: Allow input for relative fee limit of 0.0001%
 
-  - Improved settings page with subsections
+  - Bonds: Correctly display success screen after unlocking fb
+
+  - Sweep: Display success screen after a scheduler run completes
+
+  - Coin Control: Quick freeze/unfreeze utxos
+
+  - Coin Control: Show jar total amount in detail view
 developer: JoinMarket WebUI Organisation
 website: https://jamapp.org
 dependencies:


### PR DESCRIPTION
This version includes:
- Jam: [v0.1.5](https://github.com/joinmarket-webui/jam/releases/tag/v0.1.5)
- joinmarket-clientserver: [v0.9.9](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.9)

All notable changes of the UI can be seen in the [Jam v0.1.5 changelog](https://github.com/joinmarket-webui/jam/blob/v0.1.5/CHANGELOG.md)