### PR TITLE
chore(trilium-notes): update to v0.60.4

### DIFF
--- a/trilium-notes/docker-compose.yml
+++ b/trilium-notes/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: zadam/trilium:0.59.4@sha256:5b68fd04fd6f3c26944f0c61f7a470e94480b1f6d61709201331a400be882a1c
+    image: zadam/trilium:0.60.4@sha256:307b926bfed9133b144a4dfdb11c1b2e053c94ac29355ede8cf5ae017a52d8a5
     restart: on-failure
     environment:
       - TRILIUM_DATA_DIR=/data

--- a/trilium-notes/umbrel-app.yml
+++ b/trilium-notes/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: trilium-notes
 category: files
 name: Trilium Notes
-version: "0.59.4"
+version: "0.60.4"
 tagline: Build your personal knowledge base with Trilium Notes
 description: >-
   Features
@@ -61,20 +61,17 @@ torOnly: false
 submitter: Pranshu Agrawal
 submission: https://github.com/getumbrel/umbrel-apps/pull/199
 releaseNotes: >-
-  This update upgrades Trilium Notes from version 0.55.1 to 0.59.4.
-  
-  
-  Version 0.59.4 includes the following changes:
+  This update upgrades Trilium Notes from version 0.59.4 to 0.60.4.
 
-  - fix displaying error message in mermaid
-  
-  - download offline images from libreoffice
-  
-  - fix duplicating subtree with internal links
-  
-  - don't update attribute detail while composing CJK characters
-  
-  - fix click events propagating from context menu being closed
-  
-  
-  Full release notes and detailed information for versions between 0.55.1 and 0.59.4 are available at https://github.com/zadam/trilium/releases
+
+  Version 0.60.4 includes the following changes:
+
+  - consistent tooltip arrow style
+  - selected text in HTML view is searched immediately in find box
+  - smooth scrolling for TOC
+  - improved Cyrillic font support
+  - move "tree actions" to the right
+  - improved include note display
+  - added ability to override default search engine
+
+  Full release notes and detailed information for versions between 0.59.4 and 0.60.4. are available at https://github.com/zadam/trilium/releases


### PR DESCRIPTION
updates trilium notes from v0.59.4 to v0.60.4 (currently the latest stable)