### PR TITLE
Update RoboSats to v0.5.0-alpha

### DIFF
--- a/robosats/docker-compose.yml
+++ b/robosats/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 12596
 
   web:
-    image: recksato/robosats-client:v0.4.0-alpha@sha256:9f9a759be3a4faf1305ab8ec17d0041fc430b604767b1b4838015d365080433d
+    image: recksato/robosats-client:v0.5.0-alpha@sha256:b240e5909df5db571c815900506a55ba8ac7dd8741ba8e7dab0dced43bb0c71b
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -34,6 +34,12 @@ description: >-
   You can join other cool Robots and get community support at https://t.me/robosats telegram group.
   
 releaseNotes: >-
+  ⚠️ You may see a warning message after updating the app, informing you that an update is still required.
+  This is a known issue and can be ignored. To prevent the message from appearing every time you open the app,
+  clear your browser cache by pressing Ctrl+Shift+R (Cmd+Shift+R on Mac) while on the app page or selecting the
+  third option in the pop-up.
+
+
   - New authentication method for robots (you must update!)
 
   - Added possibility to revert fiat sent

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -2,14 +2,14 @@ manifestVersion: 1
 id: robosats
 category: Finance
 name: RoboSats
-version: "v0.4.0-alpha"
+version: "v0.5.0-alpha"
 tagline: Simple and Private Bitcoin P2P Exchange
 description: >-
   RoboSats is a simple and private app to exchange bitcoin for national currencies. 
   Robosats simplifies the P2P user experience and uses lightning hold invoices to 
   minimize custody and trust requirements. The deterministically generated robot 
   avatars help users stick to best privacy practices.
-  
+
 
   Features:
 
@@ -18,13 +18,13 @@ description: >-
 
   - More than 10 languages available and over 60 fiat currencies
 
-  - Safe: simply lock a lightning hodl invoice and show you are real and commited.
+  - Safe: simply lock a lightning hodl invoice and show you are real and committed.
 
   - No data collection. Your communication with your peer is PGP encrypted, only you can read it.
 
-  - Lightning fast: the average soverign trade finishes in ~ 8 minutes. Faster than a single block confirmation!
+  - Lightning fast: the average sovereign trade finishes in ~ 8 minutes. Faster than a single block confirmation!
 
-  - Fully collateralized escrow: your peer is always commited and cannot run away with the funds.
+  - Fully collateralized escrow: your peer is always committed and cannot run away with the funds.
 
   - Strong incentives system: attempts of cheating are penalized with the slashing of the Sats in the fidelity bond.
 
@@ -34,21 +34,19 @@ description: >-
   You can join other cool Robots and get community support at https://t.me/robosats telegram group.
   
 releaseNotes: >-
-  - New Robot page
+  - New authentication method for robots (you must update!)
 
-  - New user onboarding dialog
+  - Added possibility to revert fiat sent
 
-  - New robot Recovery dialog.
+  - New payment methods
 
-  - New Robot Garage. The garage is a backlog of your multiple robots. It helps you switch easily between identities. Note that only the active robot will receive sound notifications for its order.
+  - New trade summary, and preliminary Sats amounts before making / taking an order.
+    
+  - New language: japanese
 
-  - A robot that has past trade now shows a warning "Reusing trading identity degrades your privacy against other users, coordinators and observers."
-
-  - Other minor bug bixes and updates.
-
+  - Many other minor bug bug fixes and updates.
   
-  Full changelog can be found here: https://github.com/Reckless-Satoshi/robosats/compare/v0.3.3-alpha...v0.4.0-alpha
-
+  Full changelog can be found here: https://github.com/Reckless-Satoshi/robosats/compare/v0.4.0-alpha...v0.5.0-alpha
 developer: RoboSats
 website: https://learn.robosats.com
 dependencies: []

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -44,7 +44,8 @@ releaseNotes: >-
     
   - New language: japanese
 
-  - Many other minor bug bug fixes and updates.
+  - Many other minor bug fixes and updates.
+  
   
   Full changelog can be found here: https://github.com/Reckless-Satoshi/robosats/compare/v0.4.0-alpha...v0.5.0-alpha
 developer: RoboSats

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -41,7 +41,7 @@ releaseNotes: >-
   - New payment methods
 
   - New trade summary, and preliminary Sats amounts before making / taking an order.
-    
+
   - New language: japanese
 
   - Many other minor bug fixes and updates.

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -35,7 +35,7 @@ description: >-
   
 releaseNotes: >-
   ⚠️ You may see a warning message after updating the app, informing you that an update is still required.
-  This is a known issue and can be ignored. To prevent the message from appearing every time you open the app,
+  This is a known issue and can be safely disregarded. To prevent the message from appearing every time you open the app,
   clear your browser cache by pressing Ctrl+Shift+R (Cmd+Shift+R on Mac) while on the app page or selecting the
   third option in the pop-up.
 


### PR DESCRIPTION
Update RoboSats to latest v0.5.0-alpha. 

This update is a must as the RoboSats coordinators have deprecated the auth method used in v0.4.0-alpha.

Untested, but exactly replicated the steps to create the v0.4.0-alpha PR https://github.com/getumbrel/umbrel-apps/pull/447