### PR TITLE
feat: bump n8n to 1.4.0

### DIFF
--- a/n8n/docker-compose.yml
+++ b/n8n/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       PROXY_AUTH_WHITELIST: "/webhook-test/*,/webhook/*"
 
   server:
-    image: n8nio/n8n:1.4.0@sha256:172abfa803047823796a7af811876a72ef8c60d5656ebeafb653703141ca1d1e
+    image: n8nio/n8n:1.4.0@sha256:04796ef0bf9ea2b34135ef4f304dad853489bec7b26a3726d3f97df13175bf5c
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/home/node/.n8n

--- a/n8n/docker-compose.yml
+++ b/n8n/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       PROXY_AUTH_WHITELIST: "/webhook-test/*,/webhook/*"
 
   server:
-    image: n8nio/n8n:0.234.1@sha256:b00e39ced253d0a5d6f234a21e7d8991dc795a99f13f32db479448087a14ff5a
+    image: n8nio/n8n:1.4.0@sha256:172abfa803047823796a7af811876a72ef8c60d5656ebeafb653703141ca1d1e
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/home/node/.n8n

--- a/n8n/umbrel-app.yml
+++ b/n8n/umbrel-app.yml
@@ -2,12 +2,36 @@ manifestVersion: 1
 id: n8n
 category: automation
 name: n8n
-version: "0.234.1"
+version: "1.4.0"
 releaseNotes: >-
-  This update includes new features, bug fixes, and performance improvements.
+  Bug Fixes
+  - core: Add recoveryInProgress flag file
+  - core: Fix continueOnFail for expression error in Set
+  - core: Fix import:workflow command
+  - core: Replace throw with warning when deactivating a non-active workflow
+  - core: Set up OAuth2 cred test
+  - editor: Do not flag dynamic load options issue on expression
+  - editor: Ensure community node install button tracks user agreement
+  - editor: Fix parsing for single quoted resolvables
+  - editor: Fix Remove all fields not removing values in resource mapper
+  - editor: Prevent Code node linter from erroring on null parse
+  - Google Sheets Node: Fix short sheet name interpreted as range
+  - Google Sheets Trigger Node: Support sheet names with non-latin characters
+  - GraphQL Node: Improve error handling
+  - Mautic Node: Fix issue with owner not being set correctly
+  - Salesforce Node: Fix Account update owner operation
+  - Shopify Node: Fix pagination when using options
+  - Webhook Node: Backward compatible form-data parsing for non-array fields
+  
+  Features
+  - core: Add a warning to error workflows that cannot be started due to permission or settings (#6961) (67b88f7)
+  - core: Add support for ready hooks, and credentials overwrite endpoint in workers (#6954) (8f8a1de)
+  - editor: Show banner for non-production licenses (#6943) (413570c)
+  - Remove PostHog event calls (#6915) (270946a)
+  - Send Email Node: Add support for sending text and html email simultaneously (#6978) (3860d41)
 
 
-  Full details for changes made since version 0.212.0 can be found at https://github.com/n8n-io/n8n/releases
+  Full details for changes made since version 1.4.0 can be found at https://github.com/n8n-io/n8n/releases/tag/n8n%401.4.0
 tagline: Build complex workflows, really fast
 description: >-
   n8n is an extendable workflow automation tool. With a fair-code distribution model, n8n will always have visible source code, 

--- a/n8n/umbrel-app.yml
+++ b/n8n/umbrel-app.yml
@@ -5,29 +5,52 @@ name: n8n
 version: "1.4.0"
 releaseNotes: >-
   Bug Fixes
+
   - core: Add recoveryInProgress flag file
+
   - core: Fix continueOnFail for expression error in Set
+
   - core: Fix import:workflow command
+
   - core: Replace throw with warning when deactivating a non-active workflow
+
   - core: Set up OAuth2 cred test
+
   - editor: Do not flag dynamic load options issue on expression
+
   - editor: Ensure community node install button tracks user agreement
+
   - editor: Fix parsing for single quoted resolvables
+
   - editor: Fix Remove all fields not removing values in resource mapper
+
   - editor: Prevent Code node linter from erroring on null parse
+  
   - Google Sheets Node: Fix short sheet name interpreted as range
+
   - Google Sheets Trigger Node: Support sheet names with non-latin characters
+
   - GraphQL Node: Improve error handling
+
   - Mautic Node: Fix issue with owner not being set correctly
+
   - Salesforce Node: Fix Account update owner operation
+
   - Shopify Node: Fix pagination when using options
+
   - Webhook Node: Backward compatible form-data parsing for non-array fields
   
+
   Features
+
   - core: Add a warning to error workflows that cannot be started due to permission or settings (#6961) (67b88f7)
+
   - core: Add support for ready hooks, and credentials overwrite endpoint in workers (#6954) (8f8a1de)
+
   - editor: Show banner for non-production licenses (#6943) (413570c)
+
   - Remove PostHog event calls (#6915) (270946a)
+  
   - Send Email Node: Add support for sending text and html email simultaneously (#6978) (3860d41)
 
 


### PR DESCRIPTION
Update N8N version to 1.4.0.
This is the latest stable version.
There are many new features from version 1 and this update is important.

[N8N 1.4.0 change log](https://github.com/n8n-io/n8n/releases/tag/n8n%401.4.0)