### PR TITLE
Fix no access to download directories in bazaar

### DIFF
--- a/bazarr/docker-compose.yml
+++ b/bazarr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/bazarr:1.2.1@sha256:dbc3c7e9ba92becf5450bdb4ea377ffddda6ce7a08e40a81b9344de27db9e52d
+    image: linuxserver/bazarr:1.2.2@sha256:15b656fc672f6d12f8810d1b32028f539ae8a672df1abe45abe8244ab1725c6c
     environment:
       - PUID=1000
       - PGID=1000

--- a/bazarr/docker-compose.yml
+++ b/bazarr/docker-compose.yml
@@ -14,4 +14,5 @@ services:
       - PGID=1000
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
+      - ${UMBREL_ROOT}/data/storage/downloads:/downloads
     restart: on-failure

--- a/bazarr/umbrel-app.yml
+++ b/bazarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bazarr
 category: media
 name: Bazarr
-version: "1.2.1"
+version: "1.2.2"
 tagline: Manage and download subtitles for Sonarr and Radarr
 description: >-
   Bazarr is a companion application to Sonarr and Radarr that manages and downloads subtitles based on your requirements.

--- a/bazarr/umbrel-app.yml
+++ b/bazarr/umbrel-app.yml
@@ -17,6 +17,11 @@ description: >-
   During initial set-up, you will need to input your Umbrel device's IP address to connect to Sonarr and/or Radarr.
   You can find your device's IP address by visiting your router's admin dashboard or by using an IP scanning tool like Angry IP Scanner.
   You will also need to input your API key for Sonarr and/or Radarr. You can find your API keys in the settings of the Sonarr and Radarr apps.
+releaseNotes: >-
+  Small bug fixes and improvements.
+
+
+  Read the full release notes at https://github.com/morpheus65535/bazarr/releases/tag/v1.2.2
 developer: morpheus65535
 website: https://www.bazarr.media/
 dependencies: []


### PR DESCRIPTION
Fixes an issue where bazaar tries to read the media file and returns an error:

FileNotFoundError: [Errno 2] No such file or directory: \'/downloads/movies/[movie_file_name]

thus never downloading nor finding any subtitles for Radaar movies or Sonar shows