### PR TITLE
Bump Oak Node to v0.3.6

### DIFF
--- a/oak-node/docker-compose.yml
+++ b/oak-node/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8100
 
   web:
-    image: oak-node.net/oak:v0.3.5@sha256:5e8091e75992692029b03a1c7b9190f7a10fca58f8c8318a7a9bcf92d35098c3
+    image: oak-node.net/oak:v0.3.6@sha256:229076857af847a4e07ef251a051b7bb01b23fd29a80e6270a8e7595b0e0daf6
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/oak-node/umbrel-app.yml
+++ b/oak-node/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: oak-node
 category: Finance
 name: Oak Node
-version: "0.3.5"
+version: "0.3.6"
 tagline: Do more with your LND node
 description: >-
   Oak Node gives you Scheduled Sends. Use it to schedule recurring tips to LNURL or Lightning Addresses. 
@@ -10,10 +10,9 @@ description: >-
 
   For Nostriches out there, the included Nostr bot gives you control over your sats from any Nostr client.
 releaseNotes: >-
-  The Nostr bot now has a Shadowy LN Tips feature. Once it's set up, you can use any Nostr client to trigger an LN tip to anyone by just liking one of their notes.
-  
-  
-  This update also brings NIP-65 support for more reliable pairing, auto-reconnects to relays when necessary, npub support and more.
+  Ever wanted a fancier Nostr pubkey, but didn't want to mine it yourself?
+  Oak now has a PowPub Client, which lets you buy the mining of vanity pubkeys from mining providers.
+  It uses a split-key approach, so the keys are known only to you.
 developer: Carlos
 website: https://oak-node.net
 dependencies:


### PR DESCRIPTION
Tested on amd64 (VM) and arm64 (raspi).