### PR TITLE
feat(trilium-notes): bump version to 59.4

### DIFF
--- a/trilium-notes/docker-compose.yml
+++ b/trilium-notes/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: zadam/trilium:0.55.1@sha256:9bf48a49359cd567bb8e9ce87c1d310713ba98ac8d517d75b07b8de907525077
+    image: zadam/trilium:0.59.4@sha256:4b131421c9d89b3171518f82ae9b5527cb6bf77cfefa996b4d3f4d34aa6399fa
     restart: on-failure
     environment:
       - TRILIUM_DATA_DIR=/data

--- a/trilium-notes/docker-compose.yml
+++ b/trilium-notes/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: zadam/trilium:0.59.4@sha256:4b131421c9d89b3171518f82ae9b5527cb6bf77cfefa996b4d3f4d34aa6399fa
+    image: zadam/trilium:0.59.4@sha256:5b68fd04fd6f3c26944f0c61f7a470e94480b1f6d61709201331a400be882a1c
     restart: on-failure
     environment:
       - TRILIUM_DATA_DIR=/data

--- a/trilium-notes/umbrel-app.yml
+++ b/trilium-notes/umbrel-app.yml
@@ -2,46 +2,46 @@ manifestVersion: 1
 id: trilium-notes
 category: Productivity
 name: Trilium Notes
-version: "0.55.1-build-2"
+version: "0.59.4"
 tagline: Build your personal knowledge base with Trilium Notes
 description: >-
   Features
 
 
   - Notes can be arranged into arbitrarily deep tree. Single note can be placed into multiple places in the tree (see cloning)
-  
+
   - Rich WYSIWYG note editing including e.g. tables, images and math with markdown autoformat
-  
+
   - Support for editing notes with source code, including syntax highlighting
-  
+
   - Fast and easy navigation between notes, full text search and note hoisting
-  
+
   - Seamless note versioning
-  
+
   - Note attributes can be used for note organization, querying and advanced scripting
-  
+
   - Synchronization with self-hosted sync server (there's a 3rd party service for hosting synchronisation server)
-  
+
   - Sharing (publishing) notes to public internet
-  
+
   - Strong note encryption with per-note granularity
-  
+
   - Sketching diagrams with bult-in Excalidraw (note type "canvas")
-  
+
   - Relation maps and link maps for visualizing notes and their relations
-  
+
   - Scripting - see Advanced showcases
-  
+
   - REST API for automation
-  
+
   - Scales well in both usability and performance upwards of 100 000 notes
-  
+
   - Touch optimized mobile frontend for smartphones and tablets
-  
+
   - Night theme
-  
+
   - Evernote and Markdown import & export
-  
+
   - Web Clipper for easy saving of web content
 developer: ZAdam
 website: https://github.com/zadam/trilium
@@ -60,3 +60,15 @@ defaultPassword: ""
 torOnly: false
 submitter: Pranshu Agrawal
 submission: https://github.com/getumbrel/umbrel-apps/pull/199
+releaseNotes: >-
+fix displaying error message in mermaid
+
+download offline images from libreoffice
+
+fix duplicating subtree with internal links
+
+don't update attribute detail while composing CJK characters
+
+fix click events propagating from context menu being closed
+
+Full release notes and detailed information is available at https://github.com/zadam/trilium/releases

--- a/trilium-notes/umbrel-app.yml
+++ b/trilium-notes/umbrel-app.yml
@@ -61,14 +61,14 @@ torOnly: false
 submitter: Pranshu Agrawal
 submission: https://github.com/getumbrel/umbrel-apps/pull/199
 releaseNotes: >-
-fix displaying error message in mermaid
-
-download offline images from libreoffice
-
-fix duplicating subtree with internal links
-
-don't update attribute detail while composing CJK characters
-
-fix click events propagating from context menu being closed
-
-Full release notes and detailed information is available at https://github.com/zadam/trilium/releases
+  - fix displaying error message in mermaid
+  
+  - download offline images from libreoffice
+  
+  - fix duplicating subtree with internal links
+  
+  - don't update attribute detail while composing CJK characters
+  
+  - fix click events propagating from context menu being closed
+  
+  - Full release notes and detailed information is available at https://github.com/zadam/trilium/releases

--- a/trilium-notes/umbrel-app.yml
+++ b/trilium-notes/umbrel-app.yml
@@ -61,6 +61,11 @@ torOnly: false
 submitter: Pranshu Agrawal
 submission: https://github.com/getumbrel/umbrel-apps/pull/199
 releaseNotes: >-
+  This update upgrades Trilium Notes from version 0.55.1 to 0.59.4.
+  
+  
+  Version 0.59.4 includes the following changes:
+
   - fix displaying error message in mermaid
   
   - download offline images from libreoffice
@@ -71,4 +76,5 @@ releaseNotes: >-
   
   - fix click events propagating from context menu being closed
   
-  - Full release notes and detailed information is available at https://github.com/zadam/trilium/releases
+  
+  Full release notes and detailed information for versions between 0.55.1 and 0.59.4 are available at https://github.com/zadam/trilium/releases


### PR DESCRIPTION
Updates trilium notes from version 55.1 to version 59.4 (currently latest stable)