### PR TITLE
Update PhotoPrism to 230923

### DIFF
--- a/photoprism/docker-compose.yml
+++ b/photoprism/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       PROXY_AUTH_WHITELIST: "/originals/*,/import/*"
   
   web:
-    image: photoprism/photoprism:230923@sha256:53c504ee6272cc8ddc6f25d49e621926df25842d87a41bd822fd0637acaa1836
+    image: photoprism/photoprism:230923@sha256:64a0c712fc2e46e93e01c18fae8a00f947440dc67c88b603f35cedd57b406eac
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: "1m"

--- a/photoprism/docker-compose.yml
+++ b/photoprism/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       PROXY_AUTH_WHITELIST: "/originals/*,/import/*"
   
   web:
-    image: photoprism/photoprism:230625@sha256:3b6a64d86abb566b5314dc7b168476e421ca7322b9102c1bd9c79834c6bc6756
+    image: photoprism/photoprism:230923@sha256:53c504ee6272cc8ddc6f25d49e621926df25842d87a41bd822fd0637acaa1836
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: "1m"

--- a/photoprism/umbrel-app.yml
+++ b/photoprism/umbrel-app.yml
@@ -44,6 +44,7 @@ torOnly: false
 releaseNotes: >-
   Our latest release includes a redesigned Places view, with the search box moved to the top and a preview for selected clusters at the bottom. We've also added support for Samsung/Google Motion Photos, so you can view them like Apple Live Photos after re-indexing your library. Beyond those highlights, you'll get many usability improvements, new search filters, and fixes for recently discovered issues. A big thank you to everyone who contributed!
 
+
   Full release notes can be found at: https://github.com/photoprism/photoprism/releases/
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/bf4c6f127f1fcf4dbe8eea55729502dfb34278e9

--- a/photoprism/umbrel-app.yml
+++ b/photoprism/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: photoprism
 category: files
 name: PhotoPrism
-version: "230625"
+version: "230923"
 tagline: Self-host your photo and video library
 description: >-
   PhotoPrism® is a privately hosted app for browsing, organizing, and
@@ -42,22 +42,7 @@ defaultUsername: "admin"
 deterministicPassword: true
 torOnly: false
 releaseNotes: >-
-  This update brings a ton of new features, performance improvements, and bug fixes, including:
-
-  - new high-resolution vector world map
-  
-  - improved performance, security, and file type support
-
-  - improved translations
-
-  - improved video trascoding
-
-  - improved user interface
-
-  - new themes
-
-  - and more!
-
+  Our latest release includes a redesigned Places view, with the search box moved to the top and a preview for selected clusters at the bottom. We've also added support for Samsung/Google Motion Photos, so you can view them like Apple Live Photos after re-indexing your library. Beyond those highlights, you'll get many usability improvements, new search filters, and fixes for recently discovered issues. A big thank you to everyone who contributed!
 
   Full release notes can be found at: https://github.com/photoprism/photoprism/releases/
 submitter: Umbrel


### PR DESCRIPTION
The [September release](https://github.com/photoprism/photoprism/releases/tag/230923-e59851350) includes a [redesigned Places view](https://user-images.githubusercontent.com/301686/269433540-cd48e79f-b2a8-4fb5-bc54-52467b15b743.jpg), with the search box moved to the top and a preview for selected clusters at the bottom. Also added support for https://github.com/photoprism/photoprism/issues/439/https://github.com/photoprism/photoprism/issues/1739, so you can view them like Apple Live Photos after [re-indexing your library](https://docs.photoprism.app/user-guide/library/originals/). Beyond those highlights, you'll get many usability improvements, new search filters, and fixes for recently discovered issues.
