### PR TITLE
Remove Transmission dependencies 

### DIFF
--- a/lidarr/umbrel-app.yml
+++ b/lidarr/umbrel-app.yml
@@ -14,6 +14,7 @@ description: >-
   It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available.
 developer: Lidarr
 website: https://lidarr.audio/
+dependencies: []
 repo: https://github.com/Lidarr/Lidarr
 support: https://github.com/Lidarr/Lidarr/issues
 port: 8686

--- a/lidarr/umbrel-app.yml
+++ b/lidarr/umbrel-app.yml
@@ -14,8 +14,6 @@ description: >-
   It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available.
 developer: Lidarr
 website: https://lidarr.audio/
-dependencies:
-  - transmission
 repo: https://github.com/Lidarr/Lidarr
 support: https://github.com/Lidarr/Lidarr/issues
 port: 8686

--- a/prowlarr/umbrel-app.yml
+++ b/prowlarr/umbrel-app.yml
@@ -8,6 +8,7 @@ description: >-
   Prowlarr is an indexer manager/proxy built on the popular *arr .net/reactjs base stack to integrate with your various PVR apps. Prowlarr supports management of both Torrent Trackers and Usenet Indexers. It integrates seamlessly with Lidarr, Mylar3, Radarr, Readarr, and Sonarr offering complete management of your indexers with no per app Indexer setup required (we do it all).
 developer: Prowlarr
 website: https://prowlarr.com/
+dependencies: []
 repo: https://github.com/Prowlarr/Prowlarr
 support: https://github.com/Prowlarr/Prowlarr/issues
 port: 9696

--- a/prowlarr/umbrel-app.yml
+++ b/prowlarr/umbrel-app.yml
@@ -8,8 +8,6 @@ description: >-
   Prowlarr is an indexer manager/proxy built on the popular *arr .net/reactjs base stack to integrate with your various PVR apps. Prowlarr supports management of both Torrent Trackers and Usenet Indexers. It integrates seamlessly with Lidarr, Mylar3, Radarr, Readarr, and Sonarr offering complete management of your indexers with no per app Indexer setup required (we do it all).
 developer: Prowlarr
 website: https://prowlarr.com/
-dependencies:
-  - transmission
 repo: https://github.com/Prowlarr/Prowlarr
 support: https://github.com/Prowlarr/Prowlarr/issues
 port: 9696

--- a/radarr/umbrel-app.yml
+++ b/radarr/umbrel-app.yml
@@ -8,6 +8,7 @@ description: >-
   Radarr is a movie collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new movies and will interface with clients and indexers to grab, sort, and rename them. It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available. Note that only one type of a given movie is supported. If you want both an 4k version and 1080p version of a given movie you will need multiple instances.
 developer: Radarr
 website: https://radarr.video/
+dependencies: []
 repo: https://github.com/Radarr/Radarr
 support: https://github.com/Radarr/Radarr/issues
 port: 7878

--- a/radarr/umbrel-app.yml
+++ b/radarr/umbrel-app.yml
@@ -8,8 +8,6 @@ description: >-
   Radarr is a movie collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new movies and will interface with clients and indexers to grab, sort, and rename them. It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available. Note that only one type of a given movie is supported. If you want both an 4k version and 1080p version of a given movie you will need multiple instances.
 developer: Radarr
 website: https://radarr.video/
-dependencies:
-  - transmission
 repo: https://github.com/Radarr/Radarr
 support: https://github.com/Radarr/Radarr/issues
 port: 7878

--- a/sonarr/umbrel-app.yml
+++ b/sonarr/umbrel-app.yml
@@ -8,8 +8,7 @@ description: >-
   Sonarr is a PVR for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.
 developer: Sonarr
 website: https://sonarr.tv/
-dependencies:
-  - transmission
+dependencies: []
 repo: https://github.com/Sonarr/Sonarr
 support: https://github.com/Sonarr/Sonarr/issues
 port: 8989


### PR DESCRIPTION
There are three different torrent clients available in the main app store. At least two of these are supported by the *arr apps. I found it strange that Transmission is listed as a dependency for the *arr apps when qBittorrent works as well. I’ve removed the requirement from the config file to allow users to manually chose in app what client to use.