### PR TITLE
Update tailscale to v1.52.0

### DIFF
--- a/tailscale/docker-compose.yml
+++ b/tailscale/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   web:
     network_mode: "host" # TODO: We can remove this later with some iptables magic
-    image: tailscale/tailscale:v1.48.1@sha256:51c756718c30b15d1d3d228b1f4425cba646ec15da5d188a0d55c32b8ea4f378
+    image: tailscale/tailscale:v1.52.0@sha256:b102f468a2f1b0b6e9717cf728c43886c136e808010547eebe9ebd80aedd34c3
     restart: on-failure
     stop_grace_period: 1m
     command: "sh -c 'tailscale web --listen 0.0.0.0:8240 & exec tailscaled --tun=userspace-networking'"

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -29,6 +29,7 @@ deterministicPassword: false
 torOnly: false
 releaseNotes: |
   This release updates Tailscale from v1.48.1 to v1.52.0 which includes: 
+  
   v1.50.0
   - tailscale ping now sends an ICMP Ping code of 0.
   - UPnP falls back to a permanent lease if a limited lease fails, some servers only support permanent.

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: tailscale
 category: networking
 name: Tailscale
-version: "v1.48.1"
+version: "v1.52.0"
 tagline: Zero config VPN to access your Umbrel from anywhere
 description: >-
   Tailscale is zero config VPN that creates a secure network between
@@ -28,8 +28,27 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: >-
-  This release updates Tailscale from v1.46.1 to v1.48.1.
+  This release updates Tailscale from v1.48.1 to v1.52.0 which includes: 
+  v1.50.0
+  - tailscale ping now sends an ICMP Ping code of 0.
+  - UPnP falls back to a permanent lease if a limited lease fails, some servers only support permanent.
+  - Adds support for Wikimedia DNS using DNS-over-HTTPS.
+  - Unhide tailscale update CLI command on most platforms.
+  - tailscale web updated to use React and be more awesome.
+  - Add --log-http option to tailscale debug portmap.
+  - tailscale netcheck now works even if the OS platform lacks CA certificates.
 
+  v1.52.0
+  - tailscale cert command renews in the background. The current certificate only displays if it has expired.
+  - tailscale status command displays a message about client updates when newer versions are available
+  - tailscale up command displays a message about client updates when newer versions are available
+  - Taildrop now resumes file transfers after partial transfers are interrupted
+  - Taildrop prevents file duplication
+  - Taildrop detects conflicting file transfers and only proceeds with one transfer
+  - Wake on LAN (WoL) is now supported for peer node wake-ups
+  - TCP DNS queries are speculatively started if UDP hasn’t responded quickly enough
+  - Truncated UDP DNS results are properly retried using TCP
+  - Go is updated to version 1.21.3
 
   Full release notes and detailed information is available at https://github.com/tailscale/tailscale/releases
 submitter: Umbrel

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -27,7 +27,7 @@ gallery:
 path: ""
 deterministicPassword: false
 torOnly: false
-releaseNotes: >-
+releaseNotes: |
   This release updates Tailscale from v1.48.1 to v1.52.0 which includes: 
   v1.50.0
   - tailscale ping now sends an ICMP Ping code of 0.


### PR DESCRIPTION
Release notes here https://github.com/tailscale/tailscale/releases

Update works pretty seamlessly which is nice. I updated on my promox umbrel instance and it didn't even drop out.
Did a completely fresh install on Pi instance, and added to tailnet- no issues!
Changed the formatting for release notes so newlines worked.

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (update)
* [x]   Arm64 -> Pi 4 8GB (fresh install)