### PR TITLE
lightning-terminal: update to v0.10.5-alpha

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.10.4-alpha@sha256:1260fad6f3930c2933d27223663e6b35beb9bbb730dac13c186ff48086b153f7
+    image: lightninglabs/lightning-terminal:v0.10.5-alpha@sha256:cc305b855e55d040a10cb8d0b374e03092ac85e30a531036d6970c36511dfef4
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.10.4-alpha"
+version: "0.10.5-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -50,20 +50,14 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  This release of Lightning Terminal (LiT) includes an update to the integrated
-  Taproot Assets daemon version. This release also adds functionality to query
-  information of specific LND accounts, as well as enabling labeling of
-  accounts.
-
-  There was no v0.10.3-alpha release, due to a build issue we had to skip that
-  version and go directly to v0.10.4-alpha.
-  
+  This release of Lightning Terminal (LiT) includes an update to the integrated 
+  Loop version along with a small UI update use the correct unit for Loop Out 
+  swap deadlines. 
   
   We'll be continuously working to improve the user experience based on
-  feedback from the community.
-  
+  feedback from the community. 
   
   This release packages LND v0.16.4-beta, Taproot Assets Daemon v0.2.3-alpha,
-  Loop v0.25.2-beta, Pool v0.6.4-beta and Faraday v0.2.11-alpha.
+  Loop v0.26.2-beta, Pool v0.6.4-beta and Faraday v0.2.11-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -54,8 +54,10 @@ releaseNotes: >-
   Loop version along with a small UI update use the correct unit for Loop Out 
   swap deadlines. 
   
+
   We'll be continuously working to improve the user experience based on
   feedback from the community. 
+  
   
   This release packages LND v0.16.4-beta, Taproot Assets Daemon v0.2.3-alpha,
   Loop v0.26.2-beta, Pool v0.6.4-beta and Faraday v0.2.11-alpha.


### PR DESCRIPTION
Hi there! Here with the latest release: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.10.5-alpha