### PR TITLE
Update Ghostfolio to 1.269.0

### DIFF
--- a/ghostfolio/docker-compose.yml
+++ b/ghostfolio/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3334
 
   server:
-    image: ghostfolio/ghostfolio:1.269.0@sha256:b3bdc2bfab3c5917cae124c6aee6a2411d6e17f1fdea1ef3845d434b4eb612d1
+    image: ghostfolio/ghostfolio:1.269.0@sha256:096ea10a7e9c8c471701da78d3aeb8434879e465b36b3564d6bb424bc47c2b3d
     restart: on-failure
     environment:
       NODE_ENV: production

--- a/ghostfolio/docker-compose.yml
+++ b/ghostfolio/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3334
 
   server:
-    image: ghostfolio/ghostfolio:1.241.0@sha256:0fd0b0bd722420bcc8fb92076f4bcfd8e1dcfb9b8b136367539e82184e992e1c
+    image: ghostfolio/ghostfolio:1.269.0@sha256:b3bdc2bfab3c5917cae124c6aee6a2411d6e17f1fdea1ef3845d434b4eb612d1
     restart: on-failure
     environment:
       NODE_ENV: production

--- a/ghostfolio/umbrel-app.yml
+++ b/ghostfolio/umbrel-app.yml
@@ -39,7 +39,9 @@ releaseNotes: >
   Version 1.269.0 release notes:
 
   - Added FINANCIAL_MODELING_PREP as a new data source type
+
   - Improved the market price on the first buy date in the chart of the position detail dialog
+  
   - Restructured the admin control panel with a new settings tab
 submitter: BeauAgst
 submission: https://github.com/getumbrel/umbrel-apps/pull/396

--- a/ghostfolio/umbrel-app.yml
+++ b/ghostfolio/umbrel-app.yml
@@ -31,15 +31,15 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: >
-  This release updates Ghostfolio from 1.241.0 to 1.269.0.
+  This version contains a crucial update to address the inability to add new securities, an issue that arose from a recent change to Yahoo Finance.
   A full list of new features, improvements, and bug fixes
   for versions between 1.241.0 and 1.269.0 can be found here: https://github.com/ghostfolio/ghostfolio/releases.
-    
+
+
   Version 1.269.0 release notes:
 
   - Added FINANCIAL_MODELING_PREP as a new data source type
   - Improved the market price on the first buy date in the chart of the position detail dialog
   - Restructured the admin control panel with a new settings tab
-
 submitter: BeauAgst
 submission: https://github.com/getumbrel/umbrel-apps/pull/396

--- a/ghostfolio/umbrel-app.yml
+++ b/ghostfolio/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ghostfolio
 category: Finance
 name: Ghostfolio
-version: "1.241.0"
+version: "1.269.0"
 tagline: Manage your wealth like a boss
 description: >-
   Ghostfolio is a privacy-first, open source dashboard for your personal finances.
@@ -31,19 +31,15 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: >
-  This release updates Ghostfolio from 1.231.0 to 1.241.0.
+  This release updates Ghostfolio from 1.241.0 to 1.269.0.
   A full list of new features, improvements, and bug fixes
-  for versions between 1.231.0 and 1.241.0 can be found here: https://github.com/ghostfolio/ghostfolio/releases.
+  for versions between 1.241.0 and 1.269.0 can be found here: https://github.com/ghostfolio/ghostfolio/releases.
     
-  Version 1.241.0 release notes:
+  Version 1.269.0 release notes:
 
-  - Filtered activities with type ITEM from search results
+  - Added FINANCIAL_MODELING_PREP as a new data source type
+  - Improved the market price on the first buy date in the chart of the position detail dialog
+  - Restructured the admin control panel with a new settings tab
 
-  - Considered the user's language in the Stripe checkout
-
-  - Upgraded the Stripe dependencies
-
-  - Upgraded twitter-api-v2 from version 1.10.3 to 1.14.2
-  
 submitter: BeauAgst
 submission: https://github.com/getumbrel/umbrel-apps/pull/396


### PR DESCRIPTION
Yahoo Finance changed something and this older version of ghostfolio is no longer working correctly. You are unable to add new assets on the portfolio screen.

My discussions with the Ghostfolio developer can confirm this here: https://ghostfolio.slack.com/archives/C02DMFGS0B1/p1684051691077229

Here is an update to the newest version of Ghostfolio recommended by the Ghostfolio developer