### PR TITLE
update Portainer to v2.19.1

### DIFF
--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 9000
 
   docker:
-    image: docker:24.0.5-dind
+    image: docker:24.0.5-dind@sha256:3c6e4dca7a63c9a32a4e00da40461ce067f255987ccc9721cf18ffa087bcd1ef
     privileged: true
     network_mode: host
     stop_grace_period: 1m

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - ${APP_DATA_DIR}/data/docker:/data
 
   portainer:
-    image: portainer/portainer-ce:2.19.0
+    image: portainer/portainer-ce:2.19.1@sha256:f29cbc7b26ebd701b1fe92b4df42edea350e871372a6296a1fa16ba999481fb2
     command: --host unix:///var/run/docker.sock --admin-password-file=/default-password
     restart: on-failure
     volumes:

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -54,12 +54,12 @@ releaseNotes: >-
   This update of Portainer from 2.19.0 to 2.19.1 includes various bug fixes, improvements, and new features, including the following highlights.
 
 
-  Breaking changes:
+  👉 Breaking changes:
 
   - Changes to API format and checking of some requests - See rest API changes below for more details.
 
 
-  Portainer:
+  👉 Portainer:
 
   - Fixed an issue where backup files were missing the Chisel private key. This could have disrupted communication between the Portainer server and agent after a restoration from backup.
 
@@ -68,7 +68,7 @@ releaseNotes: >-
   - Fixed an issue where toggles could be activated outside of their intended component area, potentially leading to inadvertent toggling.
 
 
-  RestAPI:
+  👉 RestAPI:
 
   - Fixed an issue introduced in 2.19.0 when Kubernetes environment metrics API features were enabled, where these features would return an ‘Unable to reach metrics API’ error.
 

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -53,18 +53,27 @@ defaultPassword: "changeme"
 releaseNotes: >-
   This update of Portainer from 2.19.0 to 2.19.1 includes various bug fixes, improvements, and new features, including the following highlights.
 
+
   Breaking changes:
+
   - Changes to API format and checking of some requests - See rest API changes below for more details.
 
   Portainer:
+
   - Fixed an issue where backup files were missing the Chisel private key. This could have disrupted communication between the Portainer server and agent after a restoration from backup.
+    
   - Improved the upgrade process for the Portainer server, upgrade process now halts on database migration errors, preventing database version mismatches for a more stable environment.
+
   - Fixed an issue where toggles could be activated outside of their intended component area, potentially leading to inadvertent toggling.
 
   RestAPI:
+
   - Fixed an issue introduced in 2.19.0 when Kubernetes environment metrics API features were enabled, where these features would return an ‘Unable to reach metrics API’ error.
+
   - Introduced new format around the change of a user’s password via API.
+
   - Updated the checking around change of a user via API.
+
   - Fixed API endpoints that were broken in the 2.19.0 release, ensuring that they retain their previous functionality.
 
 

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -58,13 +58,15 @@ releaseNotes: >-
 
   - Changes to API format and checking of some requests - See rest API changes below for more details.
 
+
   Portainer:
 
   - Fixed an issue where backup files were missing the Chisel private key. This could have disrupted communication between the Portainer server and agent after a restoration from backup.
-    
+
   - Improved the upgrade process for the Portainer server, upgrade process now halts on database migration errors, preventing database version mismatches for a more stable environment.
 
   - Fixed an issue where toggles could be activated outside of their intended component area, potentially leading to inadvertent toggling.
+
 
   RestAPI:
 

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: portainer
 category: developer
 name: Portainer
-version: "2.19.0"
+version: "2.19.1"
 tagline: Run custom Docker containers on your Umbrel
 description: >-
   ⚠️ Make sure to only use named Docker volumes for your stacks and containers. Data in bind-mounted volumes
@@ -50,7 +50,26 @@ gallery:
 path: ""
 defaultUsername: "admin"
 defaultPassword: "changeme"
-releaseNotes: ""
+releaseNotes: >-
+  This update of Portainer from 2.19.0 to 2.19.1 includes various bug fixes, improvements, and new features, including the following highlights.
+
+  Breaking changes:
+  - Changes to API format and checking of some requests - See rest API changes below for more details.
+
+  Portainer:
+  - Fixed an issue where backup files were missing the Chisel private key. This could have disrupted communication between the Portainer server and agent after a restoration from backup.
+  - Improved the upgrade process for the Portainer server, upgrade process now halts on database migration errors, preventing database version mismatches for a more stable environment.
+  - Fixed an issue where toggles could be activated outside of their intended component area, potentially leading to inadvertent toggling.
+
+  RestAPI:
+  - Fixed an issue introduced in 2.19.0 when Kubernetes environment metrics API features were enabled, where these features would return an ‘Unable to reach metrics API’ error.
+  - Introduced new format around the change of a user’s password via API.
+  - Updated the checking around change of a user via API.
+  - Fixed API endpoints that were broken in the 2.19.0 release, ensuring that they retain their previous functionality.
+
+
+  View full release notes here: https://github.com/portainer/portainer/releases/tag/2.19.1
+
 developer: Portainer
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/774


### PR DESCRIPTION
Tested on:
- [x]  x86_64 -> Digital Ocean droplet
- [x]  Arm64 -> Multipass Instance on Apple M2

Tested both fresh install & version update and verified the functionality by running containers and pulling images.