### PR TITLE
Update Tailscale to v1.48.1

### DIFF
--- a/tailscale/docker-compose.yml
+++ b/tailscale/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   web:
     network_mode: "host" # TODO: We can remove this later with some iptables magic
-    image: tailscale/tailscale:v1.46.1@sha256:8abcbcfe179c454ab4c3b583626c4e5b2edcb7c0851fe09ba3313d4ca02aacdc
+    image: tailscale/tailscale:v1.48.1@sha256:51c756718c30b15d1d3d228b1f4425cba646ec15da5d188a0d55c32b8ea4f378
     restart: on-failure
     stop_grace_period: 1m
     command: "sh -c 'tailscale web --listen 0.0.0.0:8240 & exec tailscaled --tun=userspace-networking'"

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -28,19 +28,9 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: >-
-  This release updates Tailscale from v1.46.1 to v1.48.1. It includes bug fixes and performance improvements:
+  This release updates Tailscale from v1.46.1 to v1.48.1.
 
-  🐛 Bug Fixes:
-  
-  - Linux
-  
-  Fix: resolve nftables interaction between tailscale and ufw which resulted in blocking subnet routed traffic
-  
-  Synology
-  
-  Fix: determine correct CPU architecture on Synology platforms during tailscale update
 
-  
   Full release notes and detailed information is available at https://github.com/tailscale/tailscale/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/1248

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: tailscale
 category: networking
 name: Tailscale
-version: "v1.46.1"
+version: "v1.48.1"
 tagline: Zero config VPN to access your Umbrel from anywhere
 description: >-
   Tailscale is zero config VPN that creates a secure network between
@@ -27,10 +27,20 @@ gallery:
 path: ""
 deterministicPassword: false
 torOnly: false
-releaseNotes: >
-  This release updates Tailscale from v1.40.1 to v1.46.1.
+releaseNotes: >-
+  This release updates Tailscale from v1.46.1 to v1.48.1. It includes bug fixes and performance improvements:
 
+  🐛 Bug Fixes:
+  
+  - Linux
+  
+  Fix: resolve nftables interaction between tailscale and ufw which resulted in blocking subnet routed traffic
+  
+  Synology
+  
+  Fix: determine correct CPU architecture on Synology platforms during tailscale update
 
+  
   Full release notes and detailed information is available at https://github.com/tailscale/tailscale/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/1248


### PR DESCRIPTION
This update fixes the `nftables` interaction between `tailscale` and `ufw` which resulted in blocking subnet routed traffic. Also, it now determine correct CPU architecture on Synology platforms during `tailscale update`