### PR TITLE
Update Homeassistant to 2023.6

### DIFF
--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: homeassistant/home-assistant:2023.2.0@sha256:a4a9f614a1edcd414d63decd99813a2ff9910d876db1e04641540a0c75d20918
+    image: homeassistant/home-assistant:2023.6@sha256:d1dadb8e6ae23c76875c24b72c7af85cbf0e35fd0f6fbfdb27f6ec56741bb7b9
     volumes:
       - ${APP_DATA_DIR}/data:/config
       - ${APP_DATA_DIR}/configuration.yaml:/config/configuration.yaml

--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: homeassistant/home-assistant:2023.6@sha256:d1dadb8e6ae23c76875c24b72c7af85cbf0e35fd0f6fbfdb27f6ec56741bb7b9
+    image: homeassistant/home-assistant:2023.6@sha256:8e069fcfddbd95c0acff88b9e515e3b208c2a5b4ad801a8f0cb8b55be417fc45
     volumes:
       - ${APP_DATA_DIR}/data:/config
       - ${APP_DATA_DIR}/configuration.yaml:/config/configuration.yaml

--- a/home-assistant/umbrel-app.yml
+++ b/home-assistant/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: home-assistant
 category: Automation
 name: Home Assistant
-version: "2023.2.0"
+version: "2023.6"
 tagline: Home automation that puts local control & privacy first
 description: >-
   Open source home automation that puts local control and privacy
@@ -33,6 +33,6 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  Full changelog (for 2023.2.0) can found at: https://www.home-assistant.io/changelogs/core-2023.2
+  Full changelog (for 2023.6.0) can found at: https://www.home-assistant.io/changelogs/core-2023.6
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/9d79cffae608c6a6ab077f859c1c531a581cf926


### PR DESCRIPTION
Bumping Homeassistant from 2023.2 to 2023.6. 

Full Changelog of 2023.6 is available here: https://www.home-assistant.io/changelogs/core-2023.6