### PR TITLE
Update PiHole to 2023.02.2

### DIFF
--- a/pi-hole/docker-compose.yml
+++ b/pi-hole/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
   
   server:
-    image: pihole/pihole:2023.02.0@sha256:65047a58be709cbfee9586ed224e7e1fd49233be4074e1659baee335105093f2
+    image: pihole/pihole:2023.02.2@sha256:9abbf1c218f32a4084e614150a44714f046f73c40a9d2889a0e6edf01ff0a387
     # Pi-hole doesn't currently support running as non-root
     # https://github.com/pi-hole/docker-pi-hole/issues/685
     # user: "1000:1000"

--- a/pi-hole/umbrel-app.yml
+++ b/pi-hole/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: pi-hole
 category: Networking
 name: Pi-hole
-version: "5.18.4"
+version: "2023.02.2"
 tagline: Block ads on your entire network
 description: >-
   Instead of browser plugins or other software on each computer,
@@ -31,17 +31,10 @@ defaultUsername: ""
 deterministicPassword: true
 torOnly: false
 releaseNotes: >-
-  - FTL v5.21
+  - Replace deprecated variables with the correct ones by @rdwebdesign in #1320
   
-  - Core v5.14.4
+  - Remove default lightttd from the image 4961bf4
   
-  - db_queries.php: use the same color scheme from Dashboard by @rdwebdesign in pi-hole/AdminLTE#2517
-  
-  - Fix multiple restarts while importing with Teleporter by @yubiuser in pi-hole/AdminLTE#2519
-  
-  - Use the setupVars.conf option TEMPERATUREUNIT, plus slight rearrangement of settings page by @rdwebdesign in pi-hole/AdminLTE#2516
-  
-  
-  Full changelog available here: https://github.com/pi-hole/AdminLTE/compare/v5.18...v5.18.4 
+  Full changelog available here: https://github.com/pi-hole/docker-pi-hole/compare/2023.02.0...2023.02.2 
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/9ca55a25e043dcd50d5cb92c6ec756d368bb4794

--- a/pi-hole/umbrel-app.yml
+++ b/pi-hole/umbrel-app.yml
@@ -31,19 +31,17 @@ defaultUsername: ""
 deterministicPassword: true
 torOnly: false
 releaseNotes: >-
-  Pi-Hole component versions:
+  Starting with version 2023.02.02, the versioning of the Pi-hole app has been updated to reference the docker-pi-hole version (https://github.com/pi-hole/docker-pi-hole).
+  This release includes specific versions of the Pi-hole components: Core v5.15.5, FTL v5.21, and AdminLTE v5.18.4
   
-  - Core v5.15.5, FTL v5.21, AdminLTE v5.18.4
+
+  Version 2023.02.02 Changelog: 
   
-  Changelog: 
-  
-  - (Umbrel Specific) Switch version referece in the Umbrel app store to Pi-Hole's docker one
-  
-  - Replace deprecated variables with the correct ones by @rdwebdesign in #1320
+  - Replace deprecated variables with the correct ones
   
   - Remove default lightttd from the image 4961bf4
   
   
-  Full changelog available here: https://github.com/pi-hole/docker-pi-hole/compare/2023.02.0...2023.02.2 
+  Full changelogs are available here: https://github.com/pi-hole/docker-pi-hole/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/9ca55a25e043dcd50d5cb92c6ec756d368bb4794

--- a/pi-hole/umbrel-app.yml
+++ b/pi-hole/umbrel-app.yml
@@ -31,6 +31,14 @@ defaultUsername: ""
 deterministicPassword: true
 torOnly: false
 releaseNotes: >-
+  Pi-Hole component versions:
+  
+  - Core v5.15.5, FTL v5.21, AdminLTE v5.18.4
+  
+  Changelog: 
+  
+  - (Umbrel Specific) Switch version referece in the Umbrel app store to Pi-Hole's docker one
+  
   - Replace deprecated variables with the correct ones by @rdwebdesign in #1320
   
   - Remove default lightttd from the image 4961bf4

--- a/pi-hole/umbrel-app.yml
+++ b/pi-hole/umbrel-app.yml
@@ -35,6 +35,7 @@ releaseNotes: >-
   
   - Remove default lightttd from the image 4961bf4
   
+  
   Full changelog available here: https://github.com/pi-hole/docker-pi-hole/compare/2023.02.0...2023.02.2 
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/9ca55a25e043dcd50d5cb92c6ec756d368bb4794


### PR DESCRIPTION
Hi,

I had noticed that the changelogs and versioning in `umbrel-app.yml` didn't follow the `docker` github repository of PiHole. I was wondering if there would be a reason?

PiHole Docker Repo: https://github.com/pi-hole/docker-pi-hole/

This PR Updates to the latest version and switched the versioning to follow PiHole's Docker Github versioning.
Tested on AMD VM