### PR TITLE
Update Torq to v1.0.10

### DIFF
--- a/torq/docker-compose.yml
+++ b/torq/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 7028
 
   web:
-    image: lncapital/torq:1.0.10@sha256:4a9f469b40b27c56d4a0e65f706c79e7e053c39bb076e38250c50a873e395e84
+    image: lncapital/torq:1.0.10@sha256:1a1ccba1d6b3e9c2196b6ee2c2d77e6662826a8d4808452f9406a2c6cb3c6426
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/torq/docker-compose.yml
+++ b/torq/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 7028
 
   web:
-    image: lncapital/torq:0.23.1@sha256:6e968ccb3d6631e373d64d9853559a690f88e827f61b535b120f2620e003028f
+    image: lncapital/torq:1.0.10@sha256:4a9f469b40b27c56d4a0e65f706c79e7e053c39bb076e38250c50a873e395e84
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/torq/umbrel-app.yml
+++ b/torq/umbrel-app.yml
@@ -51,34 +51,48 @@ gallery:
   - 4.jpg
   - 5.jpg
 releaseNotes: >-
-  New features:
   
-  - Open telemetry instrumentation
-  
-  - Jaeger tracing
-  
-  - Prometheus export
-  
-  - Peers' page now supports multi-node setups
-  
-  - Custom mempool.space URL
-  
-  - Inspect a closed/closing channel
-  
-  - Pagination added to all channel table pages and forwarding pages
-  
-  
-  Bugfixes:
-  
-  - Fix Amboss ping service
-  
-  - Increase initial channel data import throughput
-  
-  - LND maximum message size increase to 150M
-  
-  - CLN fixes (thanks to borsche-hfsp.com)
-  
-  - And more...
+  Torq v1.0.10
+
+    New:
+     - Connections status: Provides insight into the internals of Torq. (People often ask if there is a way to see if it's still importing data; well, now you can!)
+     - LND: Select an outbound channel for payment
+     - Keep historic information about tagging/untagging
+     - Manually request a channel from an LSP that is following the LSP channel request specification (i.e. Deezy)
+     - HTLC information in Open Channels
+     - Quick filter with fuzzy search on listing screens
+     - Mempool API integration for fee recommendations
+
+    New HTLC Firewall workflows:
+     - You can create one or more workflows to firewall/drop HTLCs. (i.e. block any HTLC coming from peer1 going to peer2 below a certain amount. Or block any HTLC if the amount of pending HTLC for a peer is above a certain amount)
+     - New HTLC Firewall Related workflow nodes:
+       - HTLC Intercepted (Trigger): Every HTLC will trigger the workflow when HTLC interceptor is enabled in the node's settings
+       - HTLC Event (Data Source): Starting point for the HTLC Firewall workflow
+       - HTLC Filter (Filter): Allows you to filter base on the HTLC's incoming and/or outgoing amount
+       - HTLC Channel Split (Filter): This splits the flow and you can chose to continue with either the incoming channel or outgoing channel from the HTLC
+       - HTLC Channel Join (Filter): After a split you can chose to join the flow back together
+       - HTLC Blocker (Action): This will firewall/drop the HTLC if something passed through it's parent
+
+    New workflow nodes:
+    - Close channel: be very careful with this one so you don't accidentally close a channel because of a logical error in your workflow!
+    - Open channel
+    - Request channel: You can now automatically request a channel from an LSP that is following the LSP channel request specification (i.e. Deezy)
+
+    Workflow update:
+     - Dry-run a workflow
+     - Capture workflow logs
+     - Visualize workflow logs in a flow diagram, including very detailed information for debugging workflows
+     - HTLC filterable data added to Channel Filter (i.e. summary of all pending HTLCs for peer1)
+
+    Updates:
+     - Improved filtering on the peers page
+     - Various optimizations and updates
+
+    Torq pay:
+     - We've never hidden the fact that some day you will have to pay to use Torq.
+     - This release starts a new phase for our startup.
+     - You will need a subscription and we chose to use Stripe for the initial launch.
+     - We ourselves are a startup looking for a good model to be able to provide the power of Torq to as many node operators as possible, so please don't hesitate to reach out to provide feedback! Let's take lightning to the next level, together!
 
 path: ""
 defaultUsername: ""

--- a/torq/umbrel-app.yml
+++ b/torq/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: torq
 category: bitcoin
 name: Torq
-version: "v0.23.1"
+version: "v1.0.10"
 tagline: Scalable Node Management Software
 description: >-
   Operating a Lightning node requires a lot of work. You need to monitor your channels, rebalance them, keep track of your fees and much more.
@@ -13,9 +13,9 @@ description: >-
 
   Features:
 
-  - Workflow based automation.
+  - Advanced decision engine for automation. Create your own logic visually through workflows.
 
-  - Channel and Channel group inspection, even with more than 1000 channels.
+  - Fast even with more than 1000 channels.
   
   - Advanced charts and visualizations of aggregated forwarding statistics
 


### PR DESCRIPTION
Torq v1.0

New:
 - Connections status: Provides insight into the internals of Torq. (People often ask if there is a way to see if it's still importing data; well, now you can!)
 - LND: Select an outbound channel for payment
 - Keep historic information about tagging/untagging
 - Manually request a channel from an LSP that is following the LSP channel request specification (i.e. Deezy)
 - HTLC information in Open Channels
 - Quick filter with fuzzy search on listing screens
 - Mempool API integration for fee recommendations
 
New HTLC Firewall workflows:
 - You can create one or more workflows to firewall/drop HTLCs. (i.e. block any HTLC coming from peer1 going to peer2 below a certain amount. Or block any HTLC if the amount of pending HTLC for a peer is above a certain amount)
 - New HTLC Firewall Related workflow nodes:
   - HTLC Intercepted (Trigger): Every HTLC will trigger the workflow when HTLC interceptor is enabled in the node's settings
   - HTLC Event (Data Source): Starting point for the HTLC Firewall workflow
   - HTLC Filter (Filter): Allows you to filter base on the HTLC's incoming and/or outgoing amount
   - HTLC Channel Split (Filter): This splits the flow and you can chose to continue with either the incoming channel or outgoing channel from the HTLC
   - HTLC Channel Join (Filter): After a split you can chose to join the flow back together
   - HTLC Blocker (Action): This will firewall/drop the HTLC if something passed through it's parent

New workflow nodes:
- Close channel: be very careful with this one so you don't accidentally close a channel because of a logical error in your workflow!
- Open channel
- Request channel: You can now automatically request a channel from an LSP that is following the LSP channel request specification (i.e. Deezy)

Workflow update:
 - Dry-run a workflow
 - Capture workflow logs
 - Visualize workflow logs in a flow diagram, including very detailed information for debugging workflows
 - HTLC filterable data added to Channel Filter (i.e. summary of all pending HTLCs for peer1)
 
Updates:
 - Improved filtering on the peers page
 - Various optimizations and updates

Torq pay:
 - We've never hidden the fact that some day you will have to pay to use Torq.
 - This release starts a new phase for our startup.
 - You will need a subscription and we chose to use Stripe for the initial launch.
 - We ourselves are a startup looking for a good model to be able to provide the power of Torq to as many node operators as possible, so please don't hesitate to reach out to provide feedback! Let's take lightning to the next level, together!