### PR TITLE
Update Tailscale to v1.40.1

### DIFF
--- a/tailscale/docker-compose.yml
+++ b/tailscale/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   web:
     network_mode: "host" # TODO: We can remove this later with some iptables magic
-    image: tailscale/tailscale:v1.34.2@sha256:e8589ddd8e7175e4ac0e2bd16a8ed2c17ae77e8c97dab95f22d13139600694f7
+    image: tailscale/tailscale:v1.40.0@sha256:a90a608e3c8ec069628d2f62fbf7bde5e9095f9556d1c8d05ea0489537d7a373
     restart: on-failure
     stop_grace_period: 1m
     command: "sh -c 'tailscale web --listen 0.0.0.0:8240 & exec tailscaled --tun=userspace-networking'"

--- a/tailscale/docker-compose.yml
+++ b/tailscale/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   web:
     network_mode: "host" # TODO: We can remove this later with some iptables magic
-    image: tailscale/tailscale:v1.40.0@sha256:a90a608e3c8ec069628d2f62fbf7bde5e9095f9556d1c8d05ea0489537d7a373
+    image: tailscale/tailscale:v1.40.1@sha256:08dd1f465d6e96192b36c10f4366b3988bc6ad29f7b264bd020c1762ee325305
     restart: on-failure
     stop_grace_period: 1m
     command: "sh -c 'tailscale web --listen 0.0.0.0:8240 & exec tailscaled --tun=userspace-networking'"

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: tailscale
 category: Networking
 name: Tailscale
-version: "v1.40.0"
+version: "v1.40.1"
 tagline: Zero config VPN to access your Umbrel from anywhere
 description: >-
   Tailscale is zero config VPN that creates a secure network between
@@ -28,26 +28,9 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: >
+  This release updates Tailscale from v1.34.2 to v1.40.1.
 
- - News: Early warning: as early as August 2023, Windows 7, 8, Server 2008 and Server 2012 will no longer be supported. Similarly, for macOS, macOS 10.13 High Sierra or 10.14 Mojave will no longer be supported and macOS 10.15 Catalina or later will be required.
 
- - All platforms: tailscale up --force-reauth will now display a warning and 5 second countdown if you are connected over SSH over Tailscale, unless --accept-risk=lose-ssh is also given.
-Tailscale now dynamically increases the buffer size for DERP relay messages based on the amount of available RAM (#7776).
-Improvements were made to how Tailscale advertises available endpoints to reduce the likelihood of a spurious loss of direct connections (#7877).
- 
- - Linux: Substantially higher throughput: Surpassing 10Gb/s over Tailscale
-Improved CPU consumption on systems with a very large (1M+) routing table
-
-- Windows: redo migration of pre-Fast-User-Switching state for better robustness
-
-- macOS change menu item to "Settings" instead of "Preferences" on macOS Ventura
-
-- Android: Added intents com.tailscale.ipn.VPN_CONNECT and com.tailscale.ipn.VPN_DISCONNECT
-
-- gokrazy: Tailscale SSH now works on gokrazy
-
-- QNAP: fix UI failure after reboot
-
-Full release notes can be found here: https://github.com/tailscale/tailscale/releases/tag/v1.40.0
+  Full release notes and detailed information is available at https://github.com/tailscale/tailscale/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/1248

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: tailscale
 category: Networking
 name: Tailscale
-version: "v1.34.2"
+version: "v1.40.0"
 tagline: Zero config VPN to access your Umbrel from anywhere
 description: >-
   Tailscale is zero config VPN that creates a secure network between
@@ -28,8 +28,26 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: >
-  - Fixed: Handling of a very large number of SplitDNS domains with an exit node
 
-  - Fixed: Regression handling TS_STATE_DIR in containerboot
+ - News: Early warning: as early as August 2023, Windows 7, 8, Server 2008 and Server 2012 will no longer be supported. Similarly, for macOS, macOS 10.13 High Sierra or 10.14 Mojave will no longer be supported and macOS 10.15 Catalina or later will be required.
+
+ - All platforms: tailscale up --force-reauth will now display a warning and 5 second countdown if you are connected over SSH over Tailscale, unless --accept-risk=lose-ssh is also given.
+Tailscale now dynamically increases the buffer size for DERP relay messages based on the amount of available RAM (#7776).
+Improvements were made to how Tailscale advertises available endpoints to reduce the likelihood of a spurious loss of direct connections (#7877).
+ 
+ - Linux: Substantially higher throughput: Surpassing 10Gb/s over Tailscale
+Improved CPU consumption on systems with a very large (1M+) routing table
+
+- Windows: redo migration of pre-Fast-User-Switching state for better robustness
+
+- macOS change menu item to "Settings" instead of "Preferences" on macOS Ventura
+
+- Android: Added intents com.tailscale.ipn.VPN_CONNECT and com.tailscale.ipn.VPN_DISCONNECT
+
+- gokrazy: Tailscale SSH now works on gokrazy
+
+- QNAP: fix UI failure after reboot
+
+Full release notes can be found here: https://github.com/tailscale/tailscale/releases/tag/v1.40.0
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/1248


### PR DESCRIPTION
dockerhub had 1.40 and 1.40.0 
I used 1.40.0 becasue didn't see a 1.40 in [latest releases](https://github.com/tailscale/tailscale/releases)