### PR TITLE
Update Prowlarr to v1.7.4

### DIFF
--- a/prowlarr/docker-compose.yml
+++ b/prowlarr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/prowlarr:0.4.4-nightly@sha256:053efaf2ede2a8e85a960f6db0d6a54e2ca29b13910dc3575eb5a86c686ed302
+    image: linuxserver/prowlarr:1.7.4-nightly@sha256:c6c5541b18c41c86c82bd1937d6878f02ffcdeebdf143ac62bbcf0764d2d37f7
     environment:
       - PUID=1000
       - PGID=1000

--- a/prowlarr/docker-compose.yml
+++ b/prowlarr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/prowlarr:1.7.4-nightly@sha256:c6c5541b18c41c86c82bd1937d6878f02ffcdeebdf143ac62bbcf0764d2d37f7
+    image: linuxserver/prowlarr:version-1.7.4.3769@sha256:178ca71cf4694c238fd2324a9f3b9be8e8ac5763098bfeb48dfa945b1fd0aa04
     environment:
       - PUID=1000
       - PGID=1000

--- a/prowlarr/umbrel-app.yml
+++ b/prowlarr/umbrel-app.yml
@@ -6,6 +6,9 @@ version: "v1.7.4.3769"
 tagline: Prowlarr is an indexer manager/proxy
 description: >-
   Prowlarr is an indexer manager/proxy built on the popular *arr .net/reactjs base stack to integrate with your various PVR apps. Prowlarr supports management of both Torrent Trackers and Usenet Indexers. It integrates seamlessly with Lidarr, Mylar3, Radarr, Readarr, and Sonarr offering complete management of your indexers with no per app Indexer setup required (we do it all).
+  
+  
+  On installation of Sonarr, Lidarr or Radarr, Prowlarr will automatically set up the app's connection within its settings.
 developer: Prowlarr
 website: https://prowlarr.com/
 dependencies:

--- a/prowlarr/umbrel-app.yml
+++ b/prowlarr/umbrel-app.yml
@@ -24,10 +24,7 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  On installation of Sonarr, Lidarr or Radarr, Prowlarr will automatically setup the app's connection within its settings
-
-
-  A full list of new features, improvements, and bug fixes: https://github.com/linuxserver/docker-prowlarr/releases
+  Full release notes can be found here: https://github.com/linuxserver/docker-prowlarr/releases
 torOnly: false
 permissions:
   - STORAGE_DOWNLOADSsubmitter: Umbrel

--- a/prowlarr/umbrel-app.yml
+++ b/prowlarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: prowlarr
 category: media
 name: Prowlarr
-version: "0.4.4-nightly-build-2"
+version: "prowlarr:1.7.4-nightly"
 tagline: Prowlarr is an indexer manager/proxy
 description: >-
   Prowlarr is an indexer manager/proxy built on the popular *arr .net/reactjs base stack to integrate with your various PVR apps. Prowlarr supports management of both Torrent Trackers and Usenet Indexers. It integrates seamlessly with Lidarr, Mylar3, Radarr, Readarr, and Sonarr offering complete management of your indexers with no per app Indexer setup required (we do it all).
@@ -21,7 +21,10 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  On installation of Sonarr, Lidarr or Radarr, Prowlarr will now automatically setup the app's connection within its settings
+  On installation of Sonarr, Lidarr or Radarr, Prowlarr will automatically setup the app's connection within its settings
+
+
+  A full list of new features, improvements, and bug fixes: https://github.com/linuxserver/docker-prowlarr/releases
 torOnly: false
 permissions:
   - STORAGE_DOWNLOADSsubmitter: Umbrel

--- a/prowlarr/umbrel-app.yml
+++ b/prowlarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: prowlarr
 category: media
 name: Prowlarr
-version: "prowlarr:1.7.4-nightly"
+version: "v1.7.4.3769"
 tagline: Prowlarr is an indexer manager/proxy
 description: >-
   Prowlarr is an indexer manager/proxy built on the popular *arr .net/reactjs base stack to integrate with your various PVR apps. Prowlarr supports management of both Torrent Trackers and Usenet Indexers. It integrates seamlessly with Lidarr, Mylar3, Radarr, Readarr, and Sonarr offering complete management of your indexers with no per app Indexer setup required (we do it all).


### PR DESCRIPTION
It looks like we used the nightly build before 
I used what looked like the [latest nightly build](nightly-version-1.7.4.3768) for [linux server](https://hub.docker.com/r/linuxserver/prowlarr/tags?page=2&name=1.7.4): 
![image](https://github.com/getumbrel/umbrel-apps/assets/8608634/5d4be5c9-4270-4a8b-81d4-0cee520ec5f9)

Not sure when next version is out of pre-release does look like 1.8.3 may be ready soon FYI: 
https://github.com/linuxserver/docker-prowlarr/releases

Didn't change media-app-configurator

