### PR TITLE
Update Core Lightning RTL to v0.14.0 beta

### DIFF
--- a/core-lightning-rtl/docker-compose.yml
+++ b/core-lightning-rtl/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: shahanafarooqui/rtl:0.13.2@sha256:07d4c1f263c05c32270dcaab3625fc68ef985efce652e7850fbf57f65d36366f
+    image: shahanafarooqui/rtl:0.14.0@sha256:b515990316440518197fd40ff69ce126300e5ed9367916dc13870521d02ff8f4
     restart: on-failure
     environment:
       PORT: 3000

--- a/core-lightning-rtl/umbrel-app.yml
+++ b/core-lightning-rtl/umbrel-app.yml
@@ -48,19 +48,23 @@ releaseNotes: >-
 
   Core Lightning users should note that this update depends on cl-rest v0.10.3 and Core Lightning v23.05. If you are running any version older than 23.05, you should not upgrade to this UI. The changes are not backwards compatible with older versions of Core Lightning
 
+
   Core Lightning:
 
   - Handle the breaking changes of the msat purge for CLN version v23.05
 
   - Track active HTLCs on the channels page
 
+
   Eclair:
 
   - Circular rebalancing
 
+
   LND:
 
   - Bugs fixes owing to the breaking changes on the send payment API
+
 
   General:
 

--- a/core-lightning-rtl/umbrel-app.yml
+++ b/core-lightning-rtl/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: core-lightning-rtl
 category: bitcoin
 name: Ride The Lightning (Core Lightning)
-version: "0.13.2-beta"
+version: "0.14.0-beta"
 tagline: Manage your Core Lightning node with RTL
 description: >-
   This version of RTL is specifically configured to use your Core Lightning node.
@@ -44,12 +44,33 @@ gallery:
 path: ""
 deterministicPassword: true
 releaseNotes: >-
-  - Multiple channels with the same peer now visible on the channels page
+  ⚠️ This release covers breaking changes from CLN 23.05, few minor UX enhancements and bug fixes
 
-  - User customizable grids enabling you to control: number of rows on the page, columns you want to view and default sorting order
+  Core Lightning users should note that this update depends on cl-rest v0.10.3 and Core Lightning v23.05. If you are running any version older than 23.05, you should not upgrade to this UI. The changes are not backwards compatible with older versions of Core Lightning
 
-  - Setting to control opening of unannounced channels by default
-  
-  - Other bug fixes and usability fixes
+  Core Lightning:
+
+  - Handle the breaking changes of the msat purge for CLN version v23.05
+
+  - Track active HTLCs on the channels page
+
+  Eclair:
+
+  - Circular rebalancing
+
+  LND:
+
+  - Bugs fixes owing to the breaking changes on the send payment API
+
+  General:
+
+  - Navigation bug fixes from the dashboard
+
+  - Navigation to node and channel lookup from the info page
+
+  - Connect with a peer from the node lookup page
+
+
+  Full release notes can be found here: https://github.com/Ride-The-Lightning/RTL/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/7

--- a/core-lightning-rtl/umbrel-app.yml
+++ b/core-lightning-rtl/umbrel-app.yml
@@ -47,7 +47,7 @@ releaseNotes: >-
   ⚠️ Please update your Core Lightning app to the latest version in the Umbrel App store. This is critical for ensuring compatibility with this version of Ride The Lightning.
 
 
-  This release covers breaking changes from CLN 23.05, as well as a few minor UX enhancements and bug fixes
+  This release covers breaking changes from CLN 23.05, as well as a few minor UX enhancements and bug fixes:
 
   - Handle the breaking changes of the msat purge for CLN version v23.05
 

--- a/core-lightning-rtl/umbrel-app.yml
+++ b/core-lightning-rtl/umbrel-app.yml
@@ -44,29 +44,14 @@ gallery:
 path: ""
 deterministicPassword: true
 releaseNotes: >-
-  ⚠️ This release covers breaking changes from CLN 23.05, few minor UX enhancements and bug fixes
-
-  Core Lightning users should note that this update depends on cl-rest v0.10.3 and Core Lightning v23.05. If you are running any version older than 23.05, you should not upgrade to this UI. The changes are not backwards compatible with older versions of Core Lightning
+  ⚠️ Please update your Core Lightning app to the latest version in the Umbrel App store. This is critical for ensuring compatibility with this version of Ride The Lightning.
 
 
-  Core Lightning:
+  This release covers breaking changes from CLN 23.05, as well as a few minor UX enhancements and bug fixes
 
   - Handle the breaking changes of the msat purge for CLN version v23.05
 
   - Track active HTLCs on the channels page
-
-
-  Eclair:
-
-  - Circular rebalancing
-
-
-  LND:
-
-  - Bugs fixes owing to the breaking changes on the send payment API
-
-
-  General:
 
   - Navigation bug fixes from the dashboard
 


### PR DESCRIPTION
I have updated the `Core Lightning RTL` image from version `v0.13.2-beta` to `v0.14.0-beta`.

This release covers breaking changes from CLN 23.05, a few minor UX enhancements and bug fixes

⚠️ Core Lightning users should note that this update depends on cl-rest v0.10.3 and Core Lightning v23.05. If you are running any version older than 23.05, you should not upgrade to this UI. The changes are not backwards compatible with older versions of Core Lightning

Full releases can be found here: https://github.com/Ride-The-Lightning/RTL/releases