### PR TITLE
Update Ghostfolio to 1.268.0

### DIFF
--- a/ghostfolio/docker-compose.yml
+++ b/ghostfolio/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3334
 
   server:
-    image: ghostfolio/ghostfolio:1.241.0@sha256:0fd0b0bd722420bcc8fb92076f4bcfd8e1dcfb9b8b136367539e82184e992e1c
+    image: ghostfolio/ghostfolio:1.268.0@sha256:e63a01aa95d99c0b6caf777fab0a1b9ee9d3fb95b53384f183addf38dfbae13d
     restart: on-failure
     environment:
       NODE_ENV: production

--- a/ghostfolio/umbrel-app.yml
+++ b/ghostfolio/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ghostfolio
 category: Finance
 name: Ghostfolio
-version: "1.241.0"
+version: "1.268.0"
 tagline: Manage your wealth like a boss
 description: >-
   Ghostfolio is a privacy-first, open source dashboard for your personal finances.
@@ -31,19 +31,16 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: >
-  This release updates Ghostfolio from 1.231.0 to 1.241.0.
+  This release updates Ghostfolio from 1.241.0 to 1.268.0.
   A full list of new features, improvements, and bug fixes
-  for versions between 1.231.0 and 1.241.0 can be found here: https://github.com/ghostfolio/ghostfolio/releases.
+  for versions between 1.241.0 and 1.268.0 can be found here: https://github.com/ghostfolio/ghostfolio/releases.
     
-  Version 1.241.0 release notes:
+  Version 1.268.0 release notes:
 
-  - Filtered activities with type ITEM from search results
-
-  - Considered the user's language in the Stripe checkout
-
-  - Upgraded the Stripe dependencies
-
-  - Upgraded twitter-api-v2 from version 1.10.3 to 1.14.2
+  - Added depends_on and healthcheck for the Postgres and Redis services to the docker-compose files (docker-compose.yml and docker-compose.build.yml)
+  - Improved the preview step of the activities import by unchecking duplicates
+  - Upgraded yahoo-finance2 from version 2.3.10 to 2.4.1
+    
   
 submitter: BeauAgst
 submission: https://github.com/getumbrel/umbrel-apps/pull/396


### PR DESCRIPTION
Yahoo Finance changed something and this older version of ghostfolio is no longer working correctly. You are unable to add new assets on the portfolio screen. 

My discussions with the Ghostfolio developer can confirm this here: https://ghostfolio.slack.com/archives/C02DMFGS0B1/p1684051691077229

Here is an update to a near new version of Ghostfolio recommended by the Ghostfolio developer