### PR TITLE
Update rotki 1.27.1

### DIFF
--- a/rotki/docker-compose.yml
+++ b/rotki/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   web:
-    image: rotki/rotki:v1.27.0@sha256:f1c814e3636f4a48544aca9e500ff0e54cf18e9b0e5a2eb23c309c376efdf3fb
+    image: rotki/rotki:v1.27.1@sha256:78b91c921ec9255179cfbbb2b2547dd483b8f79b702ab00f21d00d5d8ac6e0e6
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/rotki/umbrel-app.yml
+++ b/rotki/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: rotki
 category: Finance
 name: rotki
-version: "1.27.0"
+version: "1.27.1"
 tagline: Portfolio tracking, analytics, accounting and tax reporting
 description: >-
   rotki is an open source portfolio tracking, analytics, accounting and tax reporting tool that protects your privacy. 
@@ -25,19 +25,14 @@ repo: https://github.com/rotki/rotki
 support: https://github.com/rotki/rotki/issues
 port: 8084
 releaseNotes: >-
-  Rotki v1.27.0 is the biggest release rotki has ever made. It contains a lots of new features, improvements and bug fixes we made in the past 3 months! The biggest feature coming here is proper multi-evm chain support starting with Optimism and the introduction of Optimism support for transactions history, balances etc.
+  - Fixed a bug where token balance detection for EVM tokens with many addresses may not have worked properly.
+  
+  -Fixes bug where an error message is not shown when some input filled with incorrect value.
+  
+  -Fixes bug where Maker Vault Collateralization Ratio can't be edited in watcher form.
 
-
-  Important Notes:
   
-  - When opening the release for the first time you will see all your ethereum accounts that have had activity in either optimism or avalanche being also added for these chains. (The only exception to this is if you pull from premium server to a new machine and the old version you sync from has not yet been upgraded to 1.27.0)
-  
-  - If you have any optimism address you will be asked to create and add a free API key for optimistic etherscan: https://optimistic.etherscan.io/register
-  
-  - All EVM transaction events (except for the ones you customized) will need to be redecoded since this upgrade made many changes and improvements to the decoders. No action on the user side needed for this, but you may notice longer loading time when you visit the EVM transactions for the first time.
-  
-  
-  Full changelog can be found here: https://github.com/rotki/rotki/releases/tag/v1.27.0
+  Full changelog can be found here: https://github.com/rotki/rotki/releases/tag/v1.27.1
 gallery:
   - 1.jpg
   - 2.jpg

--- a/rotki/umbrel-app.yml
+++ b/rotki/umbrel-app.yml
@@ -25,11 +25,9 @@ repo: https://github.com/rotki/rotki
 support: https://github.com/rotki/rotki/issues
 port: 8084
 releaseNotes: >-
-  - Fixed a bug where token balance detection for EVM tokens with many addresses may not have worked properly.
-  
-  -Fixes bug where an error message is not shown when some input filled with incorrect value.
-  
-  -Fixes bug where Maker Vault Collateralization Ratio can't be edited in watcher form.
+  Rotki v1.27.1 is a patch release with minor bug fixes and new features.
+  Most importantly it fixes the accounting bug with the Average cost basis setting (used in UK and Canada),
+  introduces automatic detection of maker DAO vault collateral types and more!
 
   
   Full changelog can be found here: https://github.com/rotki/rotki/releases/tag/v1.27.1


### PR DESCRIPTION
Hi there,

Minor update for rotki, the full changelog is available here: https://github.com/rotki/rotki/releases/tag/v1.27.1

I don't have access to my testing environment to check if it breaks a previous install. It shouldn't as there are no disclaimers on the release page.

