### PR TITLE
lightning-terminal: update to v0.10.1-alpha

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.10.0-alpha@sha256:28ddd821f86e48c7727be40339ec58e21d362ba038b8e4de10cae8171fa52b78
+    image: lightninglabs/lightning-terminal:v0.10.1-alpha@sha256:3e25ececbb127f975d414f2a81506fe688046cd26bf548112bb1e232e1d571eb
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: Lightning Node Management
 name: Lightning Terminal
-version: "0.10.0-alpha"
+version: "0.10.1-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -50,16 +50,15 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  This release of Lightning Terminal (LiT) packages the new Taproot Assets
-  Daemon! Currently this will only be available when running LiT in testnet (or
-  regtest/simnet) mode.
+  This release of Lightning Terminal (LiT) includes updates to the versions of
+  the integrated LND, Loop and Pool daemons, along with a few LiT bug fixes.
   
   
   We'll be continuously working to improve the user experience based on
   feedback from the community.
   
   
-  This release packages LND v0.16.2-beta, Taproot Assets Daemon v0.2.0-alpha,
-  Loop v0.23.0-beta, Pool v0.6.2-beta and Faraday v0.2.11-alpha.
+  This release packages LND v0.16.3-beta, Taproot Assets Daemon v0.2.0-alpha,
+  Loop v0.24.1-beta, Pool v0.6.4-beta and Faraday v0.2.11-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
In this PR we bump Litd to v0.10.1-alpha.

See the release notes here: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.10.1-alpha

Happy to address any potential feedback! Thanks!