### PR TITLE
Update Jellyfin to v10.8.10

### DIFF
--- a/jellyfin/docker-compose.yml
+++ b/jellyfin/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: linuxserver/jellyfin:10.8.9@sha256:af281e1b23198076a2ce848d710e8c7ee6f96134d18c61e9c23128e3419d9e86
+    image: linuxserver/jellyfin:10.8.10@sha256:6d425c0a3bcc8a4e13e994ffd728c866c261548ff30c2b22dd095ef57a2bfbbf
     restart: on-failure
     hostname: "${DEVICE_HOSTNAME}"
     environment:

--- a/jellyfin/umbrel-app.yml
+++ b/jellyfin/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jellyfin
 category: media
 name: Jellyfin
-version: "10.8.9"
+version: "10.8.10"
 tagline: The Free Software Media System
 description: >-
   Jellyfin is the volunteer-built media solution that puts you in control of your media. Stream to any device from your own server, with no strings attached. Your media, your server, your way.
@@ -32,7 +32,17 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Updates Jellyfin from version 10.8.4 to 10.8.9. This update includes a series of stable hotfix releases that improve the overall performance, stability, and functionality of Jellyfin.
+  Updates Jellyfin from version 10.8.9 to 10.8.10. This update includes a series of stable hotfix releases that improve the overall performance, stability, and functionality of Jellyfin.
+
+  ⚠️ CRITICAL SECURITY ADVISORY: GHSA-9p5f-5x8v-x65m and GHSA-89hp-h43h-r5pq can be combined to allow remote code execution for any authenticated Jellyfin user including non-admin users. While the particular execution mechanism of the former dates to the 10.8.0 release, the latter was present for all Jellyfin releases before this point. It is thus absolutely critical for all Jellyfin administrators, regardless of version, to upgrade to this version if they allow any untrusted users and/or expose their instance to the Internet.
+
+  - Fix the canvas size for DVBSUB and DVDSUB subtitles
+
+  - Fix H.264 baseline hwaccel and enable enhanced Nvdec by default
+
+  - Some VAAPI VPP and OpenCL fixes
+
+  - Fix nvenc preset order
   
 
   Full changelogs for Jellyfin releases can be found here: https://github.com/jellyfin/jellyfin/releases

--- a/jellyfin/umbrel-app.yml
+++ b/jellyfin/umbrel-app.yml
@@ -32,9 +32,7 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Updates Jellyfin from version 10.8.9 to 10.8.10. This update includes a series of stable hotfix releases that improve the overall performance, stability, and functionality of Jellyfin.
-
-  ⚠️ CRITICAL SECURITY ADVISORY: GHSA-9p5f-5x8v-x65m and GHSA-89hp-h43h-r5pq can be combined to allow remote code execution for any authenticated Jellyfin user including non-admin users. While the particular execution mechanism of the former dates to the 10.8.0 release, the latter was present for all Jellyfin releases before this point. It is thus absolutely critical for all Jellyfin administrators, regardless of version, to upgrade to this version if they allow any untrusted users and/or expose their instance to the Internet.
+  ⚠️ CRITICAL SECURITY ADVISORY: There's a significant security issue in previous versions, where two vulnerabilities can be paired to allow any Jellyfin user, even those without admin rights, to remotely control the system. One of these issues has been around since the 10.8.0 release, while the other has been present in all versions of Jellyfin up to now. It's essential for all Jellyfin administrators to update to this version, especially if they have untrusted users or if their Jellyfin is accessible on the Internet.
 
   - Fix the canvas size for DVBSUB and DVDSUB subtitles
 

--- a/jellyfin/umbrel-app.yml
+++ b/jellyfin/umbrel-app.yml
@@ -33,14 +33,6 @@ defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
   ⚠️ CRITICAL SECURITY ADVISORY: There's a significant security issue in previous versions, where two vulnerabilities can be paired to allow any Jellyfin user, even those without admin rights, to remotely control the system. One of these issues has been around since the 10.8.0 release, while the other has been present in all versions of Jellyfin up to now. It's essential for all Jellyfin administrators to update to this version, especially if they have untrusted users or if their Jellyfin is accessible on the Internet.
-
-  - Fix the canvas size for DVBSUB and DVDSUB subtitles
-
-  - Fix H.264 baseline hwaccel and enable enhanced Nvdec by default
-
-  - Some VAAPI VPP and OpenCL fixes
-
-  - Fix nvenc preset order
   
 
   Full changelogs for Jellyfin releases can be found here: https://github.com/jellyfin/jellyfin/releases


### PR DESCRIPTION
Update Jellyfin image from `v10.8.9` to `v10.8.10`, which fixes a critical bug along with other bug fixes and improvements.

⚠️ CRITICAL SECURITY ADVISORY: [GHSA-9p5f-5x8v-x65m](https://github.com/jellyfin/jellyfin/security/advisories/GHSA-9p5f-5x8v-x65m) and [GHSA-89hp-h43h-r5pq](https://github.com/jellyfin/jellyfin-web/security/advisories/GHSA-89hp-h43h-r5pq) can be combined to allow remote code execution for any authenticated Jellyfin user including non-admin users. While the particular execution mechanism of the former dates to the 10.8.0 release, the latter was present for all Jellyfin releases before this point. It is thus absolutely critical for all Jellyfin administrators, regardless of version, to upgrade to this version if they allow any untrusted users and/or expose their instance to the Internet.