### PR TITLE
Update Torq to v1.0.11

### DIFF
--- a/torq/docker-compose.yml
+++ b/torq/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 7028
 
   web:
-    image: lncapital/torq:1.0.10@sha256:1a1ccba1d6b3e9c2196b6ee2c2d77e6662826a8d4808452f9406a2c6cb3c6426
+    image: lncapital/torq:1.0.11@sha256:f5aac0606fe3f821f858aba558c8ef107fe7862c5a8f2595cc94f585df11349d
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/torq/umbrel-app.yml
+++ b/torq/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: torq
 category: bitcoin
 name: Torq
-version: "v1.0.10"
+version: "v1.0.11"
 tagline: Scalable Node Management Software
 description: >-
   Operating a Lightning node requires a lot of work. You need to monitor your channels, rebalance them, keep track of your fees and much more.
@@ -51,6 +51,11 @@ gallery:
   - 4.jpg
   - 5.jpg
 releaseNotes: >-
+  
+  Torq v1.0.11
+  
+    Bug fixes:
+     - Fixes issue where creation of new tags overwrote existing tags.
   
   Torq v1.0.10
 


### PR DESCRIPTION
This update fixes a bug when creating tags. In the last release, new tags would overwrite an existing one.