### PR TITLE
Update lightning-terminal to v0.8.6-alpha

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.8.5-alpha@sha256:e534d3a4cd48e2c1bb3cc61d87300ccd59edc4a557ad353c719e110ab0fc4f6a
+    image: lightninglabs/lightning-terminal:v0.8.6-alpha@sha256:b2a5a90da72d5571f3608f830091853f2ebfd1fb2dabfa86d1447dc6d2a42dce
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: Lightning Node Management
 name: Lightning Terminal
-version: "0.8.5-alpha"
+version: "0.8.6-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -50,8 +50,22 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  This release of Lightning Terminal (LiT) updates the packaged 
-  version of LND to v0.15.5-beta, Faraday to v0.2.9-alpha, Loop 
-  to v0.20.2-beta and Pool to v0.6.1-beta.
+  This release of Lightning Terminal (LiT) includes a variety of updates
+  including support for off-chain accounts and the ability to customize the 
+  permissions of an LNC session through the UI. It also contains an 
+  implementation of a rule firewall and a privacy firewall. The rule 
+  firewall can be used to verify the parameters of certain calls (for example 
+  ensuring that calls only act on a specific set of channels) and the privacy 
+  firewall can be used to force private info (such as pub keys, channel IDs etc) 
+  to be mapped out to random values for responses and mapped back to real values
+  for requests. An Autopilot client is added which handles registration of LNC 
+  sessions with the Autopilot server. Autopilot calls will be forced to go 
+  through the new rule and privacy firewalls.
+
+  We'll be continuously working to improve the user experience based on feedback
+  from the community.
+
+  This release packages LND v0.15.5-beta, Loop v0.21.0-beta, Pool v0.6.1-beta, 
+  and Faraday v0.2.9-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -62,8 +62,10 @@ releaseNotes: >-
   sessions with the Autopilot server. Autopilot calls will be forced to go 
   through the new rule and privacy firewalls.
 
+
   We'll be continuously working to improve the user experience based on feedback
   from the community.
+
 
   This release packages LND v0.15.5-beta, Loop v0.21.0-beta, Pool v0.6.1-beta, 
   and Faraday v0.2.9-alpha.


### PR DESCRIPTION
Updates Lighting Terminal (litd) to the latest release.
https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.8.6-alpha
