### PR TITLE
Update Core Lightning to v23.08

### DIFF
--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -53,7 +53,7 @@ services:
         ipv4_address: ${APP_CORE_LIGHTNING_REST_IP}
 
   lightningd:
-    image: lncm/clightning:v22.11.1@sha256:e9939341ca6736566e0499db5a339b25140d6e77fb16ab202c217112f0df9b77
+    image: elementsproject/lightningd:v23.08@sha256:b00bbbbff77e1a3c8e1172777e0bc80c3af9f74c79683cf18a45636b04e29c7f
     restart: on-failure
     ports:
       - ${APP_CORE_LIGHTNING_DAEMON_PORT}:9735

--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -38,7 +38,7 @@ services:
         ipv4_address: ${APP_CORE_LIGHTNING_IP}
   
   c-lightning-rest:
-    image: saubyk/c-lightning-rest:0.9.0@sha256:00b40443f1f455378587abb37649fdb7c7b1efb43ed64bc9fe78d9bf6ffb4371
+    image: saubyk/c-lightning-rest:0.10.5@sha256:51941e2b5e82fae87a833fbee658961ca223a40d63e3f685f55c3538764652ec
     restart: on-failure
     ports:
       - ${APP_CORE_LIGHTNING_REST_PORT}:${APP_CORE_LIGHTNING_REST_PORT}

--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -45,9 +45,10 @@ services:
     environment:
       PORT: "${APP_CORE_LIGHTNING_REST_PORT}"
       PROTOCOL: "http"
+      LN_PATH: "${CORE_LIGHTNING_PATH}"
     volumes:
       - "${APP_CORE_LIGHTNING_REST_CERT_DIR}:/usr/src/app/certs"
-      - "${APP_DATA_DIR}/data/lightningd:/root/.lightning"
+      - "${APP_DATA_DIR}/data/lightningd:${CORE_LIGHTNING_PATH}"
     networks:
       default:
         ipv4_address: ${APP_CORE_LIGHTNING_REST_IP}

--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       - --bitcoin-rpcconnect=${APP_BITCOIN_NODE_IP}
       - --bitcoin-rpcuser=${APP_BITCOIN_RPC_USER}
       - --bitcoin-rpcpassword=${APP_BITCOIN_RPC_PASS}
+      - --lightning-dir=${CORE_LIGHTNING_PATH}
       - --proxy=${TOR_PROXY_IP}:${TOR_PROXY_PORT}
       - --bind-addr=${APP_CORE_LIGHTNING_DAEMON_IP}:9735
       - --addr=statictor:${TOR_PROXY_IP}:29051
@@ -70,9 +71,9 @@ services:
       - --database-upgrade=true
       - --experimental-websocket-port=${APP_CORE_LIGHTNING_WEBSOCKET_PORT}
       - --experimental-offers
-      #- --grpc-port=${APP_CORE_LIGHTNING_DAEMON_GRPC_PORT}
+      - --grpc-port=${APP_CORE_LIGHTNING_DAEMON_GRPC_PORT}
     volumes:
-      - "${APP_DATA_DIR}/data/lightningd:/data/.lightning"
+      - "${APP_DATA_DIR}/data/lightningd:${CORE_LIGHTNING_PATH}"
     networks:
       default:
         ipv4_address: ${APP_CORE_LIGHTNING_DAEMON_IP}

--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - --experimental-offers
       #- --grpc-port=${APP_CORE_LIGHTNING_DAEMON_GRPC_PORT}
     volumes:
-      - "${APP_DATA_DIR}/data/lightningd:/root/.lightning"
+      - "${APP_DATA_DIR}/data/lightningd:/data/.lightning"
     networks:
       default:
         ipv4_address: ${APP_CORE_LIGHTNING_DAEMON_IP}

--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_CORE_LIGHTNING_PORT
 
   app:
-    image: ghcr.io/elementsproject/cln-application:0.0.3@sha256:05595731a98a17aff6603b9ad35aaa17825bf1e51dd22da409c37f9fce5d2b2e
+    image: ghcr.io/elementsproject/cln-application:0.0.4@sha256:5c4c930c0bd4b71de202b6166affd76c080a66bd7021877ffaa471207470bbfa
     command: npm run start
     restart: on-failure
     volumes:
@@ -15,6 +15,7 @@ services:
       - ${APP_DATA_DIR}/data/lightningd:${APP_CORE_LIGHTNING_DATA_DIR}
       - ${APP_CORE_LIGHTNING_REST_CERT_DIR}:${APP_REST_CERT_VOLUME_DIR}
     environment:
+      SINGLE_SIGN_ON: "true"
       APP_CORE_LIGHTNING_IP: ${APP_CORE_LIGHTNING_IP}
       APP_CORE_LIGHTNING_PORT: ${APP_CORE_LIGHTNING_PORT}
       APP_CORE_LIGHTNING_BITCOIN_NETWORK: ${APP_CORE_LIGHTNING_BITCOIN_NETWORK}

--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - --experimental-offers
       #- --grpc-port=${APP_CORE_LIGHTNING_DAEMON_GRPC_PORT}
     volumes:
-      - "${APP_DATA_DIR}/data/lightningd:/data/.lightning"
+      - "${APP_DATA_DIR}/data/lightningd:/root/.lightning"
     networks:
       default:
         ipv4_address: ${APP_CORE_LIGHTNING_DAEMON_IP}

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: core-lightning
 category: bitcoin
 name: Core Lightning
-version: "22.11.1-ui0.0.3"
+version: "23.08-ui0.0.3"
 tagline: Run your personal Core Lightning node
 description: >-
   Get started with the Lightning network today with Core Lightning - a
@@ -32,23 +32,66 @@ defaultPassword: ""
 submitter: Blockstream
 submission: https://github.com/getumbrel/umbrel-apps/pull/475
 releaseNotes: >-
-  This update brings a stunning new look and intuitive UI, maintained officially by Blockstream
-  
-  
-  It includes two bug fixes:
-
-  - Invalid rune error thrown on some slower machines.
-  
-  - Undefined msat fields shown as NaN will be 0.
+  This release brings updates to the underlying c-lightning-REST and lightningd components of the Core Lightning app.
 
 
-  This version also includes some enhanced features such as:
+  c-lightning-REST:
+
+  - plugin.js renamed to clrest.js (required for reckless plugin manager)
   
-  - Updates for CLN v23.05 msat migration
-  
-  - Add Offers list view
-  
-  - Add Tor option for lnmessage on connect wallet
+  - allow an option to specify an IP address to bind with the server
+
+  - bug fix for error on generating new certificates
+
+  - bug fix for websocket notifications
+
+  - setchannelfee rpc has been replaced by setchannel (no impact to the developers as REST API signature remains unchanged)
+
+  - fixed the issue of server failing to initialize if IPV6 is disabled
+
+  - pay api updated with the latest params
+
+  - the msat purge
+
+  - new API endpoint for listpeerchannels rpc
+
+  - issue in the remote balance calculation fixed
+
+  - issue in the pending balance calculation fixed
+
+  - version compatibility check to address BTCPayserver forked version
+
+  - all available filtering options (invoice, payment hash & offer) for listInvoices api
+
+  - all CLN filtering options (payment hash & status) for listPays and listPayments apis
 
 
-  Full release notes are available at: https://github.com/ElementsProject/lightning/releases/tag/v22.11.1
+  Full c-lightning-REST release notes are available at https://github.com/Ride-The-Lightning/c-lightning-REST/releases
+
+
+  lightningd:
+
+  - NEW experimental feature: peer storage - back up your encrypted emergency channel backup with your peers
+
+  - access a remote node with a cli flag: lightning-cli --commando=peerid:rune
+
+  - migrate all wrapped segwit UTXOs to native segwit with upgradewallet RPC.
+
+  - large nodes are more performant.
+
+  - pay requiring a full description (not just a hash) has been pushed back, since it broke BTCPayServer and lnbits. It's still deprecated, and we will work with them to try to achieve this.
+
+  - documentation now available for Offers invoicerequest, disableinvoicerequest and listinvoicerequest commands.
+
+  - NEW commando-blacklist and commando-listrunes RPCs for blacklisting and listing stored runes.
+
+  - NEW feerates added 2 new options as "minimum" and NN"blocks". Use explicit block counts or slow/normal/urgent/minimum.
+
+  - listclosedchannels RPC to show old, dead channels.
+
+  - reckless added support for node.js plugin installation and for networks beyond bitcoin and regtest.
+
+  - spending unilateral close transactions now use dynamic fees based on deadlines (and RBF), instead of fixed fees.
+
+
+  Full lightningd release notes are available at https://github.com/ElementsProject/lightning/releases

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -34,6 +34,15 @@ submission: https://github.com/getumbrel/umbrel-apps/pull/475
 releaseNotes: >-
   This release brings updates to the underlying c-lightning-REST and lightningd components of the Core Lightning app.
 
+  cln-application:
+
+  - bug fix by filtering lnmessage's pubkey from peers list
+
+  - added support for more fiat currencies
+
+
+  Full cln-application release notes are available at https://github.com/ElementsProject/cln-application/releases/tag/v0.0.4
+
 
   c-lightning-REST:
 

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -32,9 +32,10 @@ defaultPassword: ""
 submitter: Blockstream
 submission: https://github.com/getumbrel/umbrel-apps/pull/475
 releaseNotes: >-
-  This release brings updates to the underlying c-lightning-REST and lightningd components of the Core Lightning app.
+  This release updates the user interface, as well as the underlying c-lightning-REST and lightningd components of the Core Lightning app.
 
-  cln-application:
+
+  cln-application v0.0.4 (user interface):
 
   - bug fix by filtering lnmessage's pubkey from peers list
 
@@ -44,7 +45,7 @@ releaseNotes: >-
   Full cln-application release notes are available at https://github.com/ElementsProject/cln-application/releases/tag/v0.0.4
 
 
-  c-lightning-REST:
+  c-lightning-REST v0.10.5:
 
   - plugin.js renamed to clrest.js (required for reckless plugin manager)
   
@@ -78,7 +79,7 @@ releaseNotes: >-
   Full c-lightning-REST release notes are available at https://github.com/Ride-The-Lightning/c-lightning-REST/releases
 
 
-  lightningd:
+  lightningd v23.08:
 
   - NEW experimental feature: peer storage - back up your encrypted emergency channel backup with your peers
 

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: core-lightning
 category: bitcoin
 name: Core Lightning
-version: "23.08-ui0.0.3"
+version: "23.08"
 tagline: Run your personal Core Lightning node
 description: >-
   Get started with the Lightning network today with Core Lightning - a


### PR DESCRIPTION
This PR updates c-lightning-REST to [v0.10.5](https://github.com/Ride-The-Lightning/c-lightning-REST/releases/tag/v0.10.5) and lightningd to [v23.08](https://github.com/ElementsProject/lightning/releases/tag/v23.08). 

No change has been made to the frontend cln-application. Relevant context from @ShahanaFarooqui here: https://github.com/getumbrel/umbrel-apps/pull/748#issuecomment-1696747582

This still needs to be tested.