### PR TITLE
Update Immich to v1.75.2

### DIFF
--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*,/search/*"
 
   server:
-    image: ghcr.io/immich-app/immich-server:v1.74.0@sha256:6b5a532b67d0a12276062dc404499a7b0e9fc90225e3e58199554fb776329e76
+    image: ghcr.io/immich-app/immich-server:v1.75.2@sha256:ba589a25fbef5267bcaf9350c68998e46b84bfb30b27ca33560013581c1a783b
     command: [ "start.sh", "immich" ]
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
@@ -38,7 +38,7 @@ services:
     restart: on-failure
 
   microservices:
-    image: ghcr.io/immich-app/immich-server:v1.74.0@sha256:6b5a532b67d0a12276062dc404499a7b0e9fc90225e3e58199554fb776329e76
+    image: ghcr.io/immich-app/immich-server:v1.75.2@sha256:ba589a25fbef5267bcaf9350c68998e46b84bfb30b27ca33560013581c1a783b
     # This service cannot run under 1000:1000
     # And because the uploads are shared
     # We'll run immich specific services as root
@@ -54,7 +54,7 @@ services:
     restart: on-failure
 
   machine-learning:
-    image: ghcr.io/immich-app/immich-machine-learning:v1.74.0@sha256:f504a443f13a3b2cadc4f1c4ef9fdc7b40ab326fc454bb0728c027089c146f5d
+    image: ghcr.io/immich-app/immich-machine-learning:v1.75.2@sha256:045600d0b7fb1543fdff80b3cbd303a3990792130b7a3de2459d7bb0ff5ad471
     volumes:
       - ${APP_DATA_DIR}/data/model-cache:/cache
     environment:
@@ -62,7 +62,7 @@ services:
     restart: on-failure
 
   web:
-    image: ghcr.io/immich-app/immich-web:v1.74.0@sha256:ae9192bef9215b5d898878a6c4428334f95ec3d7806064e46182ccdd572bbf53
+    image: ghcr.io/immich-app/immich-web:v1.75.2@sha256:d3056701ce73e5b647861390e2bdecdae78fb6dc97b0a5539e5f1ab5069c3180
     environment:
       <<: *env
     restart: on-failure
@@ -77,7 +77,7 @@ services:
     restart: on-failure
 
   proxy:
-    image: ghcr.io/immich-app/immich-proxy:v1.74.0@sha256:409c785c69954bba3b7905f47319af2fcb0b4972d0cf6865440dcd3c73cd909d
+    image: ghcr.io/immich-app/immich-proxy:v1.75.2@sha256:fd3a26e26ac95e1af2b3e5ef9dcc0e53f0512e5198e271193e1640d2a439711b
     environment:
       IMMICH_SERVER_URL: *immich_server_url
       IMMICH_WEB_URL: *immich_web_url

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: immich
 category: files
 name: Immich
-version: "v1.74.0"
+version: "v1.75.2"
 tagline: High-performance photo and video backup solution
 description: >-
   An open-source and high-performance self-hosted backup solution for the videos and photos on your mobile device
@@ -45,20 +45,19 @@ description: >-
   
   - User-defined storage structure
 releaseNotes: >
-  ⚠️ The mobile app needs to be on at least version v1.73.0 to be fully compatible with this update.
+  ⚠️ To disable machine learning now, use IMMICH_MACHINE_LEARNING_ENABLED=false
+  (previously IMMICH_MACHINE_LEARNING_URL=false)
+
+  ⚠️ Sentence-Transformers is no longer used for CLIP models, users who set MACHINE_LEARNING_CLIP_IMAGE_MODEL or MACHINE_LEARNING_CLIP_TEXT_MODEL must migrate to one of the ViT-B models listed here, with the caveat that OpenCLIP models will require running CLIP on all images since the embeddings are incompatible.
   
 
   This update brings the following new features to Immich:
 
-  - Optimized shared link view to use virtual viewports
+  - Add the ability to use a configuration file for bootstrapping an Immich instance instead of using the administration web UI
 
-  - Add the ability to refresh metadata and regenerate thumbnails for individual photo or video
+  - Machine learning sub-jobs can now be configured via the administration web UI
   
-  - Upgrade to Flutter 3.13 and improvement of album UI/UX
-
-  - Albums can now be viewed as a list on the web
-
-  - Add the ability to set the birthday of a person
+  - Slide show mode on the web
   
   - and more!
 

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -45,10 +45,11 @@ description: >-
   
   - User-defined storage structure
 releaseNotes: >
-  ⚠️ To disable machine learning now, use IMMICH_MACHINE_LEARNING_ENABLED=false
-  (previously IMMICH_MACHINE_LEARNING_URL=false)
-
-  ⚠️ Sentence-Transformers is no longer used for CLIP models, users who set MACHINE_LEARNING_CLIP_IMAGE_MODEL or MACHINE_LEARNING_CLIP_TEXT_MODEL must migrate to one of the ViT-B models listed here, with the caveat that OpenCLIP models will require running CLIP on all images since the embeddings are incompatible.
+  ⚠️ This update includes the following breaking changes for advanced users who have modified their docker-compose.yml file:
+  
+  - To disable machine learning now, use IMMICH_MACHINE_LEARNING_ENABLED=false (previously IMMICH_MACHINE_LEARNING_URL=false)
+  
+  - Sentence-Transformers is no longer used for CLIP models, users who set MACHINE_LEARNING_CLIP_IMAGE_MODEL or MACHINE_LEARNING_CLIP_TEXT_MODEL must migrate to one of the ViT-B models listed here, with the caveat that OpenCLIP models will require running CLIP on all images since the embeddings are incompatible.
   
 
   This update brings the following new features to Immich:


### PR DESCRIPTION
I've updated image to v1.75.2 for

- `immich-server` (the same `immich-server` tag is used under `server` and `microservices`)
- `immich-machine-learning`
- `immich-web`
- `immich-proxy`

Did not change `typesense:0.24.1`, `redis:6.2-alpine` or `postgres:14-alpine`