### PR TITLE
Add Portainer

### DIFF
--- a/portainer/default-password
+++ b/portainer/default-password
@@ -1,0 +1,1 @@
+changeme

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -28,7 +28,7 @@ services:
 
   portainer:
     image: portainer/portainer-ce:2.19.0
-    command: --admin-password-file=/default-password
+    command: --host unix:///var/run/docker.sock --admin-password-file=/default-password
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/default-password:/default-password

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: portainer_portainer_1
+      APP_PORT: 9000
+
+  docker:
+    image: docker:24.0.5-dind
+    privileged: true
+    network_mode: host
+    environment:
+      DOCKER_ENSURE_BRIDGE: "dind0:10.32.0.1/16"
+    entrypoint: /entrypoint.sh
+    command: >
+      dockerd
+        --bridge dind0
+        --data-root /data/data
+        --exec-root /data/exec
+        --host unix:///data/docker.sock
+        --pidfile /data/docker.pid
+    volumes:
+      - ./entrypoint.sh:/entrypoint.sh
+      - ./data/docker:/data
+
+  portainer:
+    image: portainer/portainer-ce:2.19.0
+    command: --bind 9000 --host unix:///docker-data/docker.sock
+    volumes:
+      - ./data/portainer:/data
+      - ./data/docker:/docker-data

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -26,7 +26,9 @@ services:
 
   portainer:
     image: portainer/portainer-ce:2.19.0
-    command: --bind :9000 --host unix:///docker-data/docker.sock
+    environment:
+      DOCKER_HOST: unix:///docker-data/docker.sock
+    # command: --bind :9000 --host unix:///docker-data/docker.sock
     volumes:
       - ${APP_DATA_DIR}/data/portainer:/data
       - ${APP_DATA_DIR}/data/docker:/docker-data

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   portainer:
     image: portainer/portainer-ce:2.19.0
-    command: --admin-password-file=/default-password
+    command: --host unix:///var/run/docker.sock --admin-password-file=/default-password
     volumes:
       - ${APP_DATA_DIR}/default-password:/default-password
       - ${APP_DATA_DIR}/data/portainer:/data

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -26,9 +26,6 @@ services:
 
   portainer:
     image: portainer/portainer-ce:2.19.0
-    environment:
-      DOCKER_HOST: unix:///docker-data/docker.sock
-    # command: --bind :9000 --host unix:///docker-data/docker.sock
     volumes:
       - ${APP_DATA_DIR}/data/portainer:/data
-      - ${APP_DATA_DIR}/data/docker:/docker-data
+      - ${APP_DATA_DIR}/data/docker:/var/run

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -26,6 +26,8 @@ services:
 
   portainer:
     image: portainer/portainer-ce:2.19.0
+    command: --admin-password-file=/default-password
     volumes:
+      - ${APP_DATA_DIR}/default-password:/default-password
       - ${APP_DATA_DIR}/data/portainer:/data
       - ${APP_DATA_DIR}/data/docker:/var/run

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   portainer:
     image: portainer/portainer-ce:2.19.0
-    command: --bind 9000 --host unix:///docker-data/docker.sock
+    command: --bind :9000 --host unix:///docker-data/docker.sock
     volumes:
       - ${APP_DATA_DIR}/data/portainer:/data
       - ${APP_DATA_DIR}/data/docker:/docker-data

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     image: docker:24.0.5-dind
     privileged: true
     network_mode: host
+    stop_grace_period: 1m
     environment:
       DOCKER_ENSURE_BRIDGE: "dind0:10.32.0.1/16"
     entrypoint: /entrypoint.sh

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     privileged: true
     network_mode: host
     stop_grace_period: 1m
+    restart: on-failure
     environment:
       DOCKER_ENSURE_BRIDGE: "dind0:10.32.0.1/16"
     entrypoint: /entrypoint.sh
@@ -28,6 +29,7 @@ services:
   portainer:
     image: portainer/portainer-ce:2.19.0
     command: --admin-password-file=/default-password
+    restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/default-password:/default-password
       - ${APP_DATA_DIR}/data/portainer:/data

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -21,12 +21,12 @@ services:
         --host unix:///data/docker.sock
         --pidfile /data/docker.pid
     volumes:
-      - ./entrypoint.sh:/entrypoint.sh
-      - ./data/docker:/data
+      - ${APP_DATA_DIR}/entrypoint.sh:/entrypoint.sh
+      - ${APP_DATA_DIR}/data/docker:/data
 
   portainer:
     image: portainer/portainer-ce:2.19.0
     command: --bind 9000 --host unix:///docker-data/docker.sock
     volumes:
-      - ./data/portainer:/data
-      - ./data/docker:/docker-data
+      - ${APP_DATA_DIR}/data/portainer:/data
+      - ${APP_DATA_DIR}/data/docker:/docker-data

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   portainer:
     image: portainer/portainer-ce:2.19.0
-    command: --host unix:///var/run/docker.sock --admin-password-file=/default-password
+    command: --admin-password-file=/default-password
     volumes:
       - ${APP_DATA_DIR}/default-password:/default-password
       - ${APP_DATA_DIR}/data/portainer:/data

--- a/portainer/entrypoint.sh
+++ b/portainer/entrypoint.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# Remove docker pidfile if it exists to ensure Docker can start up after a bad shutdown
+pidfile="/var/run/docker.pid"
+if [[ -f "${pidfile}" ]]
+then
+    rm -f "${pidfile}"
+fi
+
 # Use nftables as the backend for iptables
 for command in iptables iptables-restore iptables-restore-translate iptables-save iptables-translate
 do

--- a/portainer/entrypoint.sh
+++ b/portainer/entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Use nftables as the backend for iptables
+for command in iptables iptables-restore iptables-restore-translate iptables-save iptables-translate
+do
+    ln -sf /sbin/xtables-nft-multi /sbin/$command
+done
+
+# Ensure that a bridge exists with the given name
+ensure_bridge_exists() {
+    local name="${1}"
+    local ip_range="${2}"
+
+    # Check if the bridge already exists
+    if ip link show "${name}" &>/dev/null
+    then
+        echo "Bridge '${name}' already exists. Skipping creation."
+        ip addr show "${name}"
+        return
+    fi
+
+    echo "Bridge '${name}' does not exist. Creating..."
+    ip link add "${name}" type bridge
+    ip addr add "${ip_range}" dev "${name}"
+    ip link set "${name}" up
+
+    echo "Bridge '${name}' is now up with IP range '${ip_range}'."
+    ip addr show "${name}"
+}
+
+if [[ "${DOCKER_ENSURE_BRIDGE}" != "" ]]
+then
+    bridge="${DOCKER_ENSURE_BRIDGE%%:*}"
+    ip_range="${DOCKER_ENSURE_BRIDGE#*:}"
+    ensure_bridge_exists "${bridge}" "${ip_range}"
+fi
+
+exec dockerd-entrypoint.sh $@

--- a/portainer/entrypoint.sh
+++ b/portainer/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# This hack can be removed if https://github.com/docker-library/docker/pull/444 gets merged.
+
 # Remove docker pidfile if it exists to ensure Docker can start up after a bad shutdown
 pidfile="/var/run/docker.pid"
 if [[ -f "${pidfile}" ]]

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -3,7 +3,7 @@ id: portainer
 category: developer
 name: Portainer
 version: "2.19.0"
-tagline: Making Docker easy
+tagline: Run custom Docker containers on your Umbrel
 description: >-
   Portainer Community Edition is a lightweight service delivery platform for containerized applications that can be used to manage Docker, Swarm, Kubernetes and ACI environments.
   It is designed to be as simple to deploy as it is to use. The application allows you to manage all your orchestrator resources (containers, images, volumes, networks and more)

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -38,6 +38,7 @@ gallery:
 path: ""
 defaultUsername: "admin"
 defaultPassword: "changeme"
-releaseNotes:
+releaseNotes: ""
+developer: Portainer
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/...

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -5,24 +5,39 @@ name: Portainer
 version: "2.19.0"
 tagline: Run custom Docker containers on your Umbrel
 description: >-
-  Portainer Community Edition is a lightweight service delivery platform for containerized applications that can be used to manage Docker, Swarm, Kubernetes and ACI environments.
-  It is designed to be as simple to deploy as it is to use. The application allows you to manage all your orchestrator resources (containers, images, volumes, networks and more)
-  through a ‘smart’ GUI and/or an extensive API.
+  ⚠️ Make sure to only use named Docker volumes for your stacks and containers. Data in bind-mounted volumes
+  will be lost when the Portainer app is restarted or updated.
 
 
-  🛠️ Best Practices for Using Portainer on Umbrel:
+  ⚠️ Watch out for port conflicts between your custom Docker containers and your umbrelOS apps.
 
 
-  PORT MANAGEMENT: Be aware of potential port clashes with umbrelOS containers, apps you have installed from the Umbrel App Store or Community App Stores, and any apps you go to install in the future.
+  Portainer is the ultimate Docker management solution that simplifies running Docker containers and Docker Compose
+  setups on your Umbrel, putting comprehensive control at your fingertips.
 
 
-  DATA PERSISTENCE: To persist data you must use named Docker volumes. Avoid bind mounts as they will result in data loss when the Portainer app is restarted.
+  Portainer provides seamless container management, allowing you to efficiently monitor, start, stop, and
+  modify containers, networks, volumes, and images. You can also deploy multi-container applications using Docker Compose
+  with ease.
 
 
-  CONTAINER RESTART POLICY: Set your containers to "unless-stopped" or "always" restart policies. This will allow your containers to restart automatically when the Portainer app is restarted.
+  🛠️ Portainer on Umbrel is for power users, follow these best practices to avoid issues:
 
 
-  WEB ACCESS TO CONTAINERS: Access your running containers in your browser via umbrel.local:<mapped-port>. For example, for a container with a web UI running on port 4545, navigate to umbrel.local:4545.
+  1. Data persistence: Make sure to only used named Docker volumes for your stacks and containers. Data in bind-mounted
+  volumes will be lost when the Portainer app is restarted or updated.
+
+
+  2. Port management: Watch out for potential port conflicts between your custom containers and umbrelOS' service containers,
+  apps you have installed from the Umbrel App Store or Community App Stores, and any apps you go to install in the future.
+
+
+  3. Container restart policy: Set your containers to "unless-stopped" or "always" restart policies. This will allow your containers
+  to restart automatically when the Portainer app is restarted or updated.
+
+
+  4. Web access to containers: Access your custom containers in your browser at umbrel.local:<mapped-port>. For example, for a container
+  with a web UI running on port 4545, navigate to umbrel.local:4545 to access it.
 website: https://portainer.io
 dependencies: []
 repo: https://github.com/portainer/portainer

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -17,8 +17,8 @@ gallery:
   - 2.jpg
   - 3.jpg
 path: ""
-defaultUsername: ""
-defaultPassword: ""
+defaultUsername: "admin"
+defaultPassword: "changeme"
 releaseNotes:
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/...

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -1,0 +1,24 @@
+manifestVersion: 1
+id: portainer
+category: developer
+name: Portainer
+version: "2.19.0"
+tagline: Making Docker easy
+description: >-
+  Portainer Community Edition is a lightweight service delivery platform for containerized applications that can be used to manage Docker, Swarm, Kubernetes and ACI environments. It is designed to be as simple to deploy as it is to use. The application allows you to manage all your orchestrator resources (containers, images, volumes, networks and more) through a ‘smart’ GUI and/or an extensive API.
+developer: Portainer.io
+website: https://portainer.io
+dependencies: []
+repo: https://github.com/portainer/portainer
+support: https://github.com/portainer/portainer/issues
+port: 9000
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+releaseNotes:
+submitter: Umbrel
+submission: https://github.com/getumbrel/umbrel-apps/pull/...

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -12,13 +12,18 @@ description: >-
 
   Getting Started with Portainer on Umbrel:
 
-  1. INITIAL SETUP: After installation, reset the default password and log back in to Portainer. Once logged in, click "Get Started" and then connect to the existing "local" docker environment.
 
-  2. PORT MANAGEMENT: Be aware of potential port clashes with apps already installed from the Umbrel App Store or Community App Stores, or those you plan to install in the future.
+  1. INITIAL SETUP: After installation, open Portainer, reset the default password, and log back in to the app. Once logged in, click "Get Started" and then connect to the existing "local" docker environment.
+
+
+  2. PORT MANAGEMENT: Be aware of potential port clashes with umbrelOS containers, apps you have installed from the Umbrel App Store or Community App Stores, and any apps you go to install in the future.
+
 
   3. DATA PERSISTENCE: To persist data you must use named Docker volumes. Avoid bind mounts as they will result in data loss when the Portainer app is restarted.
 
-  4. CONTAINER RESTART POLICY: Set your containers to "unless-stopped" or "always" restart policies. This will allow your containers to start automatically after the Portainer app is restarted.
+
+  4. CONTAINER RESTART POLICY: Set your containers to "unless-stopped" or "always" restart policies. This will allow your containers to restart automatically when the Portainer app is restarted.
+
 
   5. WEB ACCESS TO CONTAINERS: Access your running containers in your browser via umbrel.local/<mapped-port>. For example, for a container with a web UI running on port 4545, navigate to umbrel.local/4545.
 website: https://portainer.io

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -53,4 +53,4 @@ defaultPassword: "changeme"
 releaseNotes: ""
 developer: Portainer
 submitter: Umbrel
-submission: https://github.com/getumbrel/umbrel-apps/pull/...
+submission: https://github.com/getumbrel/umbrel-apps/pull/774

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -5,8 +5,22 @@ name: Portainer
 version: "2.19.0"
 tagline: Making Docker easy
 description: >-
-  Portainer Community Edition is a lightweight service delivery platform for containerized applications that can be used to manage Docker, Swarm, Kubernetes and ACI environments. It is designed to be as simple to deploy as it is to use. The application allows you to manage all your orchestrator resources (containers, images, volumes, networks and more) through a ‘smart’ GUI and/or an extensive API.
-developer: Portainer.io
+  Portainer Community Edition is a lightweight service delivery platform for containerized applications that can be used to manage Docker, Swarm, Kubernetes and ACI environments.
+  It is designed to be as simple to deploy as it is to use. The application allows you to manage all your orchestrator resources (containers, images, volumes, networks and more)
+  through a ‘smart’ GUI and/or an extensive API.
+
+
+  Getting Started with Portainer on Umbrel:
+
+  1. INITIAL SETUP: After installation, reset the default password and log back in to Portainer. Once logged in, click "Get Started" and then connect to the existing "local" docker environment.
+
+  2. PORT MANAGEMENT: Be aware of potential port clashes with apps already installed from the Umbrel App Store or Community App Stores, or those you plan to install in the future.
+
+  3. DATA PERSISTENCE: To persist data you must use named Docker volumes. Avoid bind mounts as they will result in data loss when the Portainer app is restarted.
+
+  4. CONTAINER RESTART POLICY: Set your containers to "unless-stopped" or "always" restart policies. This will allow your containers to start automatically after the Portainer app is restarted.
+
+  5. WEB ACCESS TO CONTAINERS: Access your running containers in your browser via umbrel.local/<mapped-port>. For example, for a container with a web UI running on port 4545, navigate to umbrel.local/4545.
 website: https://portainer.io
 dependencies: []
 repo: https://github.com/portainer/portainer

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -22,7 +22,7 @@ description: >-
   CONTAINER RESTART POLICY: Set your containers to "unless-stopped" or "always" restart policies. This will allow your containers to restart automatically when the Portainer app is restarted.
 
 
-  WEB ACCESS TO CONTAINERS: Access your running containers in your browser via umbrel.local/<mapped-port>. For example, for a container with a web UI running on port 4545, navigate to umbrel.local/4545.
+  WEB ACCESS TO CONTAINERS: Access your running containers in your browser via umbrel.local:<mapped-port>. For example, for a container with a web UI running on port 4545, navigate to umbrel.local:4545.
 website: https://portainer.io
 dependencies: []
 repo: https://github.com/portainer/portainer

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -10,22 +10,19 @@ description: >-
   through a ‘smart’ GUI and/or an extensive API.
 
 
-  Getting Started with Portainer on Umbrel:
+  🛠️ Best Practices for Using Portainer on Umbrel:
 
 
-  1. INITIAL SETUP: After installation, open Portainer, reset the default password, and log back in to the app. Once logged in, click "Get Started" and then connect to the existing "local" docker environment.
+  PORT MANAGEMENT: Be aware of potential port clashes with umbrelOS containers, apps you have installed from the Umbrel App Store or Community App Stores, and any apps you go to install in the future.
 
 
-  2. PORT MANAGEMENT: Be aware of potential port clashes with umbrelOS containers, apps you have installed from the Umbrel App Store or Community App Stores, and any apps you go to install in the future.
+  DATA PERSISTENCE: To persist data you must use named Docker volumes. Avoid bind mounts as they will result in data loss when the Portainer app is restarted.
 
 
-  3. DATA PERSISTENCE: To persist data you must use named Docker volumes. Avoid bind mounts as they will result in data loss when the Portainer app is restarted.
+  CONTAINER RESTART POLICY: Set your containers to "unless-stopped" or "always" restart policies. This will allow your containers to restart automatically when the Portainer app is restarted.
 
 
-  4. CONTAINER RESTART POLICY: Set your containers to "unless-stopped" or "always" restart policies. This will allow your containers to restart automatically when the Portainer app is restarted.
-
-
-  5. WEB ACCESS TO CONTAINERS: Access your running containers in your browser via umbrel.local/<mapped-port>. For example, for a container with a web UI running on port 4545, navigate to umbrel.local/4545.
+  WEB ACCESS TO CONTAINERS: Access your running containers in your browser via umbrel.local/<mapped-port>. For example, for a container with a web UI running on port 4545, navigate to umbrel.local/4545.
 website: https://portainer.io
 dependencies: []
 repo: https://github.com/portainer/portainer


### PR DESCRIPTION
Portainer on Umbrel has been configured for power users aiming to run custom applications on umbrelOS. Portainer is not interfacing directly with the primary host's Docker instance active on Umbrel. Instead, it communicates with a Docker-in-Docker (DinD) service.

Follow these best practices to avoid issues:


  1. Data persistence: Make sure to only used named Docker volumes for your stacks and containers. Data in bind-mounted volumes will be lost when the Portainer app is restarted or updated.


  2. Port management: Watch out for potential port conflicts between your custom containers and umbrelOS' service containers, apps you have installed from the Umbrel App Store or Community App Stores, and any apps you go to install in the future.


  3. Container restart policy: Set your containers to "unless-stopped" or "always" restart policies. This will allow your containers to restart automatically when the Portainer app is restarted or updated.


  4. Web access to containers: Access your custom containers in your browser at umbrel.local:<mapped-port>. For example, for a container with a web UI running on port 4545, navigate to umbrel.local:4545 to access it.
