### PR TITLE
Update docker-compose.yml to reflect umbrel-lnd.conf update

### DIFF
--- a/ride-the-lightning/docker-compose.yml
+++ b/ride-the-lightning/docker-compose.yml
@@ -28,7 +28,7 @@ services:
         # LND connection details
         LN_SERVER_URL: "https://$APP_LIGHTNING_NODE_IP:$APP_LIGHTNING_NODE_REST_PORT"
         MACAROON_PATH: "/lnd/data/chain/bitcoin/$APP_BITCOIN_NETWORK"
-        CONFIG_PATH: "/lnd/lnd.conf"
+        CONFIG_PATH: "/lnd/umbrel-lnd.conf"
 
         # Boltz
         BOLTZ_SERVER_URL: "https://ride-the-lightning_boltz_1:9003"

--- a/ride-the-lightning/umbrel-app.yml
+++ b/ride-the-lightning/umbrel-app.yml
@@ -42,6 +42,7 @@ gallery:
 releaseNotes: >-
   This is a simple hotfix release to allow users to view their LND configuration file directly in the UI by accessing the Ride The Lightning app, selecting "Node Config" from the menu, and then selecting "LND Config".
 
+
   The previous v0.14.0-beta release included bug fixes and performance improvements:
 
   - Navigation bug fixes from the dashboard

--- a/ride-the-lightning/umbrel-app.yml
+++ b/ride-the-lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ride-the-lightning
 category: bitcoin
 name: Ride The Lightning
-version: "0.14.0-beta"
+version: "0.14.0-beta-hotfix-1"
 tagline: A powerful dashboard for the Lightning Network
 description: >-
   RTL is a full function, device agnostic, web user interface to help
@@ -40,7 +40,9 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  This release updates the Ride The Lightning app to v0.14.0-beta, and includes bug fixes and performance improvements:
+  This is a simple hotfix release to allow users to view their LND configuration file directly in the UI by accessing the Ride The Lightning app, selecting "Node Config" from the menu, and then selecting "LND Config".
+
+  The previous v0.14.0-beta release included bug fixes and performance improvements:
 
   - Navigation bug fixes from the dashboard
 


### PR DESCRIPTION
The latest version of the Lightning Node app does not include an lnd.conf file by default. Instead, it has a file named umbrel-lnd.conf located at:

`/lnd/umbrel-lnd.conf`

Updating RTL to reflect this