### PR TITLE
lightning-terminal: update to v0.10.4-alpha

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.10.2-alpha@sha256:b8b827a2da5ee50a3310c575e40b1a92e50f4445b2452964b450492865d7cd86
+    image: lightninglabs/lightning-terminal:v0.10.4-alpha@sha256:1260fad6f3930c2933d27223663e6b35beb9bbb730dac13c186ff48086b153f7
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.10.2-alpha"
+version: "0.10.4-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -50,16 +50,20 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  This release of Lightning Terminal (LiT) includes updates to the versions of
-  the integrated LND, Loop and Taproot Assets daemons. This release also adds
-  new super macaroon helper functions.
+  This release of Lightning Terminal (LiT) includes an update to the integrated
+  Taproot Assets daemon version. This release also adds functionality to query
+  information of specific LND accounts, as well as enabling labeling of
+  accounts.
+
+  There was no v0.10.3-alpha release, due to a build issue we had to skip that
+  version and go directly to v0.10.4-alpha.
   
   
   We'll be continuously working to improve the user experience based on
   feedback from the community.
   
   
-  This release packages LND v0.16.4-beta, Taproot Assets Daemon v0.2.2-alpha,
+  This release packages LND v0.16.4-beta, Taproot Assets Daemon v0.2.3-alpha,
   Loop v0.25.2-beta, Pool v0.6.4-beta and Faraday v0.2.11-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
In this PR we bump Litd to `v0.10.4-alpha`.

There was no `v0.10.3-alpha` release, due to a build issue we had to skip that version and go directly to `v0.10.4-alpha`.

See the release notes here: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.10.4-alpha

Happy to address any potential feedback! Thanks!