### PR TITLE
[GitHub Actions] Auto Updater

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,72 @@
+name: Auto Updater
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+    generateInputPaths:
+        name: List all app folders
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Generate matrix with all the apps in this repo
+              id: set-matrix
+              run: echo "matrix=$(ls -d ./*/ | jq --raw-input --slurp --compact-output 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+        outputs:
+            matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    update:
+        needs: generateInputPaths
+        runs-on: ubuntu-latest
+        strategy:
+            max-parallel: 1
+            fail-fast: false
+            matrix:
+                path: ${{ fromJson(needs.generateInputPaths.outputs.matrix) }}
+
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Check file existence
+              id: check_files
+              uses: andstor/file-existence-action@v2
+              with:
+                files: ${{ github.workspace }}/${{ matrix.path }}/.env
+                ignore_case: false
+            
+            - name: Load .env file
+              if: steps.check_files.outputs.files_exists == 'true'
+              uses: xom9ikk/dotenv@v2
+              with:
+                path: ${{ github.workspace }}/${{ matrix.path }}
+
+            - name: Fetch the latest version
+              id: get_latest
+              if: steps.check_files.outputs.files_exists == 'true'
+              run: echo "latest=$(curl -sL https://api.github.com/repos/${{ env.GITHUB }}/releases/latest | jq -r ".tag_name")" >> $GITHUB_OUTPUT
+            
+            - name: Fetch the latest digest
+              id: get_hash
+              if: ${{ steps.get_latest.outputs.latest != 'null' && steps.check_files.outputs.files_exists == 'true' }}
+              run: echo "hash=$(curl -sL https://hub.docker.com/v2/repositories/${{ env.DOCKER }}/tags/${{ steps.get_latest.outputs.latest }} | jq -r .digest)" >> $GITHUB_OUTPUT
+
+            - name: Update the version
+              uses: fjogeleit/yaml-update-action@main
+              if: ${{ steps.get_latest.outputs.latest != 'null' && steps.check_files.outputs.files_exists == 'true' }}
+              with:
+                valueFile: '${{ env.ID }}/umbrel-app.yml'
+                changes: |
+                    {
+                        "${{ env.ID }}/umbrel-app.yml": {
+                            "version": "${{ steps.get_latest.outputs.latest }}"
+                        },
+                        "${{ env.ID }}/docker-compose.yml": {
+                            "services.server.image": "${{ env.DOCKER }}:${{ steps.get_latest.outputs.latest }}@${{ steps.get_hash.outputs.hash }}"
+                        }
+                    }
+                commitChange: true
+                branch: master
+                message: 'Updated ${{ env.NAME }} to ${{ steps.get_latest.outputs.latest }}'

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -64,7 +64,7 @@ jobs:
                             "version": "${{ steps.get_latest.outputs.latest }}"
                         },
                         "${{ env.ID }}/docker-compose.yml": {
-                            "services.server.image": "${{ env.DOCKER }}:${{ steps.get_latest.outputs.latest }}@${{ steps.get_hash.outputs.hash }}"
+                            "services.${{ env.MAIN }}.image": "${{ env.DOCKER }}:${{ steps.get_latest.outputs.latest }}@${{ steps.get_hash.outputs.hash }}"
                         }
                     }
                 commitChange: true

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ cd btc-rpc-explorer
 - `docker-compose.yml` - Used to start and stop your app's Docker containers
 - `umbrel-app.yml` - A app manifest file so that Umbrel knows the name and version of the app
 - `exports.sh` - A shell script to export environment variables used within `docker-compose.yml` and shared with other installed apps
+- `.env` - Used for the auto updater
 
 We'll now create a `docker-compose.yml` file in this directory to define our application.
 
@@ -206,6 +207,15 @@ The `exports.sh` shell script is a simple script to export environmental variabl
 If we (for example) wanted to share BTC RPC Explorer's Address API with other apps; that would look like this:
 ```sh
 export APP_BTC_RPC_EXPLORER_ADDRESS_API="electrumx"
+```
+
+The `.env` file defines the variables our auto updater uses to fetch the latest container version
+
+```sh
+ID=<same as the folder name>
+NAME=<Friendly name>
+GITHUB=<GitHub/repo>
+DOCKER=<docker/image>
 ```
 
 4\. For our app, we'll update `<docker-image>` with `getumbrel/btc-rpc-explorer`, `<tag>` with `v2.0.2`, and `<port>` with `3002`. Since BTC RPC Explorer doesn't need to store any persistent data and doesn't require access to Bitcoin Core's or LND's data directories, we can remove the entire `volumes` block.

--- a/README.md
+++ b/README.md
@@ -211,11 +211,12 @@ export APP_BTC_RPC_EXPLORER_ADDRESS_API="electrumx"
 
 The `.env` file defines the variables our auto updater uses to fetch the latest container version
 
-```sh
+```env
 ID=<same as the folder name>
 NAME=<Friendly name>
 GITHUB=<GitHub/repo>
 DOCKER=<docker/image>
+MAIN=<ID of the main container in docker-compose>
 ```
 
 4\. For our app, we'll update `<docker-image>` with `getumbrel/btc-rpc-explorer`, `<tag>` with `v2.0.2`, and `<port>` with `3002`. Since BTC RPC Explorer doesn't need to store any persistent data and doesn't require access to Bitcoin Core's or LND's data directories, we can remove the entire `volumes` block.


### PR DESCRIPTION
A GitHub action for automatically updating all the apps on this repo daily.

I have a working example of this on my own [Umbrel apps repo](https://github.com/ShonP40/umbrel-apps).

The action fetches the latest version of each app from GitHub’s API, and then uses that data to get its Docker image digest from Docker Hub’s API.
There are failsafes as well in case of an API outage.

Each app will need to have a basic `.env` file in its folder that specifies the ID (same as the folder name), a friendly name, GitHub repo (`org/repo`) and Docker repo (`org/image`).

I will create an env file for each app in this repository once you guys confirm that this action will be added to not waste time (the action can also skip apps that don’t have an `.env` file).

Requirements for app devs for this to work:
- Have a GitHub repo with each update published as a GitHub release & have the latest release flagged as `Latest`
- Have a Docker image with versioned releases (pretty sure that this is already a requirement for Umbrel itself)