### PR TITLE
Update LNDg to v1.6.4

### DIFF
--- a/lndg/docker-compose.yml
+++ b/lndg/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LNDG_PORT
 
   web:
-    image: ghcr.io/cryptosharks131/lndg:v1.6.3@sha256:1de4c2fa831c6deb4655c509ff9e32a29a349f77965304a8236da523b44ad8c1
+    image: ghcr.io/cryptosharks131/lndg:v1.6.3@sha256:6c8c366bdefcba0b35bddec35b9bab7a5d874a3afdc18e829bec2673d47fb4e3
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/lndg/docker-compose.yml
+++ b/lndg/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LNDG_PORT
 
   web:
-    image: ghcr.io/cryptosharks131/lndg:v1.6.3@sha256:6c8c366bdefcba0b35bddec35b9bab7a5d874a3afdc18e829bec2673d47fb4e3
+    image: ghcr.io/cryptosharks131/lndg:v1.6.4@sha256:953b17802d2ddcfa8839d9ee719b623e35d149c1c934b371aa02eb4328dafdc3
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/lndg/docker-compose.yml
+++ b/lndg/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LNDG_PORT
 
   web:
-    image: ghcr.io/cryptosharks131/lndg:v1.6.1@sha256:837ca98d5f7cfb960edb4037b9798311b49edd2d1945571dbbb7cb6c46ae5d76
+    image: ghcr.io/cryptosharks131/lndg:v1.6.3@sha256:1de4c2fa831c6deb4655c509ff9e32a29a349f77965304a8236da523b44ad8c1
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/lndg/umbrel-app.yml
+++ b/lndg/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lndg
 category: Lightning Node Management
 name: LNDg
-version: "1.6.3"
+version: "1.6.4"
 tagline: Analyze and automate your Lightning node management
 description: LNDg is your command center for running a profitable and efficient
   routing node. From quickly viewing your node's health, automated rebalancing,
@@ -32,7 +32,7 @@ releaseNotes: >-
   
   - Removes all failed HTLCs greater than 30 days old
   
-  - Additional fixes included in v1.6.3
+  - Additional fixes included in v1.6.4
   
   - And more... Full details can be found here: https://github.com/cryptosharks131/lndg/releases/tag/v1.6.0
 submitter: cryptosharks131

--- a/lndg/umbrel-app.yml
+++ b/lndg/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lndg
 category: Lightning Node Management
 name: LNDg
-version: "1.6.1"
+version: "1.6.3"
 tagline: Analyze and automate your Lightning node management
 description: LNDg is your command center for running a profitable and efficient
   routing node. From quickly viewing your node's health, automated rebalancing,
@@ -32,7 +32,7 @@ releaseNotes: >-
   
   - Removes all failed HTLCs greater than 30 days old
   
-  - Additional fixes included in v1.6.1
+  - Additional fixes included in v1.6.3
   
   - And more... Full details can be found here: https://github.com/cryptosharks131/lndg/releases/tag/v1.6.0
 submitter: cryptosharks131


### PR DESCRIPTION
Updates LNDg to v1.6.4
https://github.com/cryptosharks131/lndg/releases/tag/v1.6.4
https://github.com/cryptosharks131/lndg/pkgs/container/lndg/89375368?tag=v1.6.4

-Extends pandas fix in order to resolve issue with Auto-Fees no longer triggering (v1.6.2)
-Fixes manual rebalancer when not using a last hop pubkey (v1.6.3)
-Fixes an issue that causes the rebalancer to get stuck for some users (v1.6.3)
-Fixes a rebalancer issue causing channels to stop targeting when certain status codes were returned (v1.6.4)
-Manually submitted rebalance requests are now processed without needing to clear the current queue first (v1.6.4)