### PR TITLE
Fix to use RPC port

### DIFF
--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - --bitcoin-rpcconnect=${APP_BITCOIN_NODE_IP}
       - --bitcoin-rpcuser=${APP_BITCOIN_RPC_USER}
       - --bitcoin-rpcpassword=${APP_BITCOIN_RPC_PASS}
-      - --bitcoin-rpcport=8332
+      - --bitcoin-rpcport=${$APP_BITCOIN_RPC_PORT} 
       - --lightning-dir=${CORE_LIGHTNING_PATH}
       - --proxy=${TOR_PROXY_IP}:${TOR_PROXY_PORT}
       - --bind-addr=${APP_CORE_LIGHTNING_DAEMON_IP}:9735

--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - --bitcoin-rpcconnect=${APP_BITCOIN_NODE_IP}
       - --bitcoin-rpcuser=${APP_BITCOIN_RPC_USER}
       - --bitcoin-rpcpassword=${APP_BITCOIN_RPC_PASS}
+      - --bitcoin-rpcport=8332
       - --lightning-dir=${CORE_LIGHTNING_PATH}
       - --proxy=${TOR_PROXY_IP}:${TOR_PROXY_PORT}
       - --bind-addr=${APP_CORE_LIGHTNING_DAEMON_IP}:9735

--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - --bitcoin-rpcconnect=${APP_BITCOIN_NODE_IP}
       - --bitcoin-rpcuser=${APP_BITCOIN_RPC_USER}
       - --bitcoin-rpcpassword=${APP_BITCOIN_RPC_PASS}
-      - --bitcoin-rpcport=${$APP_BITCOIN_RPC_PORT} 
+      - --bitcoin-rpcport=${APP_BITCOIN_RPC_PORT} 
       - --lightning-dir=${CORE_LIGHTNING_PATH}
       - --proxy=${TOR_PROXY_IP}:${TOR_PROXY_PORT}
       - --bind-addr=${APP_CORE_LIGHTNING_DAEMON_IP}:9735

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -32,7 +32,7 @@ defaultPassword: ""
 submitter: Blockstream
 submission: https://github.com/getumbrel/umbrel-apps/pull/475
 releaseNotes: >-
-  This is a hotfix update that fixes a bug preventing the Core Lightning app from running in test networks (e.g., testnet). No other changes are included in this release.
+  This hotfix update resolves an issue that was preventing the Core Lightning app from operating on test networks such as testnet. No additional changes are included in this release.
 
 
   The release notes from 23.08 are included here for completeness.

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -32,7 +32,10 @@ defaultPassword: ""
 submitter: Blockstream
 submission: https://github.com/getumbrel/umbrel-apps/pull/475
 releaseNotes: >-
-  This release updates the user interface, as well as the underlying c-lightning-REST and lightningd components of the Core Lightning app.
+  This is a hotfix update that fixes a bug preventing the Core Lightning app from running in test networks (e.g., testnet). No other changes are included in this release.
+
+
+  The release notes from 23.08 are included here for completeness.
 
 
   cln-application v0.0.4 (user interface):
@@ -102,9 +105,6 @@ releaseNotes: >-
   - reckless added support for node.js plugin installation and for networks beyond bitcoin and regtest.
 
   - spending unilateral close transactions now use dynamic fees based on deadlines (and RBF), instead of fixed fees.
-
-
-  Note: The 23.08-hotfix-1 update fixes a bug that was resulting in the app not working for networks other than mainnet
 
 
   Full lightningd release notes are available at https://github.com/ElementsProject/lightning/releases

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: core-lightning
 category: bitcoin
 name: Core Lightning
-version: "23.08"
+version: "23.08-hotfix-1"
 tagline: Run your personal Core Lightning node
 description: >-
   Get started with the Lightning network today with Core Lightning - a
@@ -102,6 +102,8 @@ releaseNotes: >-
   - reckless added support for node.js plugin installation and for networks beyond bitcoin and regtest.
 
   - spending unilateral close transactions now use dynamic fees based on deadlines (and RBF), instead of fixed fees.
+
+  Note: The 23.08-hotfix-1 update fixes a bug that was resulting in the app not working for networks other than mainnet
 
 
   Full lightningd release notes are available at https://github.com/ElementsProject/lightning/releases

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -103,6 +103,7 @@ releaseNotes: >-
 
   - spending unilateral close transactions now use dynamic fees based on deadlines (and RBF), instead of fixed fees.
 
+
   Note: The 23.08-hotfix-1 update fixes a bug that was resulting in the app not working for networks other than mainnet
 
 


### PR DESCRIPTION
Fixes issue when running Bitcoin in testnet, Core Lightning will also now automatically open in testnet successfully, thank you!
Worked and opened app at 97% Bitcoin testnet synced and opening at 100% showing: 
![image](https://github.com/getumbrel/umbrel-apps/assets/8608634/ab7ade89-0ecb-4190-a59c-70d91aba1820)


Not sure if denoting that it is indeed in testnet?

something app proxy can handle?