### PR TITLE
Update Torq v0.20.3

### DIFF
--- a/torq/docker-compose.yml
+++ b/torq/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 7028
 
   web:
-    image: lncapital/torq:0.19.2@sha256:463851d9743e97a0524f0fddbc0f4c14d793f49aa6985f970776c3af4737b063
+    image: lncapital/torq:0.20.3@sha256:f24fbd49c09f3ad3aa3099053bc95102783e8fce15f5b15bc21509c5b43950df
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/torq/umbrel-app.yml
+++ b/torq/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: torq
 category: Lightning Node Management
 name: Torq
-version: "v0.19.2"
+version: "v0.20.3"
 tagline: Capital management for routing nodes on the lightning network
 description: >-
   Operating a routing node requires managing capital efficiently. If you look past the technical challenges, what you are trying to do is stack sats and support the network by routing liquidity. No matter your motivation, efficiently managing your capital is essential.
@@ -49,7 +49,9 @@ gallery:
   - 4.jpg
   - 5.jpg
 releaseNotes: >-
-  Mobile layout fix and bug fix to reconnect to LND after any connection issues.
+  New peers page, bugs and performance enhancements.
+
+  Database migrations might take some time on first start up.
 
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
Fixes high CPU usage and adds peers page

Tested on a real RaspberryPi

I realise there is already a PR  for this (#499) but we went for simpler release notes and a warning that db migrations might take a while on first start-up as they clean up a lot of old logs.