### PR TITLE
Update Immich to 1.65.0

### DIFF
--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*,/search/*"
 
   server:
-    image: altran1502/immich-server:v1.65.0@sha256:92b21221e62129505e24adc8f42ecf867b5b00155668a9a15bf4039e7ef75e65
+    image: altran1502/immich-server:v1.66.1@sha256:819360b4bce04cf36f2fe6e861f13c29dcf06ad0b8af7ea96f02cbe18c0d7824
     entrypoint: ["/bin/sh", "./start-server.sh"]
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
@@ -38,7 +38,7 @@ services:
     restart: on-failure
 
   microservices:
-    image: altran1502/immich-server:v1.65.0@sha256:92b21221e62129505e24adc8f42ecf867b5b00155668a9a15bf4039e7ef75e65
+    image: altran1502/immich-server:v1.66.1@sha256:819360b4bce04cf36f2fe6e861f13c29dcf06ad0b8af7ea96f02cbe18c0d7824
     # This service cannot run under 1000:1000
     # And because the uploads are shared
     # We'll run immich specific services as root
@@ -54,7 +54,7 @@ services:
     restart: on-failure
 
   machine-learning:
-    image: altran1502/immich-machine-learning:v1.65.0@sha256:f62ec3fcbfb24ebc0a428563697fadab0e7f25815e563b20cbf2800b724f291a
+    image: altran1502/immich-machine-learning:v1.66.1@sha256:6412d3d499bd68012f1dcfbccd38c442d66524c37493b9883ab5e9ec0c06300c
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
       - ${APP_DATA_DIR}/data/model-cache:/cache
@@ -65,7 +65,7 @@ services:
     restart: on-failure
 
   web:
-    image: altran1502/immich-web:v1.65.0@sha256:7a421679201e731bb226847a5849c9cd5e68c99cb9b1896c04cebbcabf738a25
+    image: altran1502/immich-web:v1.66.1@sha256:61611ce73dc2c9d47005cb7a033ac5fb0a558991e24ba51dd7630bb51915fba6
     entrypoint: ["/bin/sh", "./entrypoint.sh"]
     environment:
       <<: *env
@@ -81,7 +81,7 @@ services:
     restart: on-failure
 
   proxy:
-    image: altran1502/immich-proxy:v1.65.0@sha256:8b38f16df60113b3f56122091fb85cb59dd4176c3aadf6027603c2fda397095e
+    image: altran1502/immich-proxy:v1.66.1@sha256:739523b97551477aa3c19114983c41b4a669a4635b4e76b5fc899149d21710b0
     environment:
       IMMICH_SERVER_URL: *immich_server_url
       IMMICH_WEB_URL: *immich_web_url

--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   server:
     image: altran1502/immich-server:v1.66.1@sha256:819360b4bce04cf36f2fe6e861f13c29dcf06ad0b8af7ea96f02cbe18c0d7824
-    entrypoint: ["/bin/sh", "./start-server.sh"]
+    command: [ "start.sh", "immich" ]
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
     environment:
@@ -42,7 +42,7 @@ services:
     # This service cannot run under 1000:1000
     # And because the uploads are shared
     # We'll run immich specific services as root
-    entrypoint: ["/bin/sh", "./start-microservices.sh"]
+    command: [ "start.sh", "microservices" ]
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
     environment:
@@ -56,23 +56,19 @@ services:
   machine-learning:
     image: altran1502/immich-machine-learning:v1.66.1@sha256:6412d3d499bd68012f1dcfbccd38c442d66524c37493b9883ab5e9ec0c06300c
     volumes:
-      - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
       - ${APP_DATA_DIR}/data/model-cache:/cache
     environment:
       <<: *env
-    depends_on:
-      - postgres
     restart: on-failure
 
   web:
     image: altran1502/immich-web:v1.66.1@sha256:61611ce73dc2c9d47005cb7a033ac5fb0a558991e24ba51dd7630bb51915fba6
-    entrypoint: ["/bin/sh", "./entrypoint.sh"]
     environment:
       <<: *env
     restart: on-failure
 
   typesense:
-    image: typesense/typesense:0.24.0@sha256:3cc1251f09ef6c75a5b1f2751c04e7265c770c0f2b69cba1f9a9f20da57cfa28
+    image: typesense/typesense:0.24.1@sha256:9bcff2b829f12074426ca044b56160ca9d777a0c488303469143dd9f8259d4dd
     environment:
       TYPESENSE_API_KEY: *typesense_api_key
       TYPESENSE_DATA_DIR: "/data"
@@ -87,17 +83,16 @@ services:
       IMMICH_WEB_URL: *immich_web_url
     depends_on:
       - server
+      - web
     restart: on-failure
 
   redis:
-    image: redis:6.2-bullseye@sha256:ffd3d04c8f7832ccdda89616ebaf3cb38414b645ebbf76dbef1fc9c36a72a2d1
+    image: redis:6.2-alpine@sha256:70a7a5b641117670beae0d80658430853896b5ef269ccf00d1827427e3263fa3
     user: "1000:1000"
     restart: on-failure
-    volumes:
-      - ${APP_DATA_DIR}/data/redis:/data
 
   postgres:
-    image: postgres:14-bullseye@sha256:135c62a8134dcef829a1e4f5568bfae44bcfa2c75659ff948f43c71964366aa4
+    image: postgres:14-alpine@sha256:28407a9961e76f2d285dc6991e8e48893503cc3836a4755bbc2d40bcc272a441
     user: "1000:1000"
     environment:
       <<: *env

--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*,/search/*"
 
   server:
-    image: altran1502/immich-server:v1.61.0@sha256:c04710ed178b8418bf67ef9e069f5ecc3104955fa54f279fb91941786681a355
+    image: altran1502/immich-server:v1.65.0@sha256:92b21221e62129505e24adc8f42ecf867b5b00155668a9a15bf4039e7ef75e65
     entrypoint: ["/bin/sh", "./start-server.sh"]
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
@@ -38,7 +38,7 @@ services:
     restart: on-failure
 
   microservices:
-    image: altran1502/immich-server:v1.61.0@sha256:c04710ed178b8418bf67ef9e069f5ecc3104955fa54f279fb91941786681a355
+    image: altran1502/immich-server:v1.65.0@sha256:92b21221e62129505e24adc8f42ecf867b5b00155668a9a15bf4039e7ef75e65
     # This service cannot run under 1000:1000
     # And because the uploads are shared
     # We'll run immich specific services as root
@@ -54,7 +54,7 @@ services:
     restart: on-failure
 
   machine-learning:
-    image: altran1502/immich-machine-learning:v1.61.0@sha256:c86e77729444f9da4e97af9e392359afa24e201b0003dafe0f1f769f263095f1
+    image: altran1502/immich-machine-learning:v1.65.0@sha256:f62ec3fcbfb24ebc0a428563697fadab0e7f25815e563b20cbf2800b724f291a
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
       - ${APP_DATA_DIR}/data/model-cache:/cache
@@ -65,7 +65,7 @@ services:
     restart: on-failure
 
   web:
-    image: altran1502/immich-web:v1.61.0@sha256:7d631ccb35ef45a1dd80706ea9f2532fbb865e7dbb8eb3c322bb893a306780c2
+    image: altran1502/immich-web:v1.65.0@sha256:7a421679201e731bb226847a5849c9cd5e68c99cb9b1896c04cebbcabf738a25
     entrypoint: ["/bin/sh", "./entrypoint.sh"]
     environment:
       <<: *env
@@ -81,7 +81,7 @@ services:
     restart: on-failure
 
   proxy:
-    image: altran1502/immich-proxy:v1.61.0@sha256:3f5802339c86e2aeae463b2d6ef5a2014805b0aba3818b91b05dab59766fef78
+    image: altran1502/immich-proxy:v1.65.0@sha256:8b38f16df60113b3f56122091fb85cb59dd4176c3aadf6027603c2fda397095e
     environment:
       IMMICH_SERVER_URL: *immich_server_url
       IMMICH_WEB_URL: *immich_web_url

--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -90,6 +90,8 @@ services:
     image: redis:6.2-alpine@sha256:70a7a5b641117670beae0d80658430853896b5ef269ccf00d1827427e3263fa3
     user: "1000:1000"
     restart: on-failure
+    volumes:
+      - ${APP_DATA_DIR}/data/redis:/data
 
   postgres:
     image: postgres:14-alpine@sha256:28407a9961e76f2d285dc6991e8e48893503cc3836a4755bbc2d40bcc272a441

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: immich
 category: files
 name: Immich
-version: "v1.61.0"
+version: "v1.65.0"
 tagline: High performance photo and video backup solution
 description: >-
   An open source and high performance self-hosted backup solution for the videos and photos on your mobile device
@@ -53,10 +53,15 @@ releaseNotes: >
 
   - Memories feature
 
+  - Select-all button on the web
+
+  - The thumbnail now displays the blur version of the thumbnail image before the actual image is loaded. This mechanism replaces the transition from the gray box to the actual image to provide a better transition in the browsing experience.
+
   - and more!
 
 
-  Full release notes for this update can be found at https://github.com/immich-app/immich/releases/tag/v1.61.0
+  Full release notes for this update can be found at https://github.com/immich-app/immich/releases/tag/v1.65.0
+  Full changelog between v1.61.0 and v1.65.0 can be found here: https://github.com/immich-app/immich/compare/v1.61.0...v1.65.0
 developer: Alex Tran
 website: https://www.immich.app
 dependencies: []

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -47,21 +47,18 @@ description: >-
 releaseNotes: >
   This update brings the following new features to Immich:
 
-  - Justified layout for timeline view
+  - Choose a new feature photo for a person (in order to use this feature, please run the Detect Faces job for ALL)
 
-  - Proper support for RAW file formats
+  - Shift-key selection on the web timeline
 
-  - Memories feature
+  - Support for more raw formats
 
-  - Select-all button on the web
-
-  - The thumbnail now displays the blur version of the thumbnail image before the actual image is loaded. This mechanism replaces the transition from the gray box to the actual image to provide a better transition in the browsing experience.
+  - Album titles now appear in the search results
 
   - and more!
 
 
-  Full release notes for this update can be found at https://github.com/immich-app/immich/releases/tag/v1.65.0
-  Full changelog between v1.61.0 and v1.65.0 can be found here: https://github.com/immich-app/immich/compare/v1.61.0...v1.65.0
+  Full release notes are found at: https://github.com/immich-app/immich/releases
 developer: Alex Tran
 website: https://www.immich.app
 dependencies: []

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: immich
 category: files
 name: Immich
-version: "v1.65.0"
+version: "v1.66.1"
 tagline: High performance photo and video backup solution
 description: >-
   An open source and high performance self-hosted backup solution for the videos and photos on your mobile device


### PR DESCRIPTION
Getting Immich update PR going

added tag for 
immich-server
Looks like one for microservices is the same

immich-machine-learning
immich-web
&
immich-proxy

didn't change the new typesense
redis
or 
postgres