### PR TITLE
Update Samourai Server (revert using Docker DNS)

### DIFF
--- a/samourai-server/docker-compose.yml
+++ b/samourai-server/docker-compose.yml
@@ -3,10 +3,9 @@ version: "3.7"
 services:
   app_proxy:
     environment:
-      APP_HOST: samourai-server_nginx_1
+      APP_HOST: $APP_SAMOURAI_SERVER_IP
       APP_PORT: 8081
       PROXY_AUTH_ADD: "false"
-  
   db:
     image: louneskmt/dojo-db:1.5.0-low-mem@sha256:5af4f90818d55360e572033fcc493cd945143e7a3aaef91fa7e102f3c66c7a5b
     init: true
@@ -20,12 +19,15 @@ services:
       MYSQL_PASSWORD: password
     volumes:
       - ${APP_DATA_DIR}/mysql/data:/var/lib/mysql
+    networks:
+      default:
+        ipv4_address: $APP_SAMOURAI_SERVER_DB_IP
 
   node:
     image: louneskmt/dojo-nodejs:1.16.1@sha256:49de92774ecfcb88af1dc67f8d498641d750c4ec9acaab3c448d70c4f2d4bfe7
     init: true
     restart: on-failure
-    command: "/home/node/app/wait-for-it.sh samourai-server_db_1:3306 --timeout=720 --strict -- /home/node/app/restart.sh"
+    command: "/home/node/app/wait-for-it.sh ${APP_SAMOURAI_SERVER_DB_IP}:3306 --timeout=720 --strict -- /home/node/app/restart.sh"
     user: "1000:1000"
     environment:
       # GLOBAL
@@ -33,7 +35,7 @@ services:
       DOJO_VERSION_TAG: 1.16.1
       NET_DOJO_TOR_IPV4: $TOR_PROXY_IP
       TOR_SOCKS_PORT: $TOR_PROXY_PORT
-      NET_DOJO_MYSQL_IPV4: samourai-server_db_1
+      NET_DOJO_MYSQL_IPV4: $APP_SAMOURAI_SERVER_DB_IP
 
       # MYSQL
       MYSQL_DATABASE: samourai-main
@@ -82,6 +84,9 @@ services:
       INDEXER_BATCH_SUPPORT: inactive # 'active' for ElectrumX, 'inactive' otherwise
     depends_on:
       - db
+    networks:
+      default:
+        ipv4_address: $APP_SAMOURAI_SERVER_NODE_IP
 
   whirlpool:
     image: louneskmt/whirlpool:0.10.15@sha256:3b766327dfa4c2ae40f190c18afa1f3c9cb9101d7964049dc79bdcb89fd21a90
@@ -92,7 +97,7 @@ services:
       - "--listen"
       - "--cli.apiKey=$APP_SAMOURAI_SERVER_WHIRLPOOL_API_KEY"
       - "--cli.api.http-enable=true"
-      - "--cli.api.http-port=8898"
+      - "--cli.api.http-port=$APP_SAMOURAI_SERVER_WHIRLPOOL_PORT"
       - "--cli.tor=true"
       - "--cli.torConfig.coordinator.enabled=true"
       - "--cli.torConfig.coordinator.onion=true"
@@ -104,11 +109,14 @@ services:
     environment:
       WHIRLPOOL_BITCOIN_NETWORK: $APP_BITCOIN_NETWORK
       WHIRLPOOL_DOJO: "on"
-      WHIRLPOOL_DOJO_IP: "samourai-server_nginx_1"
+      WHIRLPOOL_DOJO_IP: $APP_SAMOURAI_SERVER_IP
     depends_on:
       - node
     volumes:
       - ${APP_DATA_DIR}/whirlpool:/home/whirlpool/.whirlpool-cli
+    networks:
+      default:
+        ipv4_address: $APP_SAMOURAI_SERVER_WHIRLPOOL_IP
 
   nginx:
     image: nginx:1.21-alpine@sha256:686aac2769fd6e7bab67663fd38750c135b72d993d0bb0a942ab02ef647fc9c3
@@ -123,16 +131,19 @@ services:
       - ${APP_DATA_DIR}/nginx/connect:/var/www/connect
     environment:
       COMMON_BTC_NETWORK: $APP_BITCOIN_NETWORK
-      DOJO_LOCAL_PORT: 3009
+      DOJO_LOCAL_PORT: $APP_SAMOURAI_SERVER_DOJO_PORT
       DOJO_HIDDEN_SERVICE: $APP_SAMOURAI_SERVER_DOJO_HIDDEN_SERVICE
       WHIRLPOOL_HIDDEN_SERVICE: $APP_SAMOURAI_SERVER_WHIRLPOOL_HIDDEN_SERVICE
       NODE_PREFIX_SUPPORT: support
       NODE_ADMIN_KEY: $APP_SAMOURAI_SERVER_NODE_ADMIN_KEY
       WHIRLPOOL_API_KEY: $APP_SAMOURAI_SERVER_WHIRLPOOL_API_KEY
     ports:
-      - "3009:80"
+      - "$APP_SAMOURAI_SERVER_DOJO_PORT:80"
     depends_on:
       - node
+    networks:
+      default:
+        ipv4_address: $APP_SAMOURAI_SERVER_IP
 
   tor:
     image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a

--- a/samourai-server/exports.sh
+++ b/samourai-server/exports.sh
@@ -1,3 +1,11 @@
+export APP_SAMOURAI_SERVER_IP="10.21.21.22"
+export APP_SAMOURAI_SERVER_DOJO_PORT="3009"
+export APP_SAMOURAI_SERVER_CONNECT_PORT="3005"
+export APP_SAMOURAI_SERVER_WHIRLPOOL_IP="10.21.21.23"
+export APP_SAMOURAI_SERVER_WHIRLPOOL_PORT="8898"
+export APP_SAMOURAI_SERVER_DB_IP="10.21.21.24"
+export APP_SAMOURAI_SERVER_NODE_IP="10.21.21.25"
+
 dojo_hidden_service_file="${EXPORTS_TOR_DATA_DIR}/app-${EXPORTS_APP_ID}-dojo/hostname"
 whirlpool_hidden_service_file="${EXPORTS_TOR_DATA_DIR}/app-${EXPORTS_APP_ID}-whirlpool/hostname"
 export APP_SAMOURAI_SERVER_DOJO_HIDDEN_SERVICE="$(cat "${dojo_hidden_service_file}" 2>/dev/null || echo "notyetset.onion")"

--- a/samourai-server/torrc.template
+++ b/samourai-server/torrc.template
@@ -1,7 +1,7 @@
-# samourai-server whirlpool Hidden Service
-HiddenServiceDir /data/app-$APP_ID-whirlpool
-HiddenServicePort 80 samourai-server_whirlpool_1:8898
-
 # samourai-server dojo Hidden Service
 HiddenServiceDir /data/app-$APP_ID-dojo
-HiddenServicePort 80 samourai-server_nginx_1:80
+HiddenServicePort 80 $APP_SAMOURAI_SERVER_IP:80
+
+# samourai-server whirlpool Hidden Service
+HiddenServiceDir /data/app-$APP_ID-whirlpool
+HiddenServicePort 80 $APP_SAMOURAI_SERVER_WHIRLPOOL_IP:$APP_SAMOURAI_SERVER_WHIRLPOOL_PORT

--- a/samourai-server/umbrel-app.yml
+++ b/samourai-server/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: samourai-server
 category: Wallet Servers
 name: Samourai Server
-version: "1.16.1-hotfix-2"
+version: "1.16.1-hotfix-3"
 tagline: Your private backing server for Samourai Wallet
 description: >-
   Samourai Server is an exclusive Umbrel app that runs Samourai Dojo
@@ -32,6 +32,6 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Fix remote access via Tor
+  This update fixes a bug where users could not connect using Whirlpool GUI
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/461


### PR DESCRIPTION
Fixes Whirpool GUI issue noted in Issue https://github.com/getumbrel/umbrel-apps/issues/397

Whirlpool GUI connection/authentication does not appear to do any DNS resolution. The following error is shown in the GUI:

<img width="325" alt="image" src="https://user-images.githubusercontent.com/38882571/218298679-bb44cc89-db3a-4b5c-9a72-1c15e6b8c3c6.png">

and the following error is logged in the whirpool container:
`whirlpool_1   | com.samourai.wallet.api.backend.beans.HttpException: java.lang.IllegalArgumentException: Invalid URI host: null (authority: samourai-server_nginx_1:80)`

Reverting back to using hardcoded container IPs instead of name containers w/ Docker DNS fixes this issue.