### PR TITLE
Update Torq to v0.18.18

### DIFF
--- a/torq/docker-compose.yml
+++ b/torq/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 7028
 
   web:
-    image: lncapital/torq:0.18.17@sha256:cfa84321cc583345a7c0a720a35823a5f291df158c1871fa3131d907aedec06b
+    image: lncapital/torq:0.18.18@sha256:a2d5d2aed1f7ef3b94cdaf9f7c2c1aa0c386b698fdf03038bfe512ed3e7f6d8c
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/torq/umbrel-app.yml
+++ b/torq/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: torq
 category: Lightning Node Management
 name: Torq
-version: "v0.18.17"
+version: "v0.18.18"
 tagline: Capital management for routing nodes on the lightning network
 description: >-
   Operating a routing node requires managing capital efficiently. If you look past the technical challenges, what you are trying to do is stack sats and support the network by routing liquidity. No matter your motivation, efficiently managing your capital is essential.
@@ -32,6 +32,8 @@ description: >-
   - Navigate through time (days, weeks, months) to track your progress
 
   - Tag channels and nodes with custom labels (Exchange, Routing node, Sink, Source, or anything else)
+  
+  - Automation of channel policy (fee rate etc.) and add or remove tags
 
 developer: LN Capital
 website: https://ln.capital
@@ -46,24 +48,20 @@ gallery:
   - 3.jpg
   - 4.jpg
 releaseNotes: >-
-  This release includes:
+  New features:
+  
+  - Channel views can now be renamed via the title
+  
+  - Added filterable columns to Channel view
+  
+  - Tag sorting
   
   
-  * Automation!
+  Bug fixes:
+
+  - Fixed bug causing race conditions when saving a node
   
-  Automation is finally here, or at least the first part of it. You can now automate the channel policy (fee rate etc.) and add or remove tags. We will very soon release more advanced actions and of course Rebalancing!
-  
-  
-  * Detailed data import choices
-  
-  You can now select what data Torq import. This is an important feature for very large nodes that are concerned about the impact of the initial data import. You can gradually turn them on again.
-  
-  
-  * No login required on Umbrel
-  
-  
-  
-  There are also a lot of bug fixes and UI improvements that should make the user experience of Torq better.
+  - Activate Streams by default
 
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
Update Torq to v0.18.18 

  New features: 
  - Channel views can now be renamed via the title
  - Added filterable columns to Channel view
  - Tag sorting

  Bug fixes:

  - Fixed bug causing race conditions when saving a node
  - Activate Streams by default

Tested on real Rasberry PI