### PR TITLE
Update Immich to v1.81.0

### DIFF
--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*,/search/*"
 
   server:
-    image: ghcr.io/immich-app/immich-server:v1.79.1@sha256:38c3c0a8fd67aa04ee580b3a20d4a6dd7cd84df3f5387eadebc0a61ba0751518
+    image: ghcr.io/immich-app/immich-server:v1.81.0@sha256:1393fced3366f386ff1946bb9058d3337089d43545808e8ae1d5e70b7e0d793d
     command: [ "start.sh", "immich" ]
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
@@ -38,7 +38,7 @@ services:
     restart: on-failure
 
   microservices:
-    image: ghcr.io/immich-app/immich-server:v1.79.1@sha256:38c3c0a8fd67aa04ee580b3a20d4a6dd7cd84df3f5387eadebc0a61ba0751518
+    image: ghcr.io/immich-app/immich-server:v1.81.0@sha256:1393fced3366f386ff1946bb9058d3337089d43545808e8ae1d5e70b7e0d793d
     # This service cannot run under 1000:1000
     # And because the uploads are shared
     # We'll run immich specific services as root
@@ -54,7 +54,7 @@ services:
     restart: on-failure
 
   machine-learning:
-    image: ghcr.io/immich-app/immich-machine-learning:v1.79.1@sha256:7d94cbad82f1c82f2faba366f3ed0011e72c0a67760f3e032ff847745280871c
+    image: ghcr.io/immich-app/immich-machine-learning:v1.81.0@sha256:76f8a5a5d5974d3b0aca1a9aa43caaaca6c07ac93340b5c35d4141fac8747236
     volumes:
       - ${APP_DATA_DIR}/data/model-cache:/cache
     environment:
@@ -62,7 +62,7 @@ services:
     restart: on-failure
 
   web:
-    image: ghcr.io/immich-app/immich-web:v1.79.1@sha256:94c7ac4993370debca280cb864f4c110a559d81c5994d745ebd7214edfb4f3b3
+    image: ghcr.io/immich-app/immich-web:v1.81.0@sha256:e1ba855a0243fd5f027b03ea52b59b9823ab7e2db2a5b1facb8ec1d8e4b93088
     environment:
       <<: *env
     restart: on-failure
@@ -77,7 +77,7 @@ services:
     restart: on-failure
 
   proxy:
-    image: ghcr.io/immich-app/immich-proxy:v1.79.1@sha256:7309809fbfbf21dfd6f15bb02a865a0670284343e07240a55962fba9d2193b71
+    image: ghcr.io/immich-app/immich-proxy:v1.81.0@sha256:fc19b7dec711d9ca37a40e9dcbbeec5282ab1a19b51fd0a1cbb7bb8da7f866b8
     environment:
       IMMICH_SERVER_URL: *immich_server_url
       IMMICH_WEB_URL: *immich_web_url

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -48,8 +48,7 @@ releaseNotes: >-
   ⚠️ Please update Immich to this version as soon as possible. This release fixes a severe security vulnerability caused by a third-party dependency.
   Additionally, please note the following actions that may be required after the update:
 
-  - The reverse geocoding settings have been moved to the admin settings pages. If you have set the level of accuracy in the ".env" file, you will need to make the corresponding changes in the settings menu on the administration page on the web.
-    
+  - The reverse geocoding settings have been moved to the admin settings pages. If you have set the level of accuracy in the ".env" file, you will need to make the corresponding changes in the settings menu on the administration page on the web.    
   - Please migrate thumbnails to a new folder structure by running the new migration job in "Admin > Settings > Migration"
     
 

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: immich
 category: files
 name: Immich
-version: "v1.79.1"
+version: "v1.81.0"
 tagline: High-performance photo and video backup solution
 description: >-
   An open-source and high-performance self-hosted backup solution for the videos and photos on your mobile device
@@ -45,17 +45,26 @@ description: >-
   
   - User-defined storage structure
 releaseNotes: >-
+  ⚠️ Fixes a security vulnerability (CVE-2023-5129) by rebuilding the Docker image with the newest Debian libwebp library
+
+  ⚠️ Migrate thumbnails to a new folder structure by running the new migration job "Admin > Settings > Migration"
+
+  ⚠️ The reverse geocoding settings have been moved to the admin settings pages. If you have set the level of accuracy in the ".env" file, you will need to make the corresponding changes in the settings menu on the administration page on the web.
+
+
   This update includes many bug fixes and performance improvements, including the following highlights:
   
-  - Support for external libraries
+  - Added mechanism to store generated files for thumbnails and encoded-videos in subfolders
 
-  - Better synchronization mechanism on the mobile app
+  - Added an ability to suggest people’s names during name assignment for faces
   
-  - Set minimum detected face to show on your instance
+  - Added an option to show the sidebar menu for the people page in the user setting on the web
 
-  - Allow self-signed certificate on the mobile app
+  - Added week number as an option for path templating
 
-  - Fixed LivePhotos upload on iOS
+  - Fixes issues related to External Libraries, metadata processing, and Live Photos
+
+  - and more!
 
 
   Full release notes are found at: https://github.com/immich-app/immich/releases

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -45,12 +45,13 @@ description: >-
   
   - User-defined storage structure
 releaseNotes: >-
-  ⚠️ Fixes a security vulnerability (CVE-2023-5129) by rebuilding the Docker image with the newest Debian libwebp library
+  ⚠️ Please update Immich to this version as soon as possible. This release fixes a severe security vulnerability caused by a third-party dependency.
+  Additionally, please note the following actions that may be required after the update:
 
-  ⚠️ Migrate thumbnails to a new folder structure by running the new migration job "Admin > Settings > Migration"
-
-  ⚠️ The reverse geocoding settings have been moved to the admin settings pages. If you have set the level of accuracy in the ".env" file, you will need to make the corresponding changes in the settings menu on the administration page on the web.
-
+    - The reverse geocoding settings have been moved to the admin settings pages. If you have set the level of accuracy in the ".env" file, you will need to make the corresponding changes in the settings menu on the administration page on the web.
+    
+    - Please migrate thumbnails to a new folder structure by running the new migration job in "Admin > Settings > Migration"
+    
 
   This update includes many bug fixes and performance improvements, including the following highlights:
   

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -48,7 +48,8 @@ releaseNotes: >-
   ⚠️ Please update Immich to this version as soon as possible. This release fixes a severe security vulnerability caused by a third-party dependency.
   Additionally, please note the following actions that may be required after the update:
 
-  - The reverse geocoding settings have been moved to the admin settings pages. If you have set the level of accuracy in the ".env" file, you will need to make the corresponding changes in the settings menu on the administration page on the web.    
+  - The reverse geocoding settings have been moved to the admin settings pages. If you have set the level of accuracy in the ".env" file, you will need to make the corresponding changes in the settings menu on the administration page on the web.
+  
   - Please migrate thumbnails to a new folder structure by running the new migration job in "Admin > Settings > Migration"
     
 

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -48,9 +48,9 @@ releaseNotes: >-
   ⚠️ Please update Immich to this version as soon as possible. This release fixes a severe security vulnerability caused by a third-party dependency.
   Additionally, please note the following actions that may be required after the update:
 
-    - The reverse geocoding settings have been moved to the admin settings pages. If you have set the level of accuracy in the ".env" file, you will need to make the corresponding changes in the settings menu on the administration page on the web.
+  - The reverse geocoding settings have been moved to the admin settings pages. If you have set the level of accuracy in the ".env" file, you will need to make the corresponding changes in the settings menu on the administration page on the web.
     
-    - Please migrate thumbnails to a new folder structure by running the new migration job in "Admin > Settings > Migration"
+  - Please migrate thumbnails to a new folder structure by running the new migration job in "Admin > Settings > Migration"
     
 
   This update includes many bug fixes and performance improvements, including the following highlights:


### PR DESCRIPTION
I have updated image to v1.81.0 for

`immich-server` (the same `immich-server` tag is used under `server` and `microservices`)
`immich-machine-learning`
`immich-web`
`immich-proxy`

Did not change `typesense:0.24.1`, `redis:6.2-alpine` or `postgres:14-alpine`