### PR TITLE
Update LNDg to v1.6.1

### DIFF
--- a/lndg/docker-compose.yml
+++ b/lndg/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LNDG_PORT
 
   web:
-    image: ghcr.io/cryptosharks131/lndg:v1.6.0@sha256:e4682241febefcaea0746681200d8e716d6d78f813010fb8d465957b8df130ba
+    image: ghcr.io/cryptosharks131/lndg:v1.6.1@sha256:837ca98d5f7cfb960edb4037b9798311b49edd2d1945571dbbb7cb6c46ae5d76
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/lndg/umbrel-app.yml
+++ b/lndg/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lndg
 category: Lightning Node Management
 name: LNDg
-version: "1.6.0"
+version: "1.6.1"
 tagline: Analyze and automate your Lightning node management
 description: LNDg is your command center for running a profitable and efficient
   routing node. From quickly viewing your node's health, automated rebalancing,
@@ -31,6 +31,8 @@ releaseNotes: >-
   - Greatly improved loading time of the /rebalancing page
   
   - Removes all failed HTLCs greater than 30 days old
+  
+  - Additional fixes included in v1.6.1
   
   - And more... Full details can be found here: https://github.com/cryptosharks131/lndg/releases/tag/v1.6.0
 submitter: cryptosharks131


### PR DESCRIPTION
Updates LNDg to v1.6.1
https://github.com/cryptosharks131/lndg/releases/tag/v1.6.1
https://github.com/cryptosharks131/lndg/pkgs/container/lndg/82690937?tag=v1.6.1

Fixes a breaking change introduced in a recent `pandas` update which causes new installs and updates to fail.