### PR TITLE
Update Jam to v0.1.6

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   web:
-    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.5-clientserver-v0.9.9@sha256:c8bf944000eb8b3b5666ac037440a4904f9c3baa8665c52081a9e5092d6bd275
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.6-clientserver-v0.9.10@sha256:92f80ceab43eea86fda4b16a90f478069e0cdd85b04bc97e25786764f4b8c4d1
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: jam
 category: bitcoin
 name: Jam
-version: "0.1.5"
+version: "0.1.6"
 tagline: Your sats. Your privacy. Your profit.
 description: >-
   Jam is a user-interface for JoinMarket with focus on
@@ -13,17 +13,15 @@ description: >-
 
   The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 releaseNotes: >-
-  - Fees: Allow min tx fee of 1sat/vbyte
+  - Import: Ability to import existing wallets
 
-  - Fees: Allow input for relative fee limit of 0.0001%
+  - Fees: Fee estimations and limits are now shown before sending collaborative transactions
 
-  - Bonds: Correctly display success screen after unlocking fb
+  - New translations: Chinese, Italian, Brazilian Portuguese, German
 
-  - Sweep: Display success screen after a scheduler run completes
+  - UI: Frozen balances are now shown at the jar level
 
-  - Coin Control: Quick freeze/unfreeze utxos
-
-  - Coin Control: Show jar total amount in detail view
+  - UI: Various interface enhancements and consistent styling
 developer: JoinMarket WebUI Org.
 website: https://jamapp.org
 dependencies:


### PR DESCRIPTION
This version includes:
- Jam: [v0.1.6](https://github.com/joinmarket-webui/jam/releases/tag/v0.1.6)
- joinmarket-clientserver: [v0.9.10](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.10)

All notable changes of the UI can be seen in the [Jam v0.1.6 changelog](https://github.com/joinmarket-webui/jam/blob/v0.1.6/CHANGELOG.md)