### PR TITLE
Update lnbits to v0.10.1

### DIFF
--- a/lnbits/docker-compose.yml
+++ b/lnbits/docker-compose.yml
@@ -32,3 +32,6 @@ services:
       LNBITS_DEFAULT_WALLET_NAME: "LNbits wallet"
       LNBITS_DISABLED_EXTENSIONS: "amilk"
       LNBITS_ADMIN_EXTENSIONS: "ngrok"
+      
+      # Cashu
+      CASHU_PRIVATE_KEY: ${APP_SEED}

--- a/lnbits/docker-compose.yml
+++ b/lnbits/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
   
   web:
-    image: lnbitsdocker/lnbits-legend:0.9.7@sha256:1fccd9611a23b9d9259ca4adff860e3e2d441ed42261d192141e76b261cd3b74
+    image: lnbitsdocker/lnbits-legend:0.10.1@sha256:c94f30fb41a6608aae2a1d0bc47831fccb109a646118100dfc23c967ab13eefe
     init: true
     restart: on-failure
     stop_grace_period: 1m

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lnbits
 category: Finance
 name: LNbits
-version: "0.10"
+version: "0.10.1"
 tagline: Multi-user wallet management system
 description: >-
   LNbits is a simple multi-user and account system for Lightning

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lnbits
 category: Finance
 name: LNbits
-version: "0.9.7"
+version: "0.10"
 tagline: Multi-user wallet management system
 description: >-
   LNbits is a simple multi-user and account system for Lightning
@@ -28,8 +28,16 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes:  >-
-  - This minor release updates the Docker images and fixes the dependency versions from 0.9.6.1.
+  - Major Update: Installable extensions
   
-  See the full changelog here: https://github.com/lnbits/lnbits/releases/tag/0.9.7
+  - Update: Clean/format code base
+  
+  - Update: respect https setting in admin ui link
+  
+  - Update: Added cyber theme
+  
+  - Bugfix: hide Admin UI if LNBITS_ADMIN_UI is false #1537
+  
+  See the full changelog here: https://github.com/lnbits/lnbits/releases/tag/0.10
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/372


### PR DESCRIPTION
Update LNbits to latest v0.10

This should also enable umbrel installations to become [cashu](https://github.com/cashubtc/cashu) mints.