### PR TITLE
Update Immich to v1.79.1

### DIFF
--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*,/search/*"
 
   server:
-    image: ghcr.io/immich-app/immich-server:v1.77.0@sha256:c16d7a36feca397b6b762cf553c2d552808ee38d1234e5b54d1be6cffe10e0b4
+    image: ghcr.io/immich-app/immich-server:v1.79.1@sha256:38c3c0a8fd67aa04ee580b3a20d4a6dd7cd84df3f5387eadebc0a61ba0751518
     command: [ "start.sh", "immich" ]
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
@@ -38,7 +38,7 @@ services:
     restart: on-failure
 
   microservices:
-    image: ghcr.io/immich-app/immich-server:v1.77.0@sha256:c16d7a36feca397b6b762cf553c2d552808ee38d1234e5b54d1be6cffe10e0b4
+    image: ghcr.io/immich-app/immich-server:v1.79.1@sha256:38c3c0a8fd67aa04ee580b3a20d4a6dd7cd84df3f5387eadebc0a61ba0751518
     # This service cannot run under 1000:1000
     # And because the uploads are shared
     # We'll run immich specific services as root
@@ -54,7 +54,7 @@ services:
     restart: on-failure
 
   machine-learning:
-    image: ghcr.io/immich-app/immich-machine-learning:v1.77.0@sha256:9cceba21035ff1bd82b3a6956eb48f2349e28ffee57bd4f82c5fa99488ae266c
+    image: ghcr.io/immich-app/immich-machine-learning:v1.79.1@sha256:7d94cbad82f1c82f2faba366f3ed0011e72c0a67760f3e032ff847745280871c
     volumes:
       - ${APP_DATA_DIR}/data/model-cache:/cache
     environment:
@@ -62,7 +62,7 @@ services:
     restart: on-failure
 
   web:
-    image: ghcr.io/immich-app/immich-web:v1.77.0@sha256:b5aacf51b8566c239c257d68bc300f4a5572d3e408d58e245d31c578065e90fd
+    image: ghcr.io/immich-app/immich-web:v1.79.1@sha256:94c7ac4993370debca280cb864f4c110a559d81c5994d745ebd7214edfb4f3b3
     environment:
       <<: *env
     restart: on-failure
@@ -77,7 +77,7 @@ services:
     restart: on-failure
 
   proxy:
-    image: ghcr.io/immich-app/immich-proxy:v1.77.0@sha256:22228613ed93eadb43db4fc4f4f4849c9954683aa399e95bdd4e8d808d288b23
+    image: ghcr.io/immich-app/immich-proxy:v1.79.1@sha256:7309809fbfbf21dfd6f15bb02a865a0670284343e07240a55962fba9d2193b71
     environment:
       IMMICH_SERVER_URL: *immich_server_url
       IMMICH_WEB_URL: *immich_web_url

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: immich
 category: files
 name: Immich
-version: "v1.77.0"
+version: "v1.79.1"
 tagline: High-performance photo and video backup solution
 description: >-
   An open-source and high-performance self-hosted backup solution for the videos and photos on your mobile device
@@ -47,13 +47,15 @@ description: >-
 releaseNotes: >-
   This update includes many bug fixes and performance improvements, including the following highlights:
   
-  - Show original uploader in shared album photo details
+  - Support for external libraries
 
-  - Improved assets upload
+  - Better synchronization mechanism on the mobile app
   
-  - Customizable machine learning settings
+  - Set minimum detected face to show on your instance
 
-  - A fix for machine learning minScore not being set correctly
+  - Allow self-signed certificate on the mobile app
+
+  - Fixed LivePhotos upload on iOS
 
 
   Full release notes are found at: https://github.com/immich-app/immich/releases


### PR DESCRIPTION
Updated image to v1.79.1 for

`immich-server` (the same `immich-server` tag is used under `server` and `microservices`)
`immich-machine-learning`
`immich-web`
`immich-proxy`

Did not change `typesense:0.24.1`, `redis:6.2-alpine` or `postgres:14-alpine`