### PR TITLE
Update Librespeed Web UI port

### DIFF
--- a/librespeed/hooks/post-update
+++ b/librespeed/hooks/post-update
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# restart app so that new port number is sourced correctly
+"${UMBREL_ROOT}/scripts/app" restart "${APP_ID}" &

--- a/librespeed/umbrel-app.yml
+++ b/librespeed/umbrel-app.yml
@@ -11,7 +11,7 @@ website: https://librespeed.org/
 dependencies: []
 repo: https://github.com/librespeed/speedtest
 support: https://github.com/librespeed/speedtest/issues
-port: 3009
+port: 3011
 gallery:
   - 1.jpg
   - 2.jpg

--- a/librespeed/umbrel-app.yml
+++ b/librespeed/umbrel-app.yml
@@ -2,10 +2,12 @@ manifestVersion: 1
 id: librespeed
 category: networking
 name: LibreSpeed
-version: "0.0.1"
+version: "5.2.5"
 tagline: Free and open source speedtest
 description: >-
   Free and open source speedtest. Measure internet speeds between your devices and your Umbrel.
+releaseNotes: >-
+  Librespeed now runs on port 3011 to avoid a port conflict with the Samourai Server app. No other changes have been made to Librespeed.
 developer: LibreSpeed
 website: https://librespeed.org/
 dependencies: []


### PR DESCRIPTION
Updates Librespeed's web ui port from 3009 to 3011 to avoid a port conflict with [Samourai Server's DOJO port](https://github.com/getumbrel/umbrel-apps/blob/0f7a8dd951e6dc165205b66c476bdee3a3ef9389/samourai-server/docker-compose.yml#L141).

Added a post-update hook to source updated port number correctly on update.