### PR TITLE
Update LNDg to v1.6.0

### DIFF
--- a/lndg/docker-compose.yml
+++ b/lndg/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LNDG_PORT
 
   web:
-    image: ghcr.io/cryptosharks131/lndg:v1.5.1@sha256:29e8358e9e8942fb7c953b0ce3e358cbcbcfc42d16a2237e7d260ceb5807521f
+    image: ghcr.io/cryptosharks131/lndg:v1.6.0@sha256:e4682241febefcaea0746681200d8e716d6d78f813010fb8d465957b8df130ba
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/lndg/umbrel-app.yml
+++ b/lndg/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lndg
 category: Lightning Node Management
 name: LNDg
-version: "1.5.1"
+version: "1.6.0"
 tagline: Analyze and automate your Lightning node management
 description: LNDg is your command center for running a profitable and efficient
   routing node. From quickly viewing your node's health, automated rebalancing,
@@ -22,18 +22,16 @@ path: ""
 defaultUsername: lndg-admin
 deterministicPassword: true
 releaseNotes: >-
-  - Async rebalancing - add additional AR workers from the advanced settings page
+  - Updated and improved UI theme
   
-  - Simple front-end table sorting and basic dark mode toggle
+  - Bump unconfirmed transactions from /balances
   
-  - Short channel ids are displayed for the nodes channel objects
+  - Downstream HTLC recording and aggregration
   
-  - Peer events are now tracked including connection times and fee policy changes
+  - Greatly improved loading time of the /rebalancing page
   
-  - The channel policy update form has been removed from the bottom of the home dashboard
+  - Removes all failed HTLCs greater than 30 days old
   
-  - Additional fixes included in v1.5.1
-  
-  - And more... Full details can be found here: https://github.com/cryptosharks131/lndg/releases/tag/v1.5.1
+  - And more... Full details can be found here: https://github.com/cryptosharks131/lndg/releases/tag/v1.6.0
 submitter: cryptosharks131
 submission: https://github.com/getumbrel/umbrel/pull/1189


### PR DESCRIPTION
Updates LNDg to v1.6.0
https://github.com/cryptosharks131/lndg/releases/tag/v1.6.0
https://github.com/cryptosharks131/lndg/pkgs/container/lndg/81448828?tag=v1.6.0