### PR TITLE
Update BTCPay Server to 1.11.1

### DIFF
--- a/btcpay-server/docker-compose.yml
+++ b/btcpay-server/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.3.62@sha256:8f484e37fc2ab7f9bf7524ad7d4d5a09a39d5bc3dee5f84cfa43f93be3396e92
+    image: nicolasdorier/nbxplorer:2.3.65@sha256:5c8e80098635a99b48562f32a0436e35e0ff72eb5c8cf3347c982b691901dfc8
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -31,7 +31,7 @@ services:
       NBXPLORER_BTCHASTXINDEX: 1
 
   web:
-    image: btcpayserver/btcpayserver:1.9.2@sha256:efa1245100cf5ec90e56e0ab216995885074357dce4817d362f2d02fd47c9048
+    image: btcpayserver/btcpayserver:1.11.2@sha256:06177a27d6d5ce5df496a848b1527a14e39606ba5468a00cf26b5b58bd269879
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -57,7 +57,7 @@ services:
       BTCPAY_TORSERVICES: "btcpayserver:$APP_HIDDEN_SERVICE"
 
   postgres:
-    image: btcpayserver/postgres:13.7@sha256:dadf0048895a888d88a2dd773dde2f5868c45f74ad37c6d208694df54b590531
+    image: btcpayserver/postgres:13.10@sha256:12b8f625bc64b5b129e0e7a672e5e31fb5d39a7dbe42233eef7ab321568f30e7
     # This needs to run as root for migrations to succeed
     # user: "1000:1000"
     restart: on-failure

--- a/btcpay-server/docker-compose.yml
+++ b/btcpay-server/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       NBXPLORER_BTCHASTXINDEX: 1
 
   web:
-    image: btcpayserver/btcpayserver:1.11.2@sha256:06177a27d6d5ce5df496a848b1527a14e39606ba5468a00cf26b5b58bd269879
+    image: btcpayserver/btcpayserver:1.11.1@sha256:44742c74deccb4a42dddf25ff5fce67c3e905eb7f88b047e8f8a80c261bc134f
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/btcpay-server/umbrel-app.yml
+++ b/btcpay-server/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: btcpay-server
 category: bitcoin
 name: BTCPay Server
-version: "1.11.0"
+version: "1.11.1"
 tagline: Accept Bitcoin payments with 0 fees & no 3rd party
 description: >-
   BTCPay Server is a payment processor that allows you to receive
@@ -34,10 +34,11 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >
-  This update from version 1.9.2 to 1.11.0 includes a range of new features, including an overhaul of invoice reporting, Point of Sale cart redesign, 
-  adding product categories to Point of Sale apps, playing a sound when an invoice is paid, and more!
+  This update from version 1.9.2 to 1.11.1 includes a range of new features, including an overhaul of invoice reporting, Point of Sale cart redesign, 
+  adding product categories to Point of Sale apps, playing a sound when an invoice is paid, bug fixes, and more!
+
 
   A full list of new features, improvements, and bug fixes
-  for versions between 1.9.2 and 1.11.0 can be found here: https://github.com/btcpayserver/btcpayserver/releases.
+  for versions between 1.9.2 and 1.11.1 can be found here: https://github.com/btcpayserver/btcpayserver/releases.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/353

--- a/btcpay-server/umbrel-app.yml
+++ b/btcpay-server/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: btcpay-server
 category: bitcoin
 name: BTCPay Server
-version: "1.9.2"
+version: "1.11.0"
 tagline: Accept Bitcoin payments with 0 fees & no 3rd party
 description: >-
   BTCPay Server is a payment processor that allows you to receive
@@ -34,11 +34,10 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >
-  This update from version 1.7.12 to 1.9.2 includes a range of new features, including customizable checkout forms and invoice metadata, store branding options,
-  a redesigned Point of Sale keypad view, improved Point of Sale receipt, and more!
-
+  This update from version 1.9.2 to 1.11.0 includes a range of new features, including an overhaul of invoice reporting, Point of Sale cart redesign, 
+  adding product categories to Point of Sale apps, playing a sound when an invoice is paid, and more!
 
   A full list of new features, improvements, and bug fixes
-  for versions between 1.7.12 and 1.9.2 can be found here: https://github.com/btcpayserver/btcpayserver/releases.
+  for versions between 1.9.2 and 1.11.0 can be found here: https://github.com/btcpayserver/btcpayserver/releases.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/353


### PR DESCRIPTION
PR for 1.11.0,
updated postgres, BTCPay, and nbxplorer tags

updating release notes description

Don't see any other big breaking changes for new update

If there's anything else I can do, do better, or can confirm standardization of release notes let me know!