### PR TITLE
Update homebox to v0.10.1

### DIFF
--- a/homebox/docker-compose.yml
+++ b/homebox/docker-compose.yml
@@ -8,8 +8,7 @@ services:
       APP_PORT: 7745
     
   web:
-    # TODO: update with version-tagged image when available (https://github.com/hay-kot/homebox/pull/372)
-    image: ghcr.io/hay-kot/homebox:nightly-rootless@sha256:1ec765caa21ad37a1fe64eaed2b10b1652169389a275c914eab71e6fd10232b9
+    image: ghcr.io/hay-kot/homebox:v0.10.1@sha256:542f3d6156c7431b2127b35b37f97a121754dd92abb910afe1bbf0008706d2a1
     restart: on-failure
     user: 1000:1000
     environment:

--- a/homebox/docker-compose.yml
+++ b/homebox/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       APP_PORT: 7745
     
   web:
-    image: ghcr.io/hay-kot/homebox:v0.10.1@sha256:542f3d6156c7431b2127b35b37f97a121754dd92abb910afe1bbf0008706d2a1
+    image: ghcr.io/hay-kot/homebox:v0.10.1-rootless@sha256:644bd92d827c7ac2c491fad8fd4607bb2b3598a92efc40236d743619c95c7050
     restart: on-failure
     user: 1000:1000
     environment:

--- a/homebox/umbrel-app.yml
+++ b/homebox/umbrel-app.yml
@@ -24,5 +24,9 @@ path: ""
 torOnly: false
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: >-
+  This This release is a minor release updating dependencies and moving to a Low-Privileged/Distroless Docker Image
+
+  Read the full release notes for additional information and detailed changes at https://github.com/hay-kot/homebox/releases/tag/v0.10.1
 submitter: Xosten
 submission: https://github.com/getumbrel/umbrel-apps/pull/501

--- a/homebox/umbrel-app.yml
+++ b/homebox/umbrel-app.yml
@@ -18,14 +18,13 @@ gallery:
   - 1.jpg
   - 2.jpg
   - 3.jpg
-releaseNotes: ""
 dependencies: []
 path: ""
 torOnly: false
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  This This release is a minor release updating dependencies and moving to a Low-Privileged/Distroless Docker Image
+  This release is a minor release updating dependencies and moving to a Low-Privileged/Distroless Docker Image
 
   Read the full release notes for additional information and detailed changes at https://github.com/hay-kot/homebox/releases/tag/v0.10.1
 submitter: Xosten

--- a/homebox/umbrel-app.yml
+++ b/homebox/umbrel-app.yml
@@ -3,7 +3,7 @@ id: homebox
 name: HomeBox
 tagline: An inventory and organization system built for the home user
 category: files
-version: "0.9.2"
+version: "v0.10.1"
 port: 7745
 description: >-
   Homebox is an inventory and organization system built for the home user! With a focus on simplicity and ease of use, Homebox is the perfect solution for your home inventory, organization, and management needs. 


### PR DESCRIPTION
Moved over to version-tagged image as per comment on last update
` TODO: update with version-tagged image when available (https://github.com/hay-kot/homebox/pull/372)`

Tested on:

- [x] x86_64 -> UmbrelOS on proxmox Debian instance
- [x] Arm64 -> Pi 4 8GB