### PR TITLE
lightning-terminal: update to v0.9.2-alpha

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.9.0-alpha@sha256:c30f040da92c4b3966c59184cdff06fa59036e560d46e7357bd36271584348a4
+    image: lightninglabs/lightning-terminal:v0.9.2-alpha@sha256:2c234ad01c662a5f2ef301f29dbb457ee2762844bc79b0baa142746752465d63
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.8.6-alpha@sha256:b2a5a90da72d5571f3608f830091853f2ebfd1fb2dabfa86d1447dc6d2a42dce
+    image: lightninglabs/lightning-terminal:v0.9.0-alpha@sha256:c30f040da92c4b3966c59184cdff06fa59036e560d46e7357bd36271584348a4
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: Lightning Node Management
 name: Lightning Terminal
-version: "0.9.0-alpha"
+version: "0.9.2-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -50,17 +50,13 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  This release of Lightning Terminal (LiT) includes updates to the versions
-  of the integrated LND, Pool, Loop and Faraday daemons. A few updates to LiT
-  itself have also been included: LiT can now be started with the `--disableui`
-  option meaning that the local UI will not be accessible and the `uipassword`
-  would no longer need to be set. REST annotations are also added for all LiT 
-  services.
+  This release of Lightning Terminal (LiT) includes an LND version bump 
+  that addresses a few performance issues.
   
   We'll be continuously working to improve the user experience based on 
   feedback from the community.
   
-  This release packages LND v0.16.0-beta, Loop v0.22.0-beta, Pool v0.6.2-beta, 
-  and Faraday v0.2.10-alpha.
+  This release packages LND v0.16.2-beta, Loop v0.23.0-beta, Pool v0.6.2-beta, 
+  and Faraday v0.2.11-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -53,8 +53,10 @@ releaseNotes: >-
   This release of Lightning Terminal (LiT) includes an LND version bump 
   that addresses a few performance issues.
   
+
   We'll be continuously working to improve the user experience based on 
   feedback from the community.
+  
   
   This release packages LND v0.16.2-beta, Loop v0.23.0-beta, Pool v0.6.2-beta, 
   and Faraday v0.2.11-alpha.

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: Lightning Node Management
 name: Lightning Terminal
-version: "0.8.6-alpha"
+version: "0.9.0-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -50,24 +50,17 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  This release of Lightning Terminal (LiT) includes a variety of updates
-  including support for off-chain accounts and the ability to customize the 
-  permissions of an LNC session through the UI. It also contains an 
-  implementation of a rule firewall and a privacy firewall. The rule 
-  firewall can be used to verify the parameters of certain calls (for example 
-  ensuring that calls only act on a specific set of channels) and the privacy 
-  firewall can be used to force private info (such as pub keys, channel IDs etc) 
-  to be mapped out to random values for responses and mapped back to real values
-  for requests. An Autopilot client is added which handles registration of LNC 
-  sessions with the Autopilot server. Autopilot calls will be forced to go 
-  through the new rule and privacy firewalls.
-
-
-  We'll be continuously working to improve the user experience based on feedback
-  from the community.
-
-
-  This release packages LND v0.15.5-beta, Loop v0.21.0-beta, Pool v0.6.1-beta, 
-  and Faraday v0.2.9-alpha.
+  This release of Lightning Terminal (LiT) includes updates to the versions
+  of the integrated LND, Pool, Loop and Faraday daemons. A few updates to LiT
+  itself have also been included: LiT can now be started with the `--disableui`
+  option meaning that the local UI will not be accessible and the `uipassword`
+  would no longer need to be set. REST annotations are also added for all LiT 
+  services.
+  
+  We'll be continuously working to improve the user experience based on 
+  feedback from the community.
+  
+  This release packages LND v0.16.0-beta, Loop v0.22.0-beta, Pool v0.6.2-beta, 
+  and Faraday v0.2.10-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
Hi there! Here to bump Litd to v0.9.2-alpha. 

See the release notes here: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.9.2-alpha

Thanks!