### PR TITLE
Update whoogle-search to 0.8.4

### DIFF
--- a/whoogle-search/docker-compose.yml
+++ b/whoogle-search/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 6420
 
   web:
-    image: benbusby/whoogle-search:0.8.3@sha256:feae9cdeb1aaa76fbc3e36cdfbf084ba02200a5675703f61bb2ddceb0060a13b
+    image: benbusby/whoogle-search:0.8.4@sha256:222ea6ed103bf7a5bdff06b1042ef96725dd70a7d92108f769e782f2e7808218
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/whoogle-search/umbrel-app.yml
+++ b/whoogle-search/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: whoogle-search
 category: networking
 name: Whoogle Search
-version: "0.8.3"
+version: "0.8.4"
 tagline: A self-hosted, ad-free, privacy-respecting metasearch engine
 description: >-
   Get Google search results, but without any ads, javascript, AMP links, 
@@ -68,9 +68,18 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >
-  This update fixes a Cookie Consent bug affecting all EU users.
+  Minor update:
+  - Site favicons are now fetched and displayed for each search result
+  - Audio tags are now interpreted correctly
+  - Primarily found in word definition cards in the results view
+  - POST requests now redirected as encrypted GET requests
+  - This allows navigating back from a result website to the Whoogle search result page without having to confirm form resubmission
+  - The "GET-only searches" config is still available for anyone who still prefers it
+  - URLs in element and window endpoints are now validated
+  - Fixes a potential vulnerability where an element or window endpoint could retrieve file contents from a service hosted on another port
+  - Valid HTML in result text content is now sanitized to prevent parsing issues
   
   
-  Full release notes are found at https://github.com/benbusby/whoogle-search/releases/tag/v0.8.3
+  Full release notes are found at https://github.com/benbusby/whoogle-search/releases/tag/v0.8.4
 submitter: Jasper
 submission: https://github.com/getumbrel/umbrel-apps/pull/117

--- a/whoogle-search/umbrel-app.yml
+++ b/whoogle-search/umbrel-app.yml
@@ -69,15 +69,15 @@ defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >
   Minor update:
-  - Site favicons are now fetched and displayed for each search result
-  - Audio tags are now interpreted correctly
-  - Primarily found in word definition cards in the results view
-  - POST requests now redirected as encrypted GET requests
-  - This allows navigating back from a result website to the Whoogle search result page without having to confirm form resubmission
-  - The "GET-only searches" config is still available for anyone who still prefers it
-  - URLs in element and window endpoints are now validated
-  - Fixes a potential vulnerability where an element or window endpoint could retrieve file contents from a service hosted on another port
-  - Valid HTML in result text content is now sanitized to prevent parsing issues
+    - Site favicons are now fetched and displayed for each search result
+    - Audio tags are now interpreted correctly
+    - Primarily found in word definition cards in the results view
+    - POST requests now redirected as encrypted GET requests
+    - This allows navigating back from a result website to the Whoogle search result page without having to confirm form resubmission
+    - The "GET-only searches" config is still available for anyone who still prefers it
+    - URLs in element and window endpoints are now validated
+    - Fixes a potential vulnerability where an element or window endpoint could retrieve file contents from a service hosted on another port
+    - Valid HTML in result text content is now sanitized to prevent parsing issues
   
   
   Full release notes are found at https://github.com/benbusby/whoogle-search/releases/tag/v0.8.4


### PR DESCRIPTION
Minor update. https://github.com/benbusby/whoogle-search/releases/tag/v0.8.4

Tested on:
* [x]  x86_64 -> UmbrelOS on proxmox Debian instance (install)
* [x]  Arm64 -> Pi 4 8GB (update and fresh install)