### PR TITLE
Update Tailscale to v1.46.1

### DIFF
--- a/tailscale/docker-compose.yml
+++ b/tailscale/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   web:
     network_mode: "host" # TODO: We can remove this later with some iptables magic
-    image: tailscale/tailscale:v1.40.1@sha256:08dd1f465d6e96192b36c10f4366b3988bc6ad29f7b264bd020c1762ee325305
+    image: tailscale/tailscale:v1.46.1@sha256:8abcbcfe179c454ab4c3b583626c4e5b2edcb7c0851fe09ba3313d4ca02aacdc
     restart: on-failure
     stop_grace_period: 1m
     command: "sh -c 'tailscale web --listen 0.0.0.0:8240 & exec tailscaled --tun=userspace-networking'"

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: tailscale
 category: networking
 name: Tailscale
-version: "v1.40.1"
+version: "v1.46.1"
 tagline: Zero config VPN to access your Umbrel from anywhere
 description: >-
   Tailscale is zero config VPN that creates a secure network between
@@ -28,7 +28,7 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: >
-  This release updates Tailscale from v1.34.2 to v1.40.1.
+  This release updates Tailscale from v1.40.1 to v1.46.1.
 
 
   Full release notes and detailed information is available at https://github.com/tailscale/tailscale/releases

--- a/vaultwarden/docker-compose.yml
+++ b/vaultwarden/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: vaultwarden/server:1.25.0@sha256:f3ebede27f1cf5e78373c3c4a429cf1fdd8d6b13528a2b9ca4fb3cb7cc681ba9
+    image: vaultwarden/server:1.29.1@sha256:89ffbe952338f42265dbff0033d0fa8a88458a52674a05f5ed918875e403dccd
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/vaultwarden/docker-compose.yml
+++ b/vaultwarden/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: vaultwarden/server:1.29.1@sha256:89ffbe952338f42265dbff0033d0fa8a88458a52674a05f5ed918875e403dccd
+    image: vaultwarden/server:1.25.0@sha256:f3ebede27f1cf5e78373c3c4a429cf1fdd8d6b13528a2b9ca4fb3cb7cc681ba9
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/vaultwarden/umbrel-app.yml
+++ b/vaultwarden/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: vaultwarden
 category: files
 name: Vaultwarden
-version: "1.25.0"
+version: "1.29.1"
 tagline: Unofficial Bitwarden® compatible server
 description: >-
   Vaultwarden (formerly known as Bitwarden_RS) is an alternative

--- a/vaultwarden/umbrel-app.yml
+++ b/vaultwarden/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: vaultwarden
 category: files
 name: Vaultwarden
-version: "1.29.1"
+version: "1.25.0"
 tagline: Unofficial Bitwarden® compatible server
 description: >-
   Vaultwarden (formerly known as Bitwarden_RS) is an alternative


### PR DESCRIPTION
Due to a regression introduced in the interaction between Tailscale and Linux ufw, the Linux release for `v1.48.0` has been withdrawn and is pending a fix.
To ensure stability and avoid potential issues, opting to stick with **v1.46.1** until the issue is resolved in a future release.