### PR TITLE
Bump Oak Node to v0.3.5

### DIFF
--- a/oak-node/docker-compose.yml
+++ b/oak-node/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8100
 
   web:
-    image: oak-node.net/oak:v0.3.4@sha256:b4f218a453a10174492a1b03c66329dff89bdece26c0b024e1bffe9340141048
+    image: oak-node.net/oak:v0.3.5@sha256:5e8091e75992692029b03a1c7b9190f7a10fca58f8c8318a7a9bcf92d35098c3
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/oak-node/umbrel-app.yml
+++ b/oak-node/umbrel-app.yml
@@ -2,17 +2,18 @@ manifestVersion: 1
 id: oak-node
 category: Finance
 name: Oak Node
-version: "0.3.4"
+version: "0.3.5"
 tagline: Do more with your LND node
 description: >-
-  Oak Node gives you Scheduled Payments. Now you can send sats to a Lightning Address on a schedule. 
-  Support your favorite content creators every week, every day, or even every block! Up to you.
+  Oak Node gives you Scheduled Sends. Use it to schedule recurring tips to LNURL or Lightning Addresses. 
 
 
-  Oak Node also includes an optional bot module for more advanced users.
+  For Nostriches out there, the included Nostr bot gives you control over your sats from any Nostr client.
 releaseNotes: >-
-  This update brings an experimental section for Nostr Proof-of-Work notes, 
-  alongside a few UI improvements and a Feedback Via Lightning page.
+  The Nostr bot now has a Shadowy LN Tips feature. Once it's set up, you can use any Nostr client to trigger an LN tip to anyone by just liking one of their notes.
+  
+  
+  This update also brings NIP-65 support for more reliable pairing, auto-reconnects to relays when necessary, npub support and more.
 developer: Carlos
 website: https://oak-node.net
 dependencies:


### PR DESCRIPTION
Most changes affect the Nostr bot.

I've tested it on an Umbrel VM.