### PR TITLE
Upgrade Node-Red-standalone to latest version (3.0.4)

### DIFF
--- a/node-red-standalone/docker-compose.yml
+++ b/node-red-standalone/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       PROXY_AUTH_WHITELIST: "/public/*"
   
   web:
-    image: nodered/node-red:2.2.2-12@sha256:7b8e58892801f01af48acfb18c21b845a6f35029e7654ca6e19ba86bbe810d04
+    image: nodered/node-red:3.0.2-14@sha256:ee46acc66755165535e21acce44bece8fcf709e0a68f73ae74c805dbdb2ca297
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/node-red-standalone/docker-compose.yml
+++ b/node-red-standalone/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       PROXY_AUTH_WHITELIST: "/public/*"
   
   web:
-    image: nodered/node-red:3.0.2-14@sha256:ee46acc66755165535e21acce44bece8fcf709e0a68f73ae74c805dbdb2ca297
+    image: nodered/node-red:3.0.2-14@sha256:5041fe85e55705d91594980330fc447d86d4f138723befe1628c686bace01de8
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/node-red-standalone/umbrel-app.yml
+++ b/node-red-standalone/umbrel-app.yml
@@ -17,7 +17,7 @@ description: >-
   
   Note: If you would like your 'HTTP In' nodes to be accessible without authentication, then prepend your url with '/public/'. E.g. /public/do-something
 releaseNotes: >-
-  This is a large update, from version 2.2.2 to version 3.0.2. For a full list of changes, see the release notes: https://github.com/node-red/node-red/releases
+  This updates Node Red from version 2.2.2 to version 3.0.2. For a full list of changes, see the release notes: https://github.com/node-red/node-red/releases
 developer: OpenJS Foundation
 website: https://nodered.org
 dependencies: []

--- a/node-red-standalone/umbrel-app.yml
+++ b/node-red-standalone/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: node-red-standalone
 category: automation
 name: "Node-RED"
-version: "2.2.2-12"
+version: "3.0.2-14"
 tagline: Wire together the Internet of Things
 description: >-
   Node-RED is a visual programming tool for wiring together hardware

--- a/node-red-standalone/umbrel-app.yml
+++ b/node-red-standalone/umbrel-app.yml
@@ -16,6 +16,8 @@ description: >-
 
   
   Note: If you would like your 'HTTP In' nodes to be accessible without authentication, then prepend your url with '/public/'. E.g. /public/do-something
+releaseNotes: >-
+  This is a large update, from version 2.2.2 to version 3.0.2. For a full list of changes, see the release notes: https://github.com/node-red/node-red/releases
 developer: OpenJS Foundation
 website: https://nodered.org
 dependencies: []


### PR DESCRIPTION
Upgrade Node-Red-Standalone to 3.0.4.
Tested on Custom Umbrel install on Linux