### PR TITLE
Update Node-Red-Standalone to 3.0.2-18

### DIFF
--- a/node-red-standalone/docker-compose.yml
+++ b/node-red-standalone/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       PROXY_AUTH_WHITELIST: "/public/*"
   
   web:
-    image: nodered/node-red:3.0.2-14@sha256:5041fe85e55705d91594980330fc447d86d4f138723befe1628c686bace01de8
+    image: nodered/node-red:3.0.2-18@sha256:e401cd81a43bca7db51fe8dac2c9cfc9b4ffb922ba424241280f7392e13b06a0
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/node-red-standalone/umbrel-app.yml
+++ b/node-red-standalone/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: node-red-standalone
 category: automation
 name: "Node-RED"
-version: "3.0.2-14"
+version: "3.0.2-18"
 tagline: Wire together the Internet of Things
 description: >-
   Node-RED is a visual programming tool for wiring together hardware
@@ -17,7 +17,7 @@ description: >-
   
   Note: If you would like your 'HTTP In' nodes to be accessible without authentication, then prepend your url with '/public/'. E.g. /public/do-something
 releaseNotes: >-
-  This updates Node Red from version 2.2.2 to version 3.0.2. For a full list of changes, see the release notes: https://github.com/node-red/node-red/releases
+  Upgrading Node.js from version 14 to version 18. Staying on Node-RED 3.0.2. For a full list of changes, see the release notes: https://github.com/node-red/node-red/releases
 developer: OpenJS Foundation
 website: https://nodered.org
 dependencies: []

--- a/node-red-standalone/umbrel-app.yml
+++ b/node-red-standalone/umbrel-app.yml
@@ -17,7 +17,9 @@ description: >-
   
   Note: If you would like your 'HTTP In' nodes to be accessible without authentication, then prepend your url with '/public/'. E.g. /public/do-something
 releaseNotes: >-
-  Upgrading Node.js from version 14 to version 18. Staying on Node-RED 3.0.2. For a full list of changes, see the release notes: https://github.com/node-red/node-red/releases
+  This update does not alter the Node-RED version, which remains at 3.0.2. Instead, it upgrades the underlying Node.js
+  from version 14 to 18. This change is intended to extend compatibility with Node.js modules that were previously
+  unavailable to users on Node.js 14.
 developer: OpenJS Foundation
 website: https://nodered.org
 dependencies: []


### PR DESCRIPTION
NodeJS 14 is deprecated. This version uses NodeJS 18 instead.

Tested on Raspberry Pi.
