### PR TITLE
Update uptime kuma to 1.23.3

### DIFF
--- a/homebox/docker-compose.yml
+++ b/homebox/docker-compose.yml
@@ -8,8 +8,7 @@ services:
       APP_PORT: 7745
     
   web:
-    # TODO: update with version-tagged image when available (https://github.com/hay-kot/homebox/pull/372)
-    image: ghcr.io/hay-kot/homebox:nightly-rootless@sha256:1ec765caa21ad37a1fe64eaed2b10b1652169389a275c914eab71e6fd10232b9
+    image: ghcr.io/hay-kot/homebox:v0.10.1@sha256:542f3d6156c7431b2127b35b37f97a121754dd92abb910afe1bbf0008706d2a1
     restart: on-failure
     user: 1000:1000
     environment:

--- a/homebox/docker-compose.yml
+++ b/homebox/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       APP_PORT: 7745
     
   web:
-    image: ghcr.io/hay-kot/homebox:v0.10.1@sha256:542f3d6156c7431b2127b35b37f97a121754dd92abb910afe1bbf0008706d2a1
+    image: ghcr.io/hay-kot/homebox:v0.10.1-rootless@sha256:644bd92d827c7ac2c491fad8fd4607bb2b3598a92efc40236d743619c95c7050
     restart: on-failure
     user: 1000:1000
     environment:

--- a/homebox/umbrel-app.yml
+++ b/homebox/umbrel-app.yml
@@ -24,5 +24,9 @@ path: ""
 torOnly: false
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: >-
+  This This release is a minor release updating dependencies and moving to a Low-Privileged/Distroless Docker Image
+
+  Read the full release notes for additional information and detailed changes at https://github.com/hay-kot/homebox/releases/tag/v0.10.1
 submitter: Xosten
 submission: https://github.com/getumbrel/umbrel-apps/pull/501

--- a/homebox/umbrel-app.yml
+++ b/homebox/umbrel-app.yml
@@ -18,14 +18,13 @@ gallery:
   - 1.jpg
   - 2.jpg
   - 3.jpg
-releaseNotes: ""
 dependencies: []
 path: ""
 torOnly: false
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  This This release is a minor release updating dependencies and moving to a Low-Privileged/Distroless Docker Image
+  This release is a minor release updating dependencies and moving to a Low-Privileged/Distroless Docker Image
 
   Read the full release notes for additional information and detailed changes at https://github.com/hay-kot/homebox/releases/tag/v0.10.1
 submitter: Xosten

--- a/homebox/umbrel-app.yml
+++ b/homebox/umbrel-app.yml
@@ -3,7 +3,7 @@ id: homebox
 name: HomeBox
 tagline: An inventory and organization system built for the home user
 category: files
-version: "0.9.2"
+version: "v0.10.1"
 port: 7745
 description: >-
   Homebox is an inventory and organization system built for the home user! With a focus on simplicity and ease of use, Homebox is the perfect solution for your home inventory, organization, and management needs. 

--- a/uptime-kuma/docker-compose.yml
+++ b/uptime-kuma/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3001
 
   server:
-    image: louislam/uptime-kuma:1.23.0@sha256:7d71e8d044140521ca8101dc4498636fdb753d59ac1979d2a6078204e5b3cfec
+    image: louislam/uptime-kuma:1.23.3@sha256:7d8b69a280bd9fa45d21c44a4f9b133b52925212c5d243f27ef03bcad33de2c1
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/uptime-kuma/umbrel-app.yml
+++ b/uptime-kuma/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: uptime-kuma
 category: networking
 name: Uptime Kuma
-version: "1.23.0"
+version: "1.23.3"
 tagline: Self-hosted uptime monitoring tool
 description: >
   Uptime Kuma is a self-hosted monitoring tool like Uptime Robot.
@@ -39,53 +39,27 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >
-  Updates Uptime Kuma from version 1.21.2 to 1.23.0.
-
-  🐻 It should be the last minor version of Uptime Kuma v1. I will focus on the development of v2. Stay tuned!
-
-  Update: The last minor version (1.23.x) means that there won't be any new features introduced in v1. However, bug fixes will still be provided. You can expect to see 1.23.1, 1.23.2 and so on.
-  
-
-  🆕 New Features:
-  
-  - Added an improved comprehensive monitor list filtering
-
-  - Added an ability to bulk select, pause & resume
-
-  - Added an ability to show certificate expiry on status pages
-
-  - Added Tailscale ping monitor
-
-  - Added badges for status page status
+  Updates Uptime Kuma from version 1.23.0 to 1.23.3
    
-   
-  💇‍♀️ Improvements to Maintenance:
-
-  - Dropdown menu is no longer blocked by the save button bar
-
-  - Added an ability to configure a custom PushDeer server URL
-
-  - Added an ability to set TLS certs (Put ca.pem, key.pen and cert.pem in the data/docker-tls/your_hostname/)
-
-  - Strip trailing slashes to avoid 404 from Home Assistant's API endpoint
-
+  Warning: Due to the security fix, all login sessions will be logged out, after updated to this version.
+  Important: If you are using some unofficial/3rd party tools, it could be a breaking change. You may need to re-generate an auth token.
   
   🐛 Bug Fixes:
   
-  - Fixed Redis authentication reattempt issue
+  - Fixed an issue that notification is not working if the config is too long
   
-  - Fixed notification toggle missing when import from backup
+  - Enable status page certificate expiry badge for all HTTP(s) monitors
 
-  - Fixed the issue that IPv6 addresses could not be displayed in the log
+  - Fixed kafka producer bugs
 
-  - Avoid new timezones or non-existing timezones crash Uptime Kuma
+  - Fixed an issue that x-forwarded-host is not being used correctly
 
-  - Fixed SMTP notification "Ignore TLS Error" option
+  - Fixed a race condition issue that some data is not being saved in the status page editor if you clicked it too fast
 
 
   ⬆️ Security Fixes
 
-  - Hardening: Avoid exposing the Uptime Kuma version to the public
+  - Fixed persistent session tokens issue. There was no way to revoke session tokens even if you changed the password. Now you can revoke them by changing your password if you think they may be leaked (Read more: GHSA-g9v2-wqcj-j99g).
   
   
   Full changelog for versions 1.21.2 to 1.23.0 can be found here: https://github.com/louislam/uptime-kuma/releases


### PR DESCRIPTION
Release notes: https://github.com/louislam/uptime-kuma/releases

Only weird issue I noticed is that it takes a weirdly long time to install on the Pi. Wasn't able to resolve it, if you dont mind, maybe check if this happens on your Pi too.

* [x]    x86_64 -> UmbrelOS on proxmox Debian instance (update and fresh install)
* [x]    Arm64 -> Pi 4 8GB (fresh install)