### PR TITLE
Update tautulli to v2.13.2

### DIFF
--- a/snowflake/docker-compose.yml
+++ b/snowflake/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3800
 
   proxy:
-    image: getumbrel/snowflake:v2.4.1@sha256:36b666435f4f3952dd10afa948e760e46f7e3f6f30b6a6f16c6b0cbeba358916
+    image: getumbrel/snowflake:v2.7.0@sha256:acc5713c5268d3e8c1349a69452451e4a73fe016ccf49621e36ed06f49d72948
     restart: on-failure
     stop_grace_period: 1m
     command: "-log /data/snowflake.log -verbose"

--- a/snowflake/umbrel-app.yml
+++ b/snowflake/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: snowflake
 category: networking
 name: Tor Snowflake Proxy
-version: "2.4.1"
+version: "v2.7.0"
 tagline: Help defeat internet censorship
 description: >-
   Snowflake is a system to defeat internet censorship. People who are
@@ -27,32 +27,29 @@ torOnly: false
 releaseNotes: >-
   Various bugfixes and enhancements:
   
-  - Issue 40224: Bug fix in utls roundtripper
+  - fix(proxy): Correctly close connection pipe when dealing with error 
   
-  - Fix proxy command line help output
+  - Remove proxy churn measurements from broker.
   
-  - Issue 40123: Reduce multicast DNS candidates
+  - fix(proxy): remove _potential_ deadlock
   
-  - Add ICE ephemeral ports range setting
+  - Maintain backward compatability with old clients
   
-  - Reformat using Go 1.19
+  - Randomly select front domain from comma-separated list
   
-  - Update CI tests to include latest and minimum Go versions
+  - Update dependencies
   
-  - Issue 40184: Use fixed unit for bandwidth logging
+  - chore(deps): update module github.com/xtaci/kcp-go/v5 to v5.6.3
   
-  - Update gorilla/websocket to v1.5.0
+  - Remove Golang 1.20 from CI Testing
   
-  - Issue 40175: Server performance improvements
+  - Update CI targets to test android from golang 1.21
   
-  - Issue 40183: Change snowflake proxy log verbosity
+  - Use ShouldBeNil to check for nil values
   
-  - Issue 40117: Display proxy NAT type in logs
+  - continued...
 
   
-  Full changelog: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/blob/7c154e5fd06693ddc4feb5962cab4a13aeebd405/ChangeLog
-  
-  
-  Compare to v2.1.0: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/compare/v2.1.0...v2.4.1
+  Release information: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/1284

--- a/tautulli/docker-compose.yml
+++ b/tautulli/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8181
 
   web:
-    image: lscr.io/linuxserver/tautulli:2.12.5@sha256:4bf16db026fd0aa81f4afa02cb92827f1e072b7de5a7cb71e767e960f8620f1a
+    image: linuxserver/tautulli:2.13.2@sha256:6195b187030637f5588c33988b3686b96f003c726b22958ee0d589549c6fb50f
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
     restart: on-failure

--- a/tautulli/umbrel-app.yml
+++ b/tautulli/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: tautulli
 category: media
 name: tautulli
-version: "2.12.5"
+version: "2.13.2"
 tagline: Monitor your Plex Media Server
 description: >-
   Tautulli is a 3rd party application that you can run alongside your Plex Media Server to monitor activity and track various statistics.
@@ -28,5 +28,15 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 torOnly: false
+releaseNotes: |
+  This release updates Tautulli from v2.12.5 to v2.13.2 which includes: 
+
+  - History: Added quarter values icons for history watch status. (#2179, #2156) (Thanks @herby2212)
+  - Graphs: Added concurrent streams per day graph. (#2046) (Thanks @herby2212)
+  - Exporter: Added metadata directory to exporter fields. Banner exporter fields for tv shows.
+  - UI: Added last triggered time to notification agents and newsletter agent lists.
+  - Other: Added X-Plex-Language header override to config file.
+
+  Full release notes and detailed information is available at https://github.com/Tautulli/Tautulli/releases
 submitter: Pranshu Agrawal
 submission: https://github.com/getumbrel/umbrel-apps/pull/673


### PR DESCRIPTION
Release notes: https://github.com/Tautulli/Tautulli/releases

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install)
* [x]   Arm64 -> Pi 4 8GB (fresh install)