### PR TITLE
Update Whoogle Search to v0.8.3

### DIFF
--- a/whoogle-search/docker-compose.yml
+++ b/whoogle-search/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 6420
 
   web:
-    image: benbusby/whoogle-search:0.8.2@sha256:9721b1f2de485ace28ddc359bbbf832a7da9ac705513e742e68fa4ab9ba3c41a
+    image: benbusby/whoogle-search:0.8.3@sha256:feae9cdeb1aaa76fbc3e36cdfbf084ba02200a5675703f61bb2ddceb0060a13b
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/whoogle-search/umbrel-app.yml
+++ b/whoogle-search/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: whoogle-search
 category: networking
 name: Whoogle Search
-version: "0.8.2"
+version: "0.8.3"
 tagline: A self-hosted, ad-free, privacy-respecting metasearch engine
 description: >-
   Get Google search results, but without any ads, javascript, AMP links, 
@@ -68,42 +68,9 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >
-  - adding time constraint to search options
-
-  - Fix: added a functionality to make sure escaped characters stay escaped.
-
-  - Can be updated to support other search params, if requested
-
-  - adding line break between header options
-
-  - Add whoogle.ungovernable.men to list of instances
-
-  - Omit 'mobile.' and 'm.' in site alt replacements
-
-  - Don't prepend services that have schemes with '//'
-
-  - Add two more ungovernable.men instances
-
-  - Add a function to check if target_word contains CJK characters
-
-  - Add instruction on fixing the fly.toml before deploying
-
-  - Greek Translation request
-
-  - Added Indonesian translation
-
-  - Add Azerbaijani translation
-
-  - Bump cryptography from 3.3.2 to 39.0.1
-
-  - Bump werkzeug from 0.16.0 to 2.2.3
-
-  - Add calculator widget
-
-  - Add authentication to cookie
-
-  - Fix a bug on remove_block_titles() and remove_block_url()
-
-  - Update zh-tw translation
+  This update fixes a Cookie Consent bug affecting all EU users.
+  
+  
+  Full release notes are found at https://github.com/benbusby/whoogle-search/releases/tag/v0.8.3
 submitter: Jasper
 submission: https://github.com/getumbrel/umbrel-apps/pull/117


### PR DESCRIPTION
Fixes recent EU cookie consent bug: https://github.com/benbusby/whoogle-search/pull/1054
Closes https://github.com/getumbrel/umbrel-apps/issues/738

Tested on arm64 and x86(amd64).

