### PR TITLE
Update Ride The Lightning to v0.14.0-beta

### DIFF
--- a/ride-the-lightning/docker-compose.yml
+++ b/ride-the-lightning/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3001
   
   web:
-    image: shahanafarooqui/rtl:0.13.2@sha256:07d4c1f263c05c32270dcaab3625fc68ef985efce652e7850fbf57f65d36366f
+    image: shahanafarooqui/rtl:0.14.0@sha256:b515990316440518197fd40ff69ce126300e5ed9367916dc13870521d02ff8f4
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/ride-the-lightning/umbrel-app.yml
+++ b/ride-the-lightning/umbrel-app.yml
@@ -48,6 +48,8 @@ releaseNotes: >-
 
   - Navigation to node and channel lookup from the info page
 
+  - LND bug fix for the breaking changes on the send payment API
+
 
   Full release notes can be found here: https://github.com/Ride-The-Lightning/RTL/releases
 path: ""

--- a/ride-the-lightning/umbrel-app.yml
+++ b/ride-the-lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ride-the-lightning
 category: bitcoin
 name: Ride The Lightning
-version: "0.13.2-beta-hotfix-1"
+version: "0.14.0-beta"
 tagline: A powerful dashboard for the Lightning Network
 description: >-
   RTL is a full function, device agnostic, web user interface to help
@@ -40,10 +40,16 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  This release updates the boltz-lnd dependency of the Ride The Lightning app to v1.2.7, and includes an important fix for LND fee estimation.
+  This release updates the Ride The Lightning app to v0.14.0-beta, and includes bug fixes and performance improvements:
+
+  - Navigation bug fixes from the dashboard
+
+  - Connect with a peer from the node lookup page
+
+  - Navigation to node and channel lookup from the info page
 
 
-  Full release notes for boltz-lnd can be found here: https://github.com/BoltzExchange/boltz-lnd/releases/tag/v1.2.7
+  Full release notes can be found here: https://github.com/Ride-The-Lightning/RTL/releases
 path: ""
 defaultUsername: ""
 deterministicPassword: true


### PR DESCRIPTION
I have updated the `RTL` image from version `v0.13.2-beta-hotfix-1` to `v0.14.0-beta`. As for `boltz-lnd`, there have been no new releases.