### PR TITLE
Update Helipad to v0.1.10.5

### DIFF
--- a/helipad/docker-compose.yml
+++ b/helipad/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 2112
 
   web:
-    image: podcastindexorg/podcasting20-helipad:v0.1.10@sha256:8c6854dd13bda2564c90819ba2277e7b7e68f58946238b1d71d8f6a677d2de64
+    image: podcastindexorg/podcasting20-helipad@sha256:6767de3126b0a7d317f7c87766a1f063baa44fb85dc5496c794ff9aff306a4c1
     init: true
     restart: on-failure
     stop_grace_period: 1m

--- a/helipad/umbrel-app.yml
+++ b/helipad/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: helipad
 category: bitcoin
 name: Helipad
-version: "0.1.10"
+version: "0.1.10.5"
 tagline: View boosts & boostagrams from Podcasting 2.0 apps
 description: Helipad shows boosts and boostagram messages coming in to your
   Lightning node from your listeners who are using Podcasting 2.0 apps.
@@ -21,3 +21,17 @@ path: ""
 defaultPassword: ""
 submitter: Podcastindex.org
 submission: https://github.com/getumbrel/umbrel/pull/1174
+releaseNotes: >-
+  This update includes the following improvements:
+
+  - Added Streams mode
+
+  - Added numerology emojis
+
+  - Added modal to show entire TLV record
+
+  - Actual sats received shown on mouse hover
+
+  - Podcast/episode names shown for remote item boosts
+
+  - Balance and sat totals are now number formatted


### PR DESCRIPTION
Updates the Helipad app to the latest Docker version and includes release notes with changes since the last version.