### PR TITLE
Update LNbits to 0.10.5

### DIFF
--- a/lnbits/docker-compose.yml
+++ b/lnbits/docker-compose.yml
@@ -32,5 +32,4 @@ services:
       LNBITS_DEFAULT_WALLET_NAME: "LNbits wallet"
       LNBITS_DISABLED_EXTENSIONS: "amilk"
       LNBITS_ADMIN_EXTENSIONS: "ngrok"
-      LNBITS_ADMIN_USERS: ""
       LNBITS_ADMIN_UI: "true"

--- a/lnbits/docker-compose.yml
+++ b/lnbits/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
   
   web:
-    image: lnbitsdocker/lnbits-legend:0.10.5@sha256:602dd4a490605ffeb33a1223cb824b605c062112867085c0146b9847d935b662
+    image: lnbitsdocker/lnbits-legend:0.10.6@sha256:a11aaa6d2b211db4c1ec2cafb7c35057ef45bcf4b98fb3bbf23c5635a0304aff
     init: true
     restart: on-failure
     stop_grace_period: 1m

--- a/lnbits/docker-compose.yml
+++ b/lnbits/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
   
   web:
-    image: lnbitsdocker/lnbits-legend:0.9.7@sha256:1fccd9611a23b9d9259ca4adff860e3e2d441ed42261d192141e76b261cd3b74
+    image: lnbitsdocker/lnbits-legend:0.10.5@sha256:602dd4a490605ffeb33a1223cb824b605c062112867085c0146b9847d935b662
     init: true
     restart: on-failure
     stop_grace_period: 1m
@@ -32,3 +32,5 @@ services:
       LNBITS_DEFAULT_WALLET_NAME: "LNbits wallet"
       LNBITS_DISABLED_EXTENSIONS: "amilk"
       LNBITS_ADMIN_EXTENSIONS: "ngrok"
+      LNBITS_ADMIN_USERS: ""
+      LNBITS_ADMIN_UI: "true"

--- a/lnbits/docker-compose.yml
+++ b/lnbits/docker-compose.yml
@@ -33,3 +33,4 @@ services:
       LNBITS_DISABLED_EXTENSIONS: "amilk"
       LNBITS_ADMIN_EXTENSIONS: "ngrok"
       LNBITS_ADMIN_UI: "true"
+      SUPER_USER: "$APP_PASSWORD"

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -16,6 +16,7 @@ description: >-
 
 
   HOW TO INSTALL EXTENSIONS:
+  
   Extensions can be installed by visiting the super admin page of your LNbits app. To do this, open your LNbits app
   and replace the umbrel.local:3007 URL with umbrel.local:3007/uuidv4/<your-unique-password-shown-in-the-lnbits-app-store-page>.
   This will redirect you to the super admin page where you can install extensions. These extensions can then be enabled/disabled by
@@ -39,7 +40,6 @@ releaseNotes:  >-
 
   
   IMPORTANT NOTE ON EXTENSIONS:
-  
 
   New versions of LNbits now have all extensions removed by default. To install extensions, you need
   to visit your super admin page and install them from there. To do this, open your LNbits app

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -15,6 +15,7 @@ description: >-
   LNbits is packaged with tools to help manage funds, such as a table of transactions, line chart of spending, export to CSV, and more to come. It provides an extendable platform for expanding Lightning Network functionality via LNbits extension framework, and can also be used as a fallback wallet for the LNURL scheme.
 
 
+  HOW TO INSTALL EXTENSIONS:
   Extensions can be installed by visiting the super admin page of your LNbits app. To do this, open your LNbits app
   and replace the umbrel.local:3007 URL with umbrel.local:3007/uuidv4/<your-unique-password-shown-in-the-lnbits-app-store-page>.
   This will redirect you to the super admin page where you can install extensions. These extensions can then be enabled/disabled by
@@ -38,7 +39,7 @@ releaseNotes:  >-
 
   
   IMPORTANT NOTE ON EXTENSIONS:
-  
+
   New versions of LNbits now have all extensions removed by default. To install extensions, you need
   to visit your super admin page and install them from there. To do this, open your LNbits app
   and replace the umbrel.local:3007 URL with umbrel.local:3007/uuidv4/<your-unique-password-shown-in-the-lnbits-app-store-page>.

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -39,6 +39,7 @@ releaseNotes:  >-
 
   
   IMPORTANT NOTE ON EXTENSIONS:
+  
 
   New versions of LNbits now have all extensions removed by default. To install extensions, you need
   to visit your super admin page and install them from there. To do this, open your LNbits app

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -36,7 +36,9 @@ deterministicPassword: true
 releaseNotes:  >-
   ⚠️ This update fixes a critical vulnerability in LNbits. Please update as soon as possible.
 
-
+  
+  IMPORTANT NOTE ON EXTENSIONS:
+  
   New versions of LNbits now have all extensions removed by default. To install extensions, you need
   to visit your super admin page and install them from there. To do this, open your LNbits app
   and replace the umbrel.local:3007 URL with umbrel.local:3007/uuidv4/<your-unique-password-shown-in-the-lnbits-app-store-page>.

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -16,7 +16,7 @@ description: >-
 
 
   HOW TO INSTALL EXTENSIONS:
-  
+
   Extensions can be installed by visiting the super admin page of your LNbits app. To do this, open your LNbits app
   and replace the umbrel.local:3007 URL with umbrel.local:3007/uuidv4/<your-unique-password-shown-in-the-lnbits-app-store-page>.
   This will redirect you to the super admin page where you can install extensions. These extensions can then be enabled/disabled by
@@ -45,7 +45,8 @@ releaseNotes:  >-
   to visit your super admin page and install them from there. To do this, open your LNbits app
   and replace the umbrel.local:3007 URL with umbrel.local:3007/uuidv4/<your-unique-password-shown-in-the-lnbits-app-store-page>.
   This will redirect you to the super admin page where you can install extensions. These extensions can then be enabled/disabled by
-  any user.
+  any user. Existing LNbits users that are updating their app in Umbrel may need to hard refresh their browser on the extensions page
+  in order to manage installed extensions.
 
   
   Full details on release notes can be found here: https://github.com/lnbits/lnbits/releases

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -26,7 +26,7 @@ gallery:
   - 3.jpg
 path: ""
 defaultUsername: ""
-defaultPassword: ""
+deterministicPassword: true
 releaseNotes:  >-
   - TODO: update release notes.
   

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lnbits
 category: Finance
 name: LNbits
-version: "0.9.7"
+version: "0.10.5"
 tagline: Multi-user wallet management system
 description: >-
   LNbits is a simple multi-user and account system for Lightning
@@ -28,8 +28,8 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes:  >-
-  - This minor release updates the Docker images and fixes the dependency versions from 0.9.6.1.
+  - TODO: update release notes.
   
-  See the full changelog here: https://github.com/lnbits/lnbits/releases/tag/0.9.7
+  Full details on release notes can be found here: https://github.com/lnbits/lnbits/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/372

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -13,6 +13,12 @@ description: >-
 
 
   LNbits is packaged with tools to help manage funds, such as a table of transactions, line chart of spending, export to CSV, and more to come. It provides an extendable platform for expanding Lightning Network functionality via LNbits extension framework, and can also be used as a fallback wallet for the LNURL scheme.
+
+
+  Extensions can be installed by visiting the super admin page of your LNbits app. To do this, open your LNbits app
+  and replace the umbrel.local:3007 URL with umbrel.local:3007/uuidv4/<your-unique-password-shown-in-the-lnbits-app-store-page>.
+  This will redirect you to the super admin page where you can install extensions. These extensions can then be enabled/disabled by
+  any user.
 developer: LNbits
 website: https://github.com/lnbits/lnbits-legend
 dependencies:
@@ -28,7 +34,15 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes:  >-
-  - TODO: update release notes.
+  ⚠️ This update fixes a critical vulnerability in LNbits. Please update as soon as possible.
+
+
+  New versions of LNbits now have all extensions removed by default. To install extensions, you need
+  to visit your super admin page and install them from there. To do this, open your LNbits app
+  and replace the umbrel.local:3007 URL with umbrel.local:3007/uuidv4/<your-unique-password-shown-in-the-lnbits-app-store-page>.
+  This will redirect you to the super admin page where you can install extensions. These extensions can then be enabled/disabled by
+  any user.
+
   
   Full details on release notes can be found here: https://github.com/lnbits/lnbits/releases
 submitter: Umbrel

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lnbits
 category: Finance
 name: LNbits
-version: "0.10.5"
+version: "0.10.6"
 tagline: Multi-user wallet management system
 description: >-
   LNbits is a simple multi-user and account system for Lightning


### PR DESCRIPTION
This PR addresses two concerns:
1. Critical bug: https://twitter.com/lnbits/status/1654416778804580352?s=20
2. Newer versions of LNbits have extensions [removed by default](https://github.com/lnbits/lnbits/releases/tag/0.10) for better scalability and decreased attack vectors. Users now need to be at least Admin-level to manage extensions.

(1) Is fixed by bumping LNbits to version 0.10.5
(2) Needs to be fixed by ~~setting new and existing users as Admins~~ giving users access to an admin or super user url. Currently, if a user were to update to the newest LNbits version, any extensions they had previously isntalled would disappear and there would be no way to manage extensions without manually updating `LNBITS_ADMIN_USERS` in the `docker-compose.yml` to include a relevant user id, which would reset on future app update.

Pinging @arcbtc and @lukechilds for troubleshooting help to get this out quickly.