### PR TITLE
Update Torq to v1.4.1

### DIFF
--- a/torq/docker-compose.yml
+++ b/torq/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 7028
 
   web:
-    image: lncapital/torq:1.2.1@sha256:68fdcd6739d2828fd68beec07b9a1f0bd0949736ecc793e8e144cff0be5fba47
+    image: lncapital/torq:1.4.1@sha256:9282faadf06beaef5943ed6ed5b365be41802b7c7e781dd6fe57478d2b7b274a
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/torq/umbrel-app.yml
+++ b/torq/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: torq
 category: bitcoin
 name: Torq
-version: "v1.2.1"
+version: "v1.4.1"
 tagline: Scalable Node Management Software
 description: >-
   Operating a Lightning node requires a lot of work. You need to monitor your channels, rebalance them, keep track of your fees and much more.
@@ -52,29 +52,34 @@ gallery:
   - 5.jpg
 releaseNotes: >-
   
-  Torq v.1.2.1:
+  Torq v.1.4.1:
+  
+  List of changes:
 
-  - Improved Dashboard layout
+  -  You can now duplicate views
   
-  - Extra workflow channel filter options based on last activity timestamp (Balance Change, Payment, Invoice, Forward). Some of these fields only works for LND for now.
+  -  Add payment request to payments page
   
-  - Support for CLN pagination (This release requires CLN v23.08 or above. All invoices will be re-downloaded into Torq on first start after upgrade.)
+  -  Closed channels sometimes reappeared as active when delayed gossip was processed
   
-  - Added Customer ID to torq Checkout page
+  -  Pagination indicated to many pages when filtering
   
-  - Workflow Logs Layout fixes and improvements
+  -  You can now choose refresh interval for each list view
   
-  - Search on Open, Closed and Pending Channels is now looking for channel ids and pub keys as well as Peer Alias.
+  -  Fix turnover layout and calculation
   
-  - Improvements to Torq settings page
+  -  Channel filter "Active" is now true when both sides of the channel are active (used to be local side only)
   
-  - Uses Scaling Lightning
+  -  Improvements on channel inspect page:
   
-  - Fixes for close channel workflow notifications
+  -  Show channel open and close dates on charts
   
-  - Aliases are now still obtained when new channel are pending
+  -  Added basic channel info
   
-  - Fixes column ordering on channels pages
+  -  Indicators if data is loading
+  
+  Note: This release contains database migrations and cannot be rolled back to a previous version.
+  
 
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
New Torq version with a lot of bug fixes.

  List of changes:

  -  You can now duplicate views
  
  -  Add payment request to payments page
  
  -  Closed channels sometimes reappeared as active when delayed gossip was processed
  
  -  Pagination indicated to many pages when filtering
  
  -  You can now choose refresh interval for each list view
  
  -  Fix turnover layout and calculation
  
  -  Channel filter "Active" is now true when both sides of the channel are active (used to be local side only)
  
  -  Improvements on channel inspect page:
  
  -  Show channel open and close dates on charts
  
  -  Added basic channel info
  
  -  Indicators if data is loading
  
  Note: This release contains database migrations and cannot be rolled back to a previous version.
