### PR TITLE
App Submission - Mealie

### DIFF
--- a/mealie/docker-compose.yml
+++ b/mealie/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: mealie_mealie-frontend_1
+      APP_PORT: 3000
+      PROXY_AUTH_WHITELIST: "/api/*"
+
+  mealie-frontend:
+    image: hkotel/mealie:frontend-v1.0.0beta-5@sha256:d8ff0ecd5cfe460fb593a99fa78d9ca17401925d287c723a319abd764f80b9f7
+    environment:
+      - API_URL=http://mealie-api:9000
+    volumes:
+      - ${APP_DATA_DIR}/data:/app/data
+    restart: on-failure
+
+  mealie-api:
+    image: hkotel/mealie:api-v1.0.0beta-5@sha256:5031ad226b8ec4c895afdc54dab654e07980dd33391a3e8106aadb3f09b73104
+    environment:
+      - PUID=1000
+      - PGID=1000
+    volumes:
+      - ${APP_DATA_DIR}/data:/app/data
+    restart: on-failure

--- a/mealie/umbrel-app.yml
+++ b/mealie/umbrel-app.yml
@@ -1,0 +1,26 @@
+manifestVersion: 1
+id: mealie
+category: Productivity
+name: Mealie
+version: "1.0.0beta-5"
+tagline: A Place for All Your Recipes
+description: >-
+  Mealie is a self hosted recipe manager and meal planner. Easily add recipes by providing
+  the url and Mealie will automatically import the relevant data or add a family recipe with the UI editor. Mealie also
+  provides an API for interactions from 3rd party applications.
+developer: Hayden
+website: https://docs.mealie.io/
+dependencies: []
+repo: https://github.com/hay-kot/mealie
+support: https://github.com/hay-kot/mealie/issues
+port: 9925
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+torOnly: false
+submitter: Umbrel
+submission: https://github.com/getumbrel/umbrel-apps/pull/608


### PR DESCRIPTION
https://mealie.io/
https://github.com/hay-kot/mealie

Mealie is a self hosted recipe manager and meal planner. Easily add recipes by providing the url and Mealie will automatically import the relevant data or add a family recipe with the UI editor. Mealie also provides an API for interactions from 3rd party applications.