### PR TITLE
Home Assistant - Enable USB device access

### DIFF
--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   server:
-    image: homeassistant/home-assistant:2023.6.3@sha256:1dd89ec1ce8de5ea869a489d5699bd91f77058ffaa6f5484b3e81323128abd2c
+    image: homeassistant/home-assistant:2023.7.1@sha256:a86ff5d05ce46520c53d67c8da55aba310de9b9b4ca8eead1ae0b5ab1c068f97
     network_mode: host
     # UI at default port 8123
     privileged: true

--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -5,5 +5,7 @@ services:
     image: homeassistant/home-assistant:2023.6.3@sha256:1dd89ec1ce8de5ea869a489d5699bd91f77058ffaa6f5484b3e81323128abd2c
     network_mode: host
     # UI at default port 8123
+    privileged: true
     volumes:
       - ${APP_DATA_DIR}/data:/config
+      - /dev:/dev

--- a/home-assistant/umbrel-app.yml
+++ b/home-assistant/umbrel-app.yml
@@ -34,22 +34,21 @@ defaultPassword: ""
 torOnly: false
 releaseNotes: >-
   🚨 IMPORTANT: If you are using both the Home Assistant and Tallycoin Connect apps on your Umbrel, please
-  update Tallycoin Connect to the latest version before updating Home Assistant. This step ensures a smooth
+  update Tallycoin Connect to the latest version on the Umbrel App Store (1.8.0-1) before updating Home Assistant. This step ensures a smooth
   operation by preventing any port conflicts between the two apps.
 
 
-  For Home Assistant mobile app users, there's a minor yet significant change. In your Home Assistant mobile
+  For Home Assistant mobile app users, there's a minor yet important change you will need to make. In your Home Assistant mobile
   app, please use the new port number '8123' to connect it to the Home Assistant app on your Umbrel, or
   simply reinstall the mobile app for automatic Umbrel detection.
   
 
-  This update brings Home Assistant to version 2023.6.3, and also includes automatic device discovery for
-  devices connected to the same network, and the ability to save your personalized settings and automations!
+  This update brings Home Assistant to version 2023.7.1, and now includes USB Discovery! The previous update included automatic device discovery for
+  devices connected to the same network, and the ability to save your personalized settings and automations.
 
 
-  Home Assistant 2023.6.3 brings a variety of improvements and bug fixes. Services like Fully Kiosk,
-  Fortios device tracker, and Insteon events are now handled more efficiently. The YouTube integration
-  has been refined, selecting lower quality thumbnails for better performance and introducing
-  re-authentication strings for enhanced security. Read more at: https://github.com/home-assistant/core/releases/tag/2023.6.3
+  This update to 2023.7.1 brings a variety of improvements and bug fixes. Services can now respond with data, Bluetooth proxies are now lightning fast,
+  you can copy-and-paste cards between your dashboards, and broken automations no longer disappear into thin air and are, instead, marked as problematic.
+  Read more at: https://github.com/home-assistant/core/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/9d79cffae608c6a6ab077f859c1c531a581cf926

--- a/home-assistant/umbrel-app.yml
+++ b/home-assistant/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: home-assistant
 category: automation
 name: Home Assistant
-version: "2023.6.3"
+version: "2023.7.1"
 tagline: Home automation that puts local control & privacy first
 description: >-
   Open source home automation that puts local control and privacy

--- a/home-assistant/umbrel-app.yml
+++ b/home-assistant/umbrel-app.yml
@@ -33,14 +33,9 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  🚨 IMPORTANT: If you are using both the Home Assistant and Tallycoin Connect apps on your Umbrel, please
-  update Tallycoin Connect to the latest version on the Umbrel App Store (1.8.0-1) before updating Home Assistant. This step ensures a smooth
-  operation by preventing any port conflicts between the two apps.
-
-
-  For Home Assistant mobile app users, there's a minor yet important change you will need to make. In your Home Assistant mobile
-  app, please use the new port number '8123' to connect it to the Home Assistant app on your Umbrel, or
-  simply reinstall the mobile app for automatic Umbrel detection.
+  For Home Assistant mobile app users, there's an important change introduced since the last version. In your Home Assistant mobile app,
+  please use the new port number '8123' to connect it to the Home Assistant app on your Umbrel. If you haven't already made this change, please do so
+  now. Alternatively, you can reinstall the mobile app for automatic Umbrel detection.
   
 
   This update brings Home Assistant to version 2023.7.1, and now includes USB Discovery! The previous update included automatic device discovery for


### PR DESCRIPTION
This PR enables Home Assistant to have access to USB devices connected to the host machine, while not requiring the USB to be connected prior to starting the Docker container.

