### PR TITLE
Adding to Nostr Relay connection tips

### DIFF
--- a/nostr-relay/umbrel-app.yml
+++ b/nostr-relay/umbrel-app.yml
@@ -16,7 +16,7 @@ description: >
   
   Tip: Install Tailscale on your Umbrel and your devices for an uninterrupted connection between your clients and your relay, even when you're away from your home network. 
 
-  For the remote connection enable Tailscale's MagicDNS by navigate to your Tailscale's DNS admin console here(https://login.tailscale.com/admin/dns) and clicking "Enable DNS" and use ws://umbrel:4848 as your Relay URL.  More information on MagicDNS here. (https://tailscale.com/kb/1081/magicdns/)
+  For the remote connection enable Tailscale's MagicDNS by navigating to your Tailscale's DNS admin console here(https://login.tailscale.com/admin/dns) and clicking "Enable DNS" and use ws://umbrel:4848 as your Relay URL.  More information on MagicDNS here. (https://tailscale.com/kb/1081/magicdns/)
 
   
   Nostr Relay is powered by the open source nostr-rs-relay project — a Rust implementation of Nostr relay. It currently supports the entire relay protocol, including NIP-01, NIP-02, NIP-03, NIP-05, NIP-09, NIP-11, NIP-12, NIP-15, NIP-16, NIP-20, NIP-22, NIP-26, NIP-28, and NIP-33.

--- a/nostr-relay/umbrel-app.yml
+++ b/nostr-relay/umbrel-app.yml
@@ -14,7 +14,9 @@ description: >
   In Damus, go to Settings > Relays to add your Relay URL.
 
   
-  Tip: Install Tailscale on your Umbrel and your devices for an uninterrupted connection between your clients and your relay, even when you're away from your home network. Enable Tailscale's MagicDNS and use ws://umbrel:4848 as your Relay URL.
+  Tip: Install Tailscale on your Umbrel and your devices for an uninterrupted connection between your clients and your relay, even when you're away from your home network. 
+
+  For the remote connection enable Tailscale's MagicDNS by navigate to your Tailscale's DNS admin console here(https://login.tailscale.com/admin/dns) and clicking "Enable DNS" and use ws://umbrel:4848 as your Relay URL.  More information on MagicDNS here. (https://tailscale.com/kb/1081/magicdns/)
 
   
   Nostr Relay is powered by the open source nostr-rs-relay project — a Rust implementation of Nostr relay. It currently supports the entire relay protocol, including NIP-01, NIP-02, NIP-03, NIP-05, NIP-09, NIP-11, NIP-12, NIP-15, NIP-16, NIP-20, NIP-22, NIP-26, NIP-28, and NIP-33.


### PR DESCRIPTION
I received feedback that the current "MagicDNS" link navigates to the knowledge base article, and was confusing some users by not actually taking them to the admin console where the update button is...

Trying to make it easier and adding link directly to DNS console on Tailscale, 

I also don't know how to add links correctly in yaml file, tried to reword it in an intuitive way