### PR TITLE
lightning-terminal: update to v0.10.2-alpha

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.10.1-alpha@sha256:3e25ececbb127f975d414f2a81506fe688046cd26bf548112bb1e232e1d571eb
+    image: lightninglabs/lightning-terminal:v0.10.2-alpha@sha256:b8b827a2da5ee50a3310c575e40b1a92e50f4445b2452964b450492865d7cd86
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.10.1-alpha"
+version: "0.10.2-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -51,14 +51,15 @@ defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
   This release of Lightning Terminal (LiT) includes updates to the versions of
-  the integrated LND, Loop and Pool daemons, along with a few LiT bug fixes.
+  the integrated LND, Loop and Taproot Assets daemons. This release also adds
+  new super macaroon helper functions.
   
   
   We'll be continuously working to improve the user experience based on
   feedback from the community.
   
   
-  This release packages LND v0.16.3-beta, Taproot Assets Daemon v0.2.0-alpha,
-  Loop v0.24.1-beta, Pool v0.6.4-beta and Faraday v0.2.11-alpha.
+  This release packages LND v0.16.4-beta, Taproot Assets Daemon v0.2.2-alpha,
+  Loop v0.25.2-beta, Pool v0.6.4-beta and Faraday v0.2.11-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
In this PR we bump Litd to v0.10.2-alpha.

See the release notes here: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.10.2-alpha

Happy to address any potential feedback! Thanks!