### PR TITLE
Update vaultwarden to 1.30.0

### DIFF
--- a/vaultwarden/docker-compose.yml
+++ b/vaultwarden/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: vaultwarden/server:1.29.1@sha256:c2849f8189e4d425a9d80db0380566cc38577b289b9e6c88330e190e19af5a30
+    image: vaultwarden/server:1.30.0@sha256:27638a2ae977d66d99891c06562ff9ba78a60869d2e5a94cf2953f1d03fde12f
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/vaultwarden/umbrel-app.yml
+++ b/vaultwarden/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: vaultwarden
 category: files
 name: Vaultwarden
-version: "1.29.1"
+version: "1.30.0"
 tagline: Unofficial Bitwarden® compatible server
 description: >-
   Vaultwarden is an alternative
@@ -45,18 +45,18 @@ description: >-
 
 
   *Please note that Vaultwarden is not associated with the Bitwarden® project nor 8bit Solutions LLC. When using this app, please report any bugs or suggestions to us directly, regardless of whatever clients you are using (mobile, desktop, browser, etc), and do not use Bitwarden®'s official support channels.
-releaseNotes: >-
-  This release updates Vaultwarden from v1.25.0 to v1.29.1. It includes many bug fixes and performance improvements, as well as the following new features:
+releaseNotes: |
+  This release updates Vaultwarden from v1.29.1 to v1.30.1. 
   
-  - Support for Forward Email
-  
-  - WebSocket notifications now work via the default HTTP port
+  Major changes and New Features:
 
-  - The latest Bitwarden Directory Connector can be used now
+  - Added passkey support, allowing the browser extensions to store and use your passkeys, make sure the extension is updated to version 2023.10.0 or newer for passkey support.
   
-  - Support for Argon2 key derivation for the admin page token
+  - Updated web vault to 2023.10.0.
 
-  - and more!
+  - Fixed crashes in ARMv6 devices
+  
+  - Fixed crashes when trying to create/edit a cipher in the mobile applications.
 
 
   The full release notes are available at https://github.com/dani-garcia/vaultwarden/releases


### PR DESCRIPTION
Was hoping to test that data persisted across updates, but TOR is really slow today. Update works fine tho.

https://github.com/dani-garcia/vaultwarden/releases/tag/1.30.0

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (update)
* [x]   Arm64 -> Pi 4 8GB (fresh install)