### PR TITLE
App Submission - Chatpad AI

### DIFF
--- a/chatpad-ai/docker-compose.yml
+++ b/chatpad-ai/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: chatpad-ai_web_1
+      APP_PORT: 80
+
+  web:
+    image: ghcr.io/deiucanta/chatpad:e60272eefaf6e61f435b8bc65befba577b883750@sha256:fd0fa39524931e1e072cab58fcecdec51f60cf73c440cef05283cfa6a5b80cc9
+    restart: on-failure

--- a/chatpad-ai/umbrel-app.yml
+++ b/chatpad-ai/umbrel-app.yml
@@ -9,7 +9,7 @@ description: >-
   Chatpad AI is an alternative user interface for OpenAI's chat models. Simply add your OpenAI API key and you're ready to go!
 
 
-  No tracking, no cookies, no bullshit. All your data is stored locally within your browser. You can export and import conversations to safeguard against data loss.
+  No tracking. No cookies. All your data is stored locally within your browser, and you can export and import conversations to safeguard against data loss.
 developer: Andrei Canta
 website: https://github.com/deiucanta/chatpad
 dependencies: []

--- a/chatpad-ai/umbrel-app.yml
+++ b/chatpad-ai/umbrel-app.yml
@@ -1,0 +1,28 @@
+manifestVersion: 1
+id: chatpad-ai
+category: Productivity
+name: Chatpad AI
+# using first 6 characters of commit hash as version number (docker image tag uses full commit hash)
+version: "e60272"
+tagline: Premium quality UI for ChatGPT
+description: >-
+  Chatpad AI is an alternative user interface for OpenAI's chat models. Simply add your OpenAI API key and you're ready to go!
+
+
+  No tracking, no cookies, no bullshit. All your data is stored locally within your browser. You can export and import conversations to safeguard against data loss.
+developer: Andrei Canta
+website: https://github.com/deiucanta/chatpad
+dependencies: []
+repo: https://github.com/deiucanta/chatpad
+support: https://github.com/deiucanta/chatpad/issues
+port: 10102
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+releaseNotes: ""
+submitter: Umbrel
+submission: https://github.com/getumbrel/umbrel-apps/pull/604


### PR DESCRIPTION
https://chatpad.ai/
https://github.com/deiucanta/chatpad

Chatpad AI is an alternative user interface for OpenAI's chat models. Simply add your OpenAI API key and you're ready to go!

No tracking, no cookies, no bullshit. All your data is stored locally within your browser. You can export and import conversations to safeguard against data loss.