### PR TITLE
Circuitbreaker: Upgrade to v0.5.0

### DIFF
--- a/circuitbreaker/docker-compose.yml
+++ b/circuitbreaker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 9235
       
   web:
-    image: ghcr.io/lightningequipment/circuitbreaker:v0.4.3@sha256:b8e0505da638ff47d69f0c3af8140d82dde970dadadf5949565426c4f3c9ded9
+    image: ghcr.io/lightningequipment/circuitbreaker:v0.5.0@0e5ba7c4f7be9921123d8ae4f1f120a2ebc2502d185a75ff93537b071fe6366b
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/circuitbreaker/docker-compose.yml
+++ b/circuitbreaker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 9235
       
   web:
-    image: ghcr.io/lightningequipment/circuitbreaker:v0.5.0@0e5ba7c4f7be9921123d8ae4f1f120a2ebc2502d185a75ff93537b071fe6366b
+    image: ghcr.io/lightningequipment/circuitbreaker:v0.5.0@sha256:0e5ba7c4f7be9921123d8ae4f1f120a2ebc2502d185a75ff93537b071fe6366b
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/circuitbreaker/umbrel-app.yml
+++ b/circuitbreaker/umbrel-app.yml
@@ -44,7 +44,7 @@ releaseNotes: >-
   Specifically, it will persist timestamped forwarding history records for successful and failed HTLCs (LND only saves successful forwards, and does not keep timestamps). By default, circuitbreaker will only store 100,000 records so the maximum amount of space that these records will take is approximately 14MB.  This value can be changed using the `--fwdhistorylimit` flag, which allows zero values to disable the feature completely.
 
 
-  This feature was developed as part of the ongoing protocol work to research [mitigation of channel jamming attacks against the network](https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-August/004034.html). Volunteers interested in contributing to this research through running *local-only* analysis of the data circuitbreaker collects can express interest [here](https://docs.google.com/forms/d/e/1FAIpQLScm2xs4hNsrkI8UCBS4aTdO03YrmWT2X0-j6zXWpkZ7keKiUw/viewform?usp=sf_link) or contact carla@chaincode.com for details.
+  This feature was developed as part of the ongoing protocol work to research mitigation of channel jamming attacks against the network (https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-August/004034.html). Volunteers interested in contributing to this research through running *local-only* analysis of the data circuitbreaker collects can express interest at https://docs.google.com/forms/d/e/1FAIpQLScm2xs4hNsrkI8UCBS4aTdO03YrmWT2X0-j6zXWpkZ7keKiUw/viewform?usp=sf_link or contact carla@chaincode.com for details.
 developer: Joost Jager
 website: https://github.com/joostjager
 dependencies: 

--- a/circuitbreaker/umbrel-app.yml
+++ b/circuitbreaker/umbrel-app.yml
@@ -40,7 +40,9 @@ description: >-
 releaseNotes: >-
   This release updates circuitbreaker to v0.5.0, which adds functionality to track granular HTLC forwarding information that is not saved by LND. This detailed information about HTLC forwards is also valuable for node operators looking to gain a more detailed understanding of their forwarding flow.
 
+
   Specifically, it will persist timestamped forwarding history records for successful and failed HTLCs (LND only saves successful forwards, and does not keep timestamps). By default, circuitbreaker will only store 100,000 records so the maximum amount of space that these records will take is approximately 14MB.  This value can be changed using the `--fwdhistorylimit` flag, which allows zero values to disable the feature completely.
+
 
   This feature was developed as part of the ongoing protocol work to research [mitigation of channel jamming attacks against the network](https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-August/004034.html). Volunteers interested in contributing to this research through running *local-only* analysis of the data circuitbreaker collects can express interest [here](https://docs.google.com/forms/d/e/1FAIpQLScm2xs4hNsrkI8UCBS4aTdO03YrmWT2X0-j6zXWpkZ7keKiUw/viewform?usp=sf_link) or contact carla@chaincode.com for details.
 developer: Joost Jager

--- a/circuitbreaker/umbrel-app.yml
+++ b/circuitbreaker/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: circuitbreaker
 category: bitcoin
 name: Circuit Breaker
-version: "v0.4.3"
+version: "v0.5.0"
 tagline: Your Lightning Node's Firewall
 description: >-
   It allows nodes to protect themselves from being flooded with HTLCs. 
@@ -38,13 +38,11 @@ description: >-
 
   WARNING: See queue mode warning.
 releaseNotes: >-
-  - Improved web interface.
+  This release updates circuitbreaker to v0.5.0, which adds functionality to track granular HTLC forwarding information that is not saved by LND. This detailed information about HTLC forwards is also valuable for node operators looking to gain a more detailed understanding of their forwarding flow.
 
-  - Edit limits for multiple nodes in one operation.
+  Specifically, it will persist timestamped forwarding history records for successful and failed HTLCs (LND only saves successful forwards, and does not keep timestamps). By default, circuitbreaker will only store 100,000 records so the maximum amount of space that these records will take is approximately 14MB.  This value can be changed using the `--fwdhistorylimit` flag, which allows zero values to disable the feature completely.
 
-  - Added BLOCKED mode to completely block traffic from a peer.
-
-  - Fixed bug where Circuit Breaker wouldn't restart after a failure.
+  This feature was developed as part of the ongoing protocol work to research [mitigation of channel jamming attacks against the network](https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-August/004034.html). Volunteers interested in contributing to this research through running *local-only* analysis of the data circuitbreaker collects can express interest [here](https://docs.google.com/forms/d/e/1FAIpQLScm2xs4hNsrkI8UCBS4aTdO03YrmWT2X0-j6zXWpkZ7keKiUw/viewform?usp=sf_link) or contact carla@chaincode.com for details.
 developer: Joost Jager
 website: https://github.com/joostjager
 dependencies: 


### PR DESCRIPTION
This PR upgrades circuitbreaker to v0.5.0, which contains an upgrade to start storing more granular HTLC forwarding data. 

The final section of the release notes has a call to action to help out with ongoing research for protocol work - happy to remove it if it's not appropriate!