### PR TITLE
update Immich to v1.82.0

### DIFF
--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*,/search/*"
 
   server:
-    image: ghcr.io/immich-app/immich-server:v1.82.0@sha256:b8368f3a58940f383fd8c4f91389100797ab9df1a66f7cff71d9413ffe1a29d2
+    image: ghcr.io/immich-app/immich-server:v1.82.1@sha256:c6dc1823f99e3b23002088eab26b7675e7c3b4703ab71449d054dd18bbdfb11d
     command: [ "start.sh", "immich" ]
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
@@ -38,7 +38,7 @@ services:
     restart: on-failure
 
   microservices:
-    image: ghcr.io/immich-app/immich-server:v1.82.0@sha256:b8368f3a58940f383fd8c4f91389100797ab9df1a66f7cff71d9413ffe1a29d2
+    image: ghcr.io/immich-app/immich-server:v1.82.1@sha256:c6dc1823f99e3b23002088eab26b7675e7c3b4703ab71449d054dd18bbdfb11d
     # This service cannot run under 1000:1000
     # And because the uploads are shared
     # We'll run immich specific services as root
@@ -54,7 +54,7 @@ services:
     restart: on-failure
 
   machine-learning:
-    image: ghcr.io/immich-app/immich-machine-learning:v1.82.0@sha256:f58f14cb9874e6947a8f8499fc95400a544043288b40db39b80675af91982d40
+    image: ghcr.io/immich-app/immich-machine-learning:v1.82.1@sha256:9ff5a57031bcf687b2d222f5f473279ae5e47908d38da70c568c95b211227667
     volumes:
       - ${APP_DATA_DIR}/data/model-cache:/cache
     environment:
@@ -62,7 +62,7 @@ services:
     restart: on-failure
 
   web:
-    image: ghcr.io/immich-app/immich-web:v1.82.0@sha256:027a317afa4f2e3d7b661f4186888f5f4a7aab1ca7151e7324912163c0ee8535
+    image: ghcr.io/immich-app/immich-web:v1.82.1@sha256:b59ec80d45a9395f020c312868abd08eafbfe3594e83955d7e566096309f0f2f
     environment:
       <<: *env
     restart: on-failure
@@ -77,7 +77,7 @@ services:
     restart: on-failure
 
   proxy:
-    image: ghcr.io/immich-app/immich-proxy:v1.82.0@sha256:cdca2fef7d9e7479aefd8db398c89fb960ca65ea2b98af98ed98ddf5530f0bbc
+    image: ghcr.io/immich-app/immich-proxy:v1.82.1@sha256:96239238d467a69e68db007339497c5e5bab820d2152300aa46b3e031f2c245e
     environment:
       IMMICH_SERVER_URL: *immich_server_url
       IMMICH_WEB_URL: *immich_web_url

--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*,/search/*"
 
   server:
-    image: ghcr.io/immich-app/immich-server:v1.81.0@sha256:1393fced3366f386ff1946bb9058d3337089d43545808e8ae1d5e70b7e0d793d
+    image: ghcr.io/immich-app/immich-server:v1.82.0@sha256:b8368f3a58940f383fd8c4f91389100797ab9df1a66f7cff71d9413ffe1a29d2
     command: [ "start.sh", "immich" ]
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
@@ -38,7 +38,7 @@ services:
     restart: on-failure
 
   microservices:
-    image: ghcr.io/immich-app/immich-server:v1.81.0@sha256:1393fced3366f386ff1946bb9058d3337089d43545808e8ae1d5e70b7e0d793d
+    image: ghcr.io/immich-app/immich-server:v1.82.0@sha256:b8368f3a58940f383fd8c4f91389100797ab9df1a66f7cff71d9413ffe1a29d2
     # This service cannot run under 1000:1000
     # And because the uploads are shared
     # We'll run immich specific services as root
@@ -54,7 +54,7 @@ services:
     restart: on-failure
 
   machine-learning:
-    image: ghcr.io/immich-app/immich-machine-learning:v1.81.0@sha256:76f8a5a5d5974d3b0aca1a9aa43caaaca6c07ac93340b5c35d4141fac8747236
+    image: ghcr.io/immich-app/immich-machine-learning:v1.82.0@sha256:f58f14cb9874e6947a8f8499fc95400a544043288b40db39b80675af91982d40
     volumes:
       - ${APP_DATA_DIR}/data/model-cache:/cache
     environment:
@@ -62,7 +62,7 @@ services:
     restart: on-failure
 
   web:
-    image: ghcr.io/immich-app/immich-web:v1.81.0@sha256:e1ba855a0243fd5f027b03ea52b59b9823ab7e2db2a5b1facb8ec1d8e4b93088
+    image: ghcr.io/immich-app/immich-web:v1.82.0@sha256:027a317afa4f2e3d7b661f4186888f5f4a7aab1ca7151e7324912163c0ee8535
     environment:
       <<: *env
     restart: on-failure
@@ -77,7 +77,7 @@ services:
     restart: on-failure
 
   proxy:
-    image: ghcr.io/immich-app/immich-proxy:v1.81.0@sha256:fc19b7dec711d9ca37a40e9dcbbeec5282ab1a19b51fd0a1cbb7bb8da7f866b8
+    image: ghcr.io/immich-app/immich-proxy:v1.82.0@sha256:cdca2fef7d9e7479aefd8db398c89fb960ca65ea2b98af98ed98ddf5530f0bbc
     environment:
       IMMICH_SERVER_URL: *immich_server_url
       IMMICH_WEB_URL: *immich_web_url

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: immich
 category: files
 name: Immich
-version: "v1.82.0"
+version: "v1.82.1"
 tagline: High-performance photo and video backup solution
 description: >-
   An open-source and high-performance self-hosted backup solution for the videos and photos on your mobile device

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -45,10 +45,10 @@ description: >-
   
   - User-defined storage structure
 releaseNotes: >-
-  ⚠️ Please update Immich to this version as soon as possible. This release fixes a severe security vulnerability caused by a third-party dependency.
+  ⚠️ Please update Immich to this version as soon as possible. This release fixes two security flaws noted here: https://github.com/immich-app/immich/releases/tag/v1.82.0
 
   
-  This update from v1.81.0 to v1.82.0 includes many bug fixes and performance improvements, as well as the following new features:
+  This update from v1.81.0 to v1.82.1 includes many bug fixes and performance improvements, as well as the following new features:
 
   - Trash Feature
 
@@ -56,7 +56,7 @@ releaseNotes: >-
 
   - Library Scanning Performance
 
-  - Time Bucket Grouping Accuracy
+  - Time Bucket Grouping Accuracy (to take advantage of this feature, please run the job to “Extract Metadata” for all assets.)
 
   - Storage Template Improvements
 

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -48,6 +48,9 @@ releaseNotes: >-
   ⚠️ Please update Immich to this version as soon as possible. This release fixes two security flaws noted here: https://github.com/immich-app/immich/releases/tag/v1.82.0
 
   
+  Additionally, it was discovered that thumbnails (which can be downloaded from right-click -> save images as…) contain the full EXIF (metadata) information.  Users are advised not to use the public-sharing feature until a fix is released if they have concerns about sharing metadata.
+
+  
   This update from v1.81.0 to v1.82.1 includes many bug fixes and performance improvements, as well as the following new features:
 
   - Trash Feature

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -46,7 +46,9 @@ description: >-
   - User-defined storage structure
 releaseNotes: >-
   ⚠️ Please update Immich to this version as soon as possible. This release fixes a severe security vulnerability caused by a third-party dependency.
-  Additionally, please note the following actions that may be required after the update:
+
+  
+  It includes many bug fixes and performance improvements, as well as the following new features:
 
   - Trash Feature
 

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -48,7 +48,7 @@ releaseNotes: >-
   ⚠️ Please update Immich to this version as soon as possible. This release fixes a severe security vulnerability caused by a third-party dependency.
 
   
-  It includes many bug fixes and performance improvements, as well as the following new features:
+  This update from v1.81.0 to v1.82.0 includes many bug fixes and performance improvements, as well as the following new features:
 
   - Trash Feature
 

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: immich
 category: files
 name: Immich
-version: "v1.81.0"
+version: "v1.82.0"
 tagline: High-performance photo and video backup solution
 description: >-
   An open-source and high-performance self-hosted backup solution for the videos and photos on your mobile device
@@ -48,27 +48,22 @@ releaseNotes: >-
   ⚠️ Please update Immich to this version as soon as possible. This release fixes a severe security vulnerability caused by a third-party dependency.
   Additionally, please note the following actions that may be required after the update:
 
-  - The reverse geocoding settings have been moved to the admin settings pages. If you have set the level of accuracy in the ".env" file, you will need to make the corresponding changes in the settings menu on the administration page on the web.
-  
-  - Please migrate thumbnails to a new folder structure by running the new migration job in "Admin > Settings > Migration"
-    
+  - Trash Feature
 
-  This update includes many bug fixes and performance improvements, including the following highlights:
-  
-  - Added mechanism to store generated files for thumbnails and encoded-videos in subfolders
+  - Web Client WebSocket Feature
 
-  - Added an ability to suggest people’s names during name assignment for faces
-  
-  - Added an option to show the sidebar menu for the people page in the user setting on the web
+  - Library Scanning Performance
 
-  - Added week number as an option for path templating
+  - Time Bucket Grouping Accuracy
 
-  - Fixes issues related to External Libraries, metadata processing, and Live Photos
+  - Storage Template Improvements
+
+  - Notable fix: no longer read iOS-modified photos as “FullSizeRender” 
 
   - and more!
 
 
-  Full release notes are found at: https://github.com/immich-app/immich/releases
+  Full release notes are found at: https://github.com/immich-app/immich/releases/tag/v1.82.0
 developer: Alex Tran
 website: https://www.immich.app
 dependencies: []


### PR DESCRIPTION
Tested on:
- [x]  x86_64 -> Digital Ocean droplet
- [x]  Arm64 -> Multipass Instance on Apple M2

Tested both fresh install & version update and verified the functionality by uploading images, deleting images etc.

Very cool update, Adds Trash feature & Websocket support so we don't have to refresh to see updates.