### PR TITLE
App Submission :  ActualBudget

### DIFF
--- a/actualbudget/docker-compose.yml
+++ b/actualbudget/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: actualbudget_web_1
+      APP_PORT: 5006
+
+  web:
+    image: actualbudget/actual-server:23.5.0@sha256:e2e6daa61c9049e2a7b637500f18a1a2c4ddee9af4ac4b1d90d1f2f194383b47
+    restart: on-failure
+    volumes:
+      - ${APP_DATA_DIR}/data/:/data
+    environment:
+      - PUID=1000
+      - PGID=1000

--- a/actualbudget/umbrel-app.yml
+++ b/actualbudget/umbrel-app.yml
@@ -1,0 +1,34 @@
+manifestVersion: 1
+id: actualbudget
+category: Finance
+name: ActualBudget
+version: "23.5.0"
+tagline: Envelope budgeting made easy
+description: >-
+  Actual is a super fast privacy-focused app for managing your finances. 
+  You own your data, and we will sync it across all devices with optional end-to-end encryption.
+
+  It provides a budgeting system based on "envelope budgeting," a proven method for managing your spending. 
+  You can also track all of your finances, including investment accounts, in one place.
+
+  Download the mobile application on the App Store and Play Store, then link it to you umbrel instance!
+
+  ⚠️ Important ⚠️
+  When installing the application for the first time, a warning will appear. Click on "Advanced Options", tick the box and click "Open Actual".
+  This is because ActualBudget is served via HTTP. We recommend no opening more than one tab to avoid data loss risk.
+developer: ActualServer
+website: https://actualbudget.com/
+dependencies: []
+repo: https://github.com/actualbudget/actual
+support: https://actualbudget.github.io/docs/
+port: 5006
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: Xosten
+submission: https://github.com/getumbrel/umbrel-apps/pull/550
+releaseNotes: >-


### PR DESCRIPTION
# App Submission

### ActualBudget

### 256x256 SVG icon
I can't find an SVG version sadly, hopefully you can do something with this [png](https://play-lh.googleusercontent.com/209fPBA5Q2ceVu4hIDE2x4sE3-FQPQd4lJMPWv0ckZ4yH-K6fRfRt1ZilDxG3-AmzPDX=w240-h480-rw).

...

### Gallery images
![1](https://github.com/getumbrel/umbrel-apps/assets/11696836/42f59b83-1569-4ec8-9b37-1f3a945520c5)
![2](https://github.com/getumbrel/umbrel-apps/assets/11696836/c952c57c-fc89-414d-8b9e-3a02951c786b)
![3](https://github.com/getumbrel/umbrel-apps/assets/11696836/cfecacd6-9cbc-4912-a7f4-3fbc66fdaad7)
![4](https://github.com/getumbrel/umbrel-apps/assets/11696836/bf780a5b-0259-42f5-aedf-22a1d72346f8)


### I have tested my app on:
- [ ] [Umbrel dev environment](https://github.com/getumbrel/umbrel-dev)
- [x] [Umbrel OS on a Raspberry Pi 4](https://github.com/getumbrel/umbrel-os) (Community Store)
- [ ] [Custom Umbrel install on Linux](https://github.com/getumbrel/umbrel#-installation)

#### Notes
Because we are serving content via HTTP some things should be considered.

1. An `SharedArrayBuffer` error is thrown, which can be skipped. More info about it [here](https://actualbudget.github.io/docs/Troubleshooting/SharedArrayBuffer).
2. Database encryption can't be enabled, unless one accesses Umbrel via HTTPS.

