### PR TITLE
Update gitea to 1.21.0

### DIFF
--- a/gitea/docker-compose.yml
+++ b/gitea/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: gitea/gitea:1.20.3-rootless@sha256:58495fb9d1eab613e1fd3d4274a32567dea0c56fcd2fa99e21a0751c56182dd4
+    image: gitea/gitea:1.21.0-rootless@sha256:89e4d9f64c030a1415454259f58c517e81bbe9710db1e12a17849e2c198df301
     user: "1000:1000"
     restart: on-failure
     ports:

--- a/gitea/umbrel-app.yml
+++ b/gitea/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: gitea
 category: developer
 name: Gitea
-version: "1.20.3"
+version: "1.21.0"
 tagline: A painless self-hosted Git service
 description: >-
   Gitea is a painless self-hosted Git service. It is similar to
@@ -42,61 +42,41 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >
-  This release updates Gitea from 1.19.1 to 1.20.3.
+  This release updates Gitea from 1.20.3 to 1.21.0.
   A full list of new features, improvements, and bug fixes
-  for versions between 1.19.1 and 1.20.3 can be found here: https://github.com/go-gitea/gitea/releases.
+  for versions between 1.20.3 and 1.21.0 can be found here: https://github.com/go-gitea/gitea/releases.
   
   
-  Version 1.20.3 release notes highlights:
+  Version 1.21.0 release notes highlights:
   
   
   BREAKING
 
-  - Fix the wrong derive path
+  - Restrict certificate type for builtin SSH server
 
-
-  SECURITY
-
-  - Fix API leaking Usermail if not logged in
+  - Refactor to use urfave/cli/v2
 
   
   FEATURES 
   
-  - Add ThreadID parameter for Telegram webhooks
+  - User details page
+
+  - Chore(actions): support cron schedule task 
+
+  - Add Retry button when creating a mirror-repo fails 
   
   
   ENHANCEMENTS
   
-  - Add minimum polyfill to support "relative-time-element" in PaleMoon
+  - Render email addresses as such if followed by punctuation
 
-  - Move dropzone progress bar to bottom to show filename when uploading
+  - Show error toast when file size exceeds the limits
   
-  - Fix dark theme highlight for "NameNamespace"
+  - Fix citation error when the file size is larger than 1024 bytes
   
-  - Display human-readable text instead of cryptic filemodes
+  - Remove action runners on user deletion 
   
-  - Warn instead of reporting an error when a webhook cannot be found
-  
-  - Use 'object-fit: contain' for oauth2 custom icons
-  
-  - Fix the topic validation rule and suport dots
-  
-
-  BUGFIXES
-  
-  - Fix "issueReposQueryPattern does not match query"
-
-  - Fix incorrect CLI exit code and duplicate error message
-
-  - Fix storage path logic especially for relative paths
-
-  - Fix attachment clipboard copy on insecure origin
-  
-  - Fix wrong middleware sequence
-
-  - Avoiding accessing undefined tributeValues
-
-  - Fix admin queue page title and fix CI failures
+  - Remove set tabindex on view issue
   
 
 torOnly: false

--- a/gitea/umbrel-app.yml
+++ b/gitea/umbrel-app.yml
@@ -42,19 +42,10 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >
-  This release updates Gitea from 1.20.3 to 1.21.0.
-  A full list of new features, improvements, and bug fixes
-  for versions between 1.20.3 and 1.21.0 can be found here: https://github.com/go-gitea/gitea/releases.
-  
-  
+  This release updates Gitea from 1.20.3 to 1.21.0. Please review breaking changes for 1.21.0 listed in the full release notes before updating https://github.com/go-gitea/gitea/releases/tag/v1.21.0.
+
+
   Version 1.21.0 release notes highlights:
-  
-  
-  BREAKING
-
-  - Restrict certificate type for builtin SSH server
-
-  - Refactor to use urfave/cli/v2
 
   
   FEATURES 
@@ -77,8 +68,12 @@ releaseNotes: >
   - Remove action runners on user deletion 
   
   - Remove set tabindex on view issue
-  
 
+
+  And more!
+
+  A full list of new features, improvements, and bug fixes
+  for versions between 1.20.3 and 1.21.0 can be found here: https://github.com/go-gitea/gitea/releases.
 torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/d62e00353917143a3a10d3b376859f51b665d150


### PR DESCRIPTION
https://github.com/go-gitea/gitea/releases/tag/v1.21.0

```
BREAKING

- Restrict certificate type for builtin SSH server (https://github.com/go-gitea/gitea/pull/26789)
- Refactor to use urfave/cli/v2 (https://github.com/go-gitea/gitea/pull/25959)
- Move public asset files to the proper directory (https://github.com/go-gitea/gitea/pull/25907)
- Remove commit status running and warning to align GitHub (https://github.com/go-gitea/gitea/pull/25839) (partially reverted: Restore warning commit status (https://github.com/go-gitea/gitea/pull/27504) (https://github.com/go-gitea/gitea/pull/27529))
- Remove "CHARSET" config option for MySQL, always use "utf8mb4" (https://github.com/go-gitea/gitea/pull/25413)
- Set SSH_AUTHORIZED_KEYS_BACKUP to false (https://github.com/go-gitea/gitea/pull/25412)
```

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (fresh install and update)

Everything worked fine for me and data persisted. Don't think any docker-compose.yml changes are required to reflect breaking changes.