### PR TITLE
update home-assistant to 2023.9.3

### DIFF
--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   server:
-    image: homeassistant/home-assistant:2023.7.1@sha256:a86ff5d05ce46520c53d67c8da55aba310de9b9b4ca8eead1ae0b5ab1c068f97
+    image: homeassistant/home-assistant:2023.9.3@sha256:067490d7b65cfa8b9e494a9447b0e5a7876be83ead7ec01738681c55d66e7cfe
     network_mode: host
     # UI at default port 8123
     privileged: true

--- a/home-assistant/umbrel-app.yml
+++ b/home-assistant/umbrel-app.yml
@@ -6,24 +6,29 @@ version: "2023.9.3"
 tagline: Home automation that puts local control & privacy first
 description: >-
   Open source home automation that puts local control and privacy
-  first, powered by a worldwide community of tinkerers and DIY enthusiasts. Home
-  Assistant integrates with over a thousand different devices and services. Once
-  you have integrated all your devices at home, you can unleash Home Assistant’s
-  advanced automation engine to make your home work for you. Examples: 
-
+  first. Powered by a worldwide community of tinkerers and DIY enthusiasts.
+  Once started, Home Assistant will automatically scan your network for known devices and allow you to easily set them up.
+  Home Assistant integrates with over a thousand different devices and services.
+  
+  
+  Once you have integrated all your devices at home, you can unleash Home Assistant’s
+  advanced automation engine to make your home work for you. Do things like: 
 
   - Turn on the light when the sun sets or when coming home 
 
-  - Alert you when you leave your garage door open 
+  - Get an alert when you leave your garage door open 
 
 
-  All your smart home data stays local. Home Assistant communicates with your devices locally, and will fallback to pulling in data from the cloud if there is no other option. No data is stored in the cloud, and everything is processed locally.
+  Home Assistant keeps your data local, no need for a cloud. Home Assistant communicates with your devices locally, and will fallback to pulling in data from the cloud if there is no other option. No data is stored in the cloud, and everything is processed locally.
+
+
+  Note: The USB adapter discovery feature (e.g., for Zigbee dongles connected directly to the device running Umbrel) may not work reliably for Umbrel users on Raspberry Pi.
 developer: Home Assistant
 website: https://home-assistant.io
 dependencies: []
 repo: https://github.com/home-assistant/core
 support: https://community.home-assistant.io
-port: 8123
+port: 8123 
 gallery:
   - 1.jpg
   - 2.jpg

--- a/home-assistant/umbrel-app.yml
+++ b/home-assistant/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: home-assistant
 category: automation
 name: Home Assistant
-version: "2023.7.1"
+version: "2023.9.3"
 tagline: Home automation that puts local control & privacy first
 description: >-
   Open source home automation that puts local control and privacy
@@ -33,17 +33,10 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  For Home Assistant mobile app users, there's an important change introduced since the last version. In your Home Assistant mobile app,
-  please use the new port number '8123' to connect it to the Home Assistant app on your Umbrel. If you haven't already made this change, please do so
-  now. Alternatively, you can reinstall the mobile app for automatic Umbrel detection.
+  This release included major updates to climate, humidifier, and water heater dialogs with circular sliders and status indicators.
+  The tile card and template sensor features were expanded, allowing easier control and setup from the dashboard and UI.
+  The onboarding process was also redesigned to simplify the initial Home Assistant experience.
   
-
-  This update brings Home Assistant to version 2023.7.1, and now includes USB Discovery! The previous update included automatic device discovery for
-  devices connected to the same network, and the ability to save your personalized settings and automations.
-
-
-  This update to 2023.7.1 brings a variety of improvements and bug fixes. Services can now respond with data, Bluetooth proxies are now lightning fast,
-  you can copy-and-paste cards between your dashboards, and broken automations no longer disappear into thin air and are, instead, marked as problematic.
   Read more at: https://github.com/home-assistant/core/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/9d79cffae608c6a6ab077f859c1c531a581cf926


### PR DESCRIPTION
Changes: https://www.home-assistant.io/blog/2023/09/06/release-20239/

Tested on:
- `x86_64` -> Digital Ocean droplet by updating from old to new version.
- `arm64` -> Fresh install

<img width="1582" alt="Screenshot 2023-10-04 at 10 38 30 PM" src="https://github.com/getumbrel/umbrel-apps/assets/42001064/a599b809-4f2d-4e4f-adbc-51d30de804ab">

New onboarding screen looks clean 😮‍💨 