### PR TITLE
Revert "Update Urbit to v2.2"

### DIFF
--- a/urbit/docker-compose.yml
+++ b/urbit/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       PROXY_AUTH_ADD: "false"
   
   manager:
-    image: mopfelwinrux/urbit-umbrel:v2.2@sha256:936b83f6047bb70889a2c154b1fe8b915702affa050fb0ef7b533cceb16c7093
+    image: mopfelwinrux/urbit-umbrel:v2.1@sha256:64ee32bcd3b9acf42090dfef5e4579b3c899ded011e7b55e43d0c24d273e8a37
     ports:
       - "34343:34343"
     volumes:

--- a/urbit/umbrel-app.yml
+++ b/urbit/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: urbit
 category: Networking
 name: Urbit
-version: "v2.2"
+version: "v2.1"
 tagline: Run Urbit on your Umbrel
 description: >-
   Urbit is a personal server for self-sovereign personal & networked
@@ -35,11 +35,12 @@ torOnly: false
 submitter: ~mopfel-winrux
 submission: https://github.com/getumbrel/umbrel/pull/1246
 releaseNotes: >-
-  -   Includes click, a thin client for interacting with khan/conn (control plane). See this excellent writeup by the feature’s author, ~finmep-lanteb, for more details on the rationale.
+  Arvo 414K
   
-  -   Adds a CLI option to configure the time between snapshots.
-  
-  -   Changes the placement of auto-docking in the boot sequence.
-  
-  
-  Full release notes here: https://github.com/urbit/vere/releases/tag/vere-v2.2
+  Vere v2.2
+
+
+  Support for [zuse %414] and [lull %325].
+
+
+  Full release notes here: https://github.com/urbit/vere/releases/tag/vere-v2.1


### PR DESCRIPTION
Reverts getumbrel/umbrel-apps#509

It turns out the 2.2 binary is not actually released yet and this breaks the app :( I'm not sure if there is a preferred way to submit this as a PR but happy to oblige.