### PR TITLE
Updating Nitter to Latest

### DIFF
--- a/nitter/docker-compose.yml
+++ b/nitter/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "2023.05.20"
 
 services:
   app_proxy:
@@ -9,7 +9,7 @@ services:
   web:
     # Official Nim image used as base image for nitter doesn't offer Arm variant so using a custom image w/ patch for umbrel
     # https://github.com/ceramicwhite/umbrel-patch-ci/blob/master/nitter/umbrel.patch
-    image: ceramicwhite/nitter:build-20220908@sha256:cfb1227aca5014804c47d10d7ff77f24416a3fd571549eaeee9850f915507447
+    image: zedeus/nitter:latest@sha256:2172275e119f39e5e2e4d554bf1bd70feae70ac872818ede2c1d566e601678ae
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/nitter/umbrel-app.yml
+++ b/nitter/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: nitter
 category: Social
 name: Nitter
-version: "20220908"
+version: "2023.05.20"
 tagline: Browse Twitter without tracking or ads
 description: >
   Nitter is a free and open source alternative Twitter front-end focused on privacy and performance.


### PR DESCRIPTION
Changed tag from[ ceramicwhite](https://hub.docker.com/r/ceramicwhite/nitter) from 8 months ago in dockerhub to https://hub.docker.com/r/zedeus/nitter/tags

I don't know the implications of this 

I did not change the redis tag

Without update Nitter is currently broken with "rate instance is limited" error message

this looks like the official tag/image above from developer Zedeus who is also helpful in their Matrix channel (confirmed previous version is broken right now): https://matrix.to/#/#nitter:matrix.org

Web UI for Matrix and link: https://app.element.io/#/room/#nitter:snopyta.org/$yuy1_I3Mn9D9q02RMtn7FikVIQIKE818cyowKYHxGSQ

Zedeus shared with me there's no currently versioning setup so updated the dates and didn't add any release notes...

