### PR TITLE
Update trilium-notes to 0.61.13

### DIFF
--- a/trilium-notes/docker-compose.yml
+++ b/trilium-notes/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: zadam/trilium:0.60.4@sha256:307b926bfed9133b144a4dfdb11c1b2e053c94ac29355ede8cf5ae017a52d8a5
+    image: zadam/trilium:0.61.13@sha256:f282efb9a022cac6e1eae55d6f456c2a87ee4bed2fc0f2733684ae611937f0ba
     restart: on-failure
     environment:
       - TRILIUM_DATA_DIR=/data

--- a/trilium-notes/docker-compose.yml
+++ b/trilium-notes/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: zadam/trilium:0.61.13@sha256:f282efb9a022cac6e1eae55d6f456c2a87ee4bed2fc0f2733684ae611937f0ba
+    image: zadam/trilium:0.60.4@sha256:307b926bfed9133b144a4dfdb11c1b2e053c94ac29355ede8cf5ae017a52d8a5
     restart: on-failure
     environment:
       - TRILIUM_DATA_DIR=/data

--- a/trilium-notes/umbrel-app.yml
+++ b/trilium-notes/umbrel-app.yml
@@ -70,7 +70,7 @@ releaseNotes: >-
 
   And continuing with the overall 0.61 news:
 
-  - It's possible to upgrade to 0.61 only from 0.60.X. If you're on an older version, download and run 0.60.4 first. Only after that upgrade to 0.61.
+  - It's possible to upgrade to 0.61 only from 0.60.X. If you're on an older version, you will need to uninstall and then reinstall Trilium Notes (back-up data folder first).
 
   0.61 is a big release (in some metrics largest ever) and took time a long time to develop & stabilize. I hope the experience will now be smooth.
 

--- a/trilium-notes/umbrel-app.yml
+++ b/trilium-notes/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: trilium-notes
 category: files
 name: Trilium Notes
-version: "0.60.4"
+version: "0.61.13"
 tagline: Build your personal knowledge base with Trilium Notes
 description: >-
   Features
@@ -61,24 +61,16 @@ torOnly: false
 submitter: Pranshu Agrawal
 submission: https://github.com/getumbrel/umbrel-apps/pull/199
 releaseNotes: >-
-  This update upgrades Trilium Notes from version 0.59.4 to 0.60.4.
+  This update upgrades Trilium Notes from version 0.60.4 to 0.61.13.
 
+  0.61 is a big release. The flagship feature is support for Attachments and all related functionality around it (ETAPI, Sharing ...).
 
-  Version 0.60.4 includes the following changes:
+  - revision history now captures attachments which means that in text notes you can see changes in the included images and file attachments.
 
-  - consistent tooltip arrow style
+  v0.61.13 should bring important fixes:
+  
+  - crashing on migration of inline images
 
-  - selected text in HTML view is searched immediately in find box
+  - sync error with revisions (the underlying cause is unknown, but a more graceful error handling should mitigate the problem)
 
-  - smooth scrolling for TOC
-
-  - improved Cyrillic font support
-
-  - move "tree actions" to the right
-
-  - improved include note display
-
-  - added ability to override default search engine
-
-
-  Full release notes and detailed information for versions between 0.59.4 and 0.60.4. are available at https://github.com/zadam/trilium/releases
+  Full release notes and detailed information for versions between 0.61.0 and 0.61.13. are available at https://github.com/zadam/trilium/releases

--- a/trilium-notes/umbrel-app.yml
+++ b/trilium-notes/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: trilium-notes
 category: files
 name: Trilium Notes
-version: "0.60.4"
+version: "0.61.13"
 tagline: Build your personal knowledge base with Trilium Notes
 description: >-
   Features
@@ -61,24 +61,21 @@ torOnly: false
 submitter: Pranshu Agrawal
 submission: https://github.com/getumbrel/umbrel-apps/pull/199
 releaseNotes: >-
-  This update upgrades Trilium Notes from version 0.59.4 to 0.60.4.
+  This update upgrades Trilium Notes from version 0.60.4 to 0.61.13.
 
+  v0.61.13 should bring important fixes:
 
-  Version 0.60.4 includes the following changes:
+  - crashing on migration of inline images
+  - sync error with revisions (the underlying cause is unknown, but a more graceful error handling should mitigate the problem)
 
-  - consistent tooltip arrow style
+  And continuing with the overall 0.61 news:
 
-  - selected text in HTML view is searched immediately in find box
+  - It's possible to upgrade to 0.61 only from 0.60.X. If you're on an older version, download and run 0.60.4 first. Only after that upgrade to 0.61.
 
-  - smooth scrolling for TOC
+  0.61 is a big release (in some metrics largest ever) and took time a long time to develop & stabilize. I hope the experience will now be smooth.
 
-  - improved Cyrillic font support
+  The flagship feature is support for Attachments and all related functionality around it (ETAPI, Sharing ...).
 
-  - move "tree actions" to the right
+  - revision history now captures attachments, which means that in text notes you can see changes in the included images and file attachments.
 
-  - improved include note display
-
-  - added ability to override default search engine
-
-
-  Full release notes and detailed information for versions between 0.59.4 and 0.60.4. are available at https://github.com/zadam/trilium/releases
+  Full release notes and detailed information for versions between 0.61.0 and 0.61.13. are available at https://github.com/zadam/trilium/releases

--- a/trilium-notes/umbrel-app.yml
+++ b/trilium-notes/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: trilium-notes
 category: files
 name: Trilium Notes
-version: "0.61.13"
+version: "0.60.4"
 tagline: Build your personal knowledge base with Trilium Notes
 description: >-
   Features
@@ -61,16 +61,24 @@ torOnly: false
 submitter: Pranshu Agrawal
 submission: https://github.com/getumbrel/umbrel-apps/pull/199
 releaseNotes: >-
-  This update upgrades Trilium Notes from version 0.60.4 to 0.61.13.
+  This update upgrades Trilium Notes from version 0.59.4 to 0.60.4.
 
-  0.61 is a big release. The flagship feature is support for Attachments and all related functionality around it (ETAPI, Sharing ...).
 
-  - revision history now captures attachments which means that in text notes you can see changes in the included images and file attachments.
+  Version 0.60.4 includes the following changes:
 
-  v0.61.13 should bring important fixes:
-  
-  - crashing on migration of inline images
+  - consistent tooltip arrow style
 
-  - sync error with revisions (the underlying cause is unknown, but a more graceful error handling should mitigate the problem)
+  - selected text in HTML view is searched immediately in find box
 
-  Full release notes and detailed information for versions between 0.61.0 and 0.61.13. are available at https://github.com/zadam/trilium/releases
+  - smooth scrolling for TOC
+
+  - improved Cyrillic font support
+
+  - move "tree actions" to the right
+
+  - improved include note display
+
+  - added ability to override default search engine
+
+
+  Full release notes and detailed information for versions between 0.59.4 and 0.60.4. are available at https://github.com/zadam/trilium/releases


### PR DESCRIPTION
Release notes: https://github.com/zadam/trilium/releases

Note the main dev does say this: 'It's possible to upgrade to 0.61 only from 0.60.X. If you're on an older version, download and run 0.60.4 first. Only after that upgrade to 0.61.'

I had no issues updating (it was 0.60.4 before this), but should we be aware of users that may be on an older version because they can't manually go between versions?

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install)
* [x]   Arm64 -> Pi 4 8GB (fresh install and update)