### PR TITLE
Update Vaultwarden to v1.29.1

### DIFF
--- a/vaultwarden/docker-compose.yml
+++ b/vaultwarden/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: vaultwarden/server:1.29.1@sha256:89ffbe952338f42265dbff0033d0fa8a88458a52674a05f5ed918875e403dccd
+    image: vaultwarden/server:1.29.1@sha256:c2849f8189e4d425a9d80db0380566cc38577b289b9e6c88330e190e19af5a30
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/vaultwarden/docker-compose.yml
+++ b/vaultwarden/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: vaultwarden/server:1.25.0@sha256:f3ebede27f1cf5e78373c3c4a429cf1fdd8d6b13528a2b9ca4fb3cb7cc681ba9
+    image: vaultwarden/server:1.29.1@sha256:89ffbe952338f42265dbff0033d0fa8a88458a52674a05f5ed918875e403dccd
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/vaultwarden/umbrel-app.yml
+++ b/vaultwarden/umbrel-app.yml
@@ -27,6 +27,21 @@ description: >-
   - YubiKey and Duo support
 
    Please note that Vaultwarden is not associated with the Bitwarden® project nor 8bit Solutions LLC. When using this app, please report any bugs or suggestions to us directly, regardless of whatever clients you are using (mobile, desktop, browser, etc), and do not use Bitwarden®'s official support channels.
+releaseNotes: >
+  This release updates Vaultwarden from v1.25.0 to v1.29.1. It includes many bug fixes and performance improvements, as well as the following new features:
+  
+  - Support for Forward Email
+  
+  - WebSocket notifications now work via the default HTTP port
+
+  - The latest Bitwarden Directory Connector can be used now
+  
+  - Support for Argon2 key derivation for the admin page token
+
+  - and more!
+
+
+  The full release notes are available at https://github.com/dani-garcia/vaultwarden/releases
 developer: Daniel García
 website: https://github.com/dani-garcia
 dependencies: []

--- a/vaultwarden/umbrel-app.yml
+++ b/vaultwarden/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: vaultwarden
 category: files
 name: Vaultwarden
-version: "1.25.0"
+version: "1.29.1"
 tagline: Unofficial Bitwarden® compatible server
 description: >-
   Vaultwarden (formerly known as Bitwarden_RS) is an alternative

--- a/vaultwarden/umbrel-app.yml
+++ b/vaultwarden/umbrel-app.yml
@@ -27,7 +27,7 @@ description: >-
   - YubiKey and Duo support
 
    Please note that Vaultwarden is not associated with the Bitwarden® project nor 8bit Solutions LLC. When using this app, please report any bugs or suggestions to us directly, regardless of whatever clients you are using (mobile, desktop, browser, etc), and do not use Bitwarden®'s official support channels.
-releaseNotes: >
+releaseNotes: >-
   This release updates Vaultwarden from v1.25.0 to v1.29.1. It includes many bug fixes and performance improvements, as well as the following new features:
   
   - Support for Forward Email


### PR DESCRIPTION
Update Vaultwarden from v1.25.0 to v1.29.1.

Full release notes can be found at: https://github.com/dani-garcia/vaultwarden/releases