### PR TITLE
App Submission - Homebridge

### DIFF
--- a/homebridge/docker-compose.yml
+++ b/homebridge/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.7"
+
+services:
+  server:
+    image: oznu/homebridge:2023-01-08@sha256:f46e9c82e4f3449e18c2b61014ba13474343fed703537983db0f59a2a4b97c31
+    # container runs as root
+    network_mode: host
+    # available at port 8581
+    volumes:
+      - ${APP_DATA_DIR}/data/homebridge:/homebridge
+    restart: on-failure

--- a/homebridge/exports.sh
+++ b/homebridge/exports.sh
@@ -1,0 +1,5 @@
+# Homebridge runs in host networking mode, so does not use the app proxy which is needed to generate the Tor HS hostname
+# This generates a fake HS hostname for Homebridge
+HOMEBRIDGE_TOR_DIR="${EXPORTS_TOR_DATA_DIR}/app-${EXPORTS_APP_ID}"
+mkdir -p "${HOMEBRIDGE_TOR_DIR}"
+touch "${HOMEBRIDGE_TOR_DIR}/hostname"

--- a/homebridge/umbrel-app.yml
+++ b/homebridge/umbrel-app.yml
@@ -1,0 +1,43 @@
+manifestVersion: 1
+id: homebridge
+category: Automation
+name: Homebridge
+version: "2023-01-08"
+tagline: "HomeKit support for the impatient"
+description: >-
+  Bringing HomeKit support where there is none. Homebridge allows you to integrate with smart home devices that do not natively support HomeKit.
+  There are over 2000 Homebridge plugins supporting thousands of different smart accessories.
+
+
+  Some of the most popular plugins include:
+  
+  - Ring
+  
+  - Nest & Nest Cameras
+  
+  - TP-Link Kasa Smart Home
+  
+  - Hue / deCONZ (Zigbee)
+  
+  - Belkin Wemo
+  
+  - myQ
+  
+  - UniFi Protect
+developer: Homebridge
+website: https://homebridge.io/
+dependencies: []
+repo: https://github.com/homebridge/homebridge
+support: https://github.com/homebridge/homebridge/issues
+port: 8581
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+torOnly: false
+releaseNotes: ""
+submitter: Umbrel
+submission: https://github.com/getumbrel/umbrel-apps


### PR DESCRIPTION
https://homebridge.io/
https://github.com/homebridge/homebridge

Bringing HomeKit support where there is none. Homebridge allows you to integrate with smart home devices that do not natively support HomeKit. There are over 2000 Homebridge plugins supporting thousands of different smart accessories.