### PR TITLE
Update Gitea to 1.18.5

### DIFF
--- a/gitea/docker-compose.yml
+++ b/gitea/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: gitea/gitea:1.16.8-rootless@sha256:8a6ad22694c76122ae075af1153a544577724c45cb45af44963aa78dc179cc46
+    image: gitea/gitea:1.18.5-rootless@sha256:40d4a630fd90cb41bea245034a1a86e3ba7220e8f6d7e5e0d0a50583df2e1a16
     user: "1000:1000"
     restart: on-failure
     ports:
@@ -31,7 +31,7 @@ services:
       GITEA__database__PASSWD: "moneyprintergobrrr"
 
   db:
-    image: mariadb:10.5.12@sha256:dfcba5641bdbfd7cbf5b07eeed707e6a3672f46823695a0d3aba2e49bbd9b1dd
+    image: mariadb:10.11.2@sha256:dd0f492b6b6e7bb4aa707181b799d4efe42cb3a9f6012ec3dbaf326d402151e8
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/gitea/umbrel-app.yml
+++ b/gitea/umbrel-app.yml
@@ -42,27 +42,33 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >
-  Release notes for 1.18.15!
+  This release updates Gitea from 1.16.8 to 1.18.5.
+  A full list of new features, improvements, and bug fixes
+  for versions between 1.16.8 and 1.18.5 can be found here: https://github.com/go-gitea/gitea/releases.
+  
+  
+  Version 1.18.5 release notes:
   
   ENHANCEMENTS
   
-  -Hide 2FA status from other members in organization members list (#22999) (#23023)
+  - Hide 2FA status from other members in organization members list
   
+
   BUGFIXES
   
-  - Add force_merge to merge request and fix checking mergable (#23010) (#23032)
+  - Add force_merge to merge request and fix checking mergable
   
-  - Use --message=%s for git commit message (#23028) (#23029)
+  - Use --message=%s for git commit message
   
-  - Render access log template as text instead of HTML (#23013) (#23025)
+  - Render access log template as text instead of HTML
   
-  - Fix the Manually Merged form (#23015) (#23017)
+  - Fix the Manually Merged form
   
-  - Use beforeCommit instead of baseCommit (#22949) (#22996)
+  - Use beforeCommit instead of baseCommit
   
-  - Display attachments of review comment when comment content is blank (#23035) (#23046)
+  - Display attachments of review comment when comment content is blank
   
-  - Return empty url for submodule tree entries (#23043) (#23048)
+  - Return empty url for submodule tree entries
 
 torOnly: false
 submitter: Umbrel

--- a/gitea/umbrel-app.yml
+++ b/gitea/umbrel-app.yml
@@ -49,6 +49,7 @@ releaseNotes: >
   
   Version 1.18.5 release notes:
   
+  
   ENHANCEMENTS
   
   - Hide 2FA status from other members in organization members list

--- a/gitea/umbrel-app.yml
+++ b/gitea/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: gitea
 category: Development
 name: Gitea
-version: "1.16.8"
+version: "1.18.5"
 tagline: A painless self-hosted Git service
 description: >-
   Gitea is a painless self-hosted Git service. It is similar to
@@ -41,6 +41,29 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: >
+Release notes for 1.18.15!
+
+ENHANCEMENTS
+
+-Hide 2FA status from other members in organization members list (#22999) (#23023)
+
+BUGFIXES
+
+- Add force_merge to merge request and fix checking mergable (#23010) (#23032)
+
+- Use --message=%s for git commit message (#23028) (#23029)
+
+- Render access log template as text instead of HTML (#23013) (#23025)
+
+- Fix the Manually Merged form (#23015) (#23017)
+
+- Use beforeCommit instead of baseCommit (#22949) (#22996)
+
+- Display attachments of review comment when comment content is blank (#23035) (#23046)
+
+- Return empty url for submodule tree entries (#23043) (#23048)
+
 torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/d62e00353917143a3a10d3b376859f51b665d150

--- a/gitea/umbrel-app.yml
+++ b/gitea/umbrel-app.yml
@@ -42,27 +42,27 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >
-Release notes for 1.18.15!
-
-ENHANCEMENTS
-
--Hide 2FA status from other members in organization members list (#22999) (#23023)
-
-BUGFIXES
-
-- Add force_merge to merge request and fix checking mergable (#23010) (#23032)
-
-- Use --message=%s for git commit message (#23028) (#23029)
-
-- Render access log template as text instead of HTML (#23013) (#23025)
-
-- Fix the Manually Merged form (#23015) (#23017)
-
-- Use beforeCommit instead of baseCommit (#22949) (#22996)
-
-- Display attachments of review comment when comment content is blank (#23035) (#23046)
-
-- Return empty url for submodule tree entries (#23043) (#23048)
+  Release notes for 1.18.15!
+  
+  ENHANCEMENTS
+  
+  -Hide 2FA status from other members in organization members list (#22999) (#23023)
+  
+  BUGFIXES
+  
+  - Add force_merge to merge request and fix checking mergable (#23010) (#23032)
+  
+  - Use --message=%s for git commit message (#23028) (#23029)
+  
+  - Render access log template as text instead of HTML (#23013) (#23025)
+  
+  - Fix the Manually Merged form (#23015) (#23017)
+  
+  - Use beforeCommit instead of baseCommit (#22949) (#22996)
+  
+  - Display attachments of review comment when comment content is blank (#23035) (#23046)
+  
+  - Return empty url for submodule tree entries (#23043) (#23048)
 
 torOnly: false
 submitter: Umbrel


### PR DESCRIPTION
I'm not sure if we need the MariaDB hash as well, I used the 10.11.2 tag from here: [MariaDB Docker Hub](https://hub.docker.com/layers/library/mariadb/10.11.2/images/sha256-dc249cd0b7e41739fc4c5dbfcfda160afc7d6d1e40ce14ffbe2b62c285dd06ef?context=explore)