### PR TITLE
Update RoboSats to v0.5.1-alpha

### DIFF
--- a/robosats/docker-compose.yml
+++ b/robosats/docker-compose.yml
@@ -7,11 +7,10 @@ services:
       APP_PORT: 12596
 
   web:
-    image: recksato/robosats-client:v0.5.0-alpha@sha256:b240e5909df5db571c815900506a55ba8ac7dd8741ba8e7dab0dced43bb0c71b
+    image: recksato/robosats-client:v0.5.1-alpha@sha256:cffbb9c467d14643fc60591d09374f44e8618f2c233c8f502abaa8f3662caff4
     restart: on-failure
     stop_grace_period: 1m
     init: true
     environment:
       TOR_PROXY_IP: ${TOR_PROXY_IP}
       TOR_PROXY_PORT: ${TOR_PROXY_PORT}
-      ROBOSATS_ONION: robosats6tkf3eva7x2voqso3a5wcorsnw34jveyxfqi2fu7oyheasid.onion

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: robosats
 category: Finance
 name: RoboSats
-version: "v0.5.0-alpha"
+version: "v0.5.1-alpha"
 tagline: Simple and Private Bitcoin P2P Exchange
 description: >-
   RoboSats is a simple and private app to exchange bitcoin for national currencies. 
@@ -42,13 +42,17 @@ releaseNotes: >-
 
   - New authentication method for robots (you must update!)
 
-  - Added possibility to revert fiat sent
+  - The robosats client app is now lighter on your node. Both in your disk and in your ram. The app is now trimmed down to 7 MB versus 130MB of v0.5.0-alpha
+
+  - New shortcut to login into any of your robots. Just enter in your browser the URL umbrel.local:12596/robot/<your_robot_token>
+
+  - Fix LNproxy feature to wrap invoices for your privacy
+
+  - Fix chat to allow multiple lines of input
+
+  - Improved security: submitted invoices/address are now PGP signed (no possible MITM attacks)
 
   - New payment methods
-
-  - New trade summary, and preliminary Sats amounts before making / taking an order.
-
-  - New language: japanese
 
   - Many other minor bug fixes and updates.
   


### PR DESCRIPTION
Update RoboSats to latest v0.5.1-alpha.

Deleted the coordinator onion endpoint environmental variable, as it is not needed anymore in the upcomming multi-coordinator client app.

Untested. Exactly replicated the steps to update to v0.5.0-alpha #528