### PR TITLE
lightning-terminal: update to v0.12.1-alpha

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.12.0-alpha@sha256:11eab3e46437844e7e227cb32880a087bca7637685914cab07b758eab8211fea
+    image: lightninglabs/lightning-terminal:v0.12.1-alpha@sha256:185f984d1b499a8d2cff4fc65747c7f20402714c112a907d578ceea5f7bd5003
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,17 +2,13 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.12.0-alpha"
+version: "0.12.1-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
   outbound liquidity on the Lightning Network. Keep your channels open and the
   funds flowing. It provides a visual interface for interacting with your
   channels and balances using Loop. 
-
-
-  New: Introducing Lightning Pool, a marketplace for Lightning channels. You can now earn sats by opening new channels to those looking to receive funds on Lightning for a set period of time, or rent a channel to start accepting payments instantly. Join the marketplace and start putting your Bitcoin to work.
-
 
   Why use Pool?
 
@@ -34,6 +30,17 @@ description: >-
   - Configurable wait times and "batching" allow for further fee savings
 
   - Refill and offload funds from any number of Lightning channels in a single on-chain transaction
+
+
+  IMPORTANT NOTE FOR UMBREL/LIGHTNING TERMINAL USERS:
+  DO NOT UNDER ANY CIRCUMSTANCE uninstall (or re-install) the "Lightning
+  Terminal" app without first making a manual backup of all local tapd data,
+  if you are using Taproot Assets as part of the "Lightning Terminal" app with
+  Umbrel. Uninstalling Umbrel apps deletes application data. This Taproot
+  Assets application data encumbers Taproot Assets AND bitcoin funds. Receiving
+  and sending tapd assets updates the daemon's funds-custody material. Merely
+  having the lnd seed phrase is NOT enough to restore assets minted or received.
+  WITHOUT BACKUP BEFORE DELETION, FUNDS ARE DESTROYED.
 developer: Lightning Labs
 website: https://lightning.engineering
 dependencies:
@@ -50,10 +57,10 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  This release of Lightning Terminal (LiT) updates the integrated Taproot
-  Assets daemon to the latest version (v0.3.0-alpha), which adds support for
-  Taproot Assets on the Bitcoin mainnet! This release also includes an update
-  to the latest patch release of the integrated Loop daemon.
+  This release of Lightning Terminal (LiT) includes updates to the versions
+  of the integrated LND, Loop and Taproot Assets daemons. This release also
+  updates the documentation for RPC commands to be more coherent, as well as
+  various minor bug fixes.
 
 
   IMPORTANT NOTE: To avoid loss of funds, it's imperative that you read the
@@ -84,7 +91,7 @@ releaseNotes: >-
   feedback from the community.
 
 
-  This release packages LND v0.17.0-beta, Taproot Assets Daemon v0.3.0-alpha,
-  Loop v0.26.4-beta, Pool v0.6.4-beta and Faraday v0.2.11-alpha.
+  This release packages LND v0.17.1-beta, Taproot Assets Daemon v0.3.1-alpha,
+  Loop v0.26.5-beta, Pool v0.6.4-beta and Faraday v0.2.11-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -68,15 +68,13 @@ releaseNotes: >-
   before using tapd on mainnet!
 
 
-  IMPORTANT NOTE FOR UMBREL/LIGHTNING TERMINAL USERS:
-  DO NOT UNDER ANY CIRCUMSTANCE uninstall (or re-install) the "Lightning
-  Terminal" app without first making a manual backup of all local tapd data,
-  if you are using Taproot Assets as part of the "Lightning Terminal" app with
-  Umbrel. Uninstalling Umbrel apps deletes application data. This Taproot
-  Assets application data encumbers Taproot Assets AND bitcoin funds. Receiving
-  and sending tapd assets updates the daemon's funds-custody material. Merely
-  having the lnd seed phrase is NOT enough to restore assets minted or received.
-  WITHOUT BACKUP BEFORE DELETION, FUNDS ARE DESTROYED.
+  🚨 CRITICAL REMINDER FOR TAPROOT ASSETS USERS:
+
+  Uninstalling this app permanently erases application data, which includes Taproot Assets and Bitcoin funds.
+  Before uninstalling or re-installing this app, you must backup the application's .tapd data folder in order to restore your taproot assets upon reinstallation.
+  Failure to do so will result in permanent loss of funds. We recommend that you make regular backups.
+  Follow this guide to backup your tapd data:
+  https://community.umbrel.com/t/backing-up-taproot-assets-tapd-data-in-lightning-terminal/14360
 
 
   The Taproot Assets daemon is still in alpha state, which means there can

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -12,8 +12,9 @@ description: >-
 
 
   🚨 CRITICAL REMINDER FOR TAPROOT ASSETS USERS:
+
   Uninstalling this app permanently erases application data, which includes Taproot Assets and Bitcoin funds.
-  Before uninstalling or re-installing this app, you must backup the application's .tapd data folder in order to restore your taproot assets.
+  Before uninstalling or re-installing this app, you must backup the application's .tapd data folder in order to restore your taproot assets upon reinstallation.
   Failure to do so will result in permanent loss of funds. We recommend that you make regular backups.
   Follow this guide to backup your tapd data:
   https://community.umbrel.com/t/backing-up-taproot-assets-tapd-data-in-lightning-terminal/14360

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -8,7 +8,16 @@ description: >-
   Lightning Terminal is the easiest way to manage inbound and
   outbound liquidity on the Lightning Network. Keep your channels open and the
   funds flowing. It provides a visual interface for interacting with your
-  channels and balances using Loop. 
+  channels and balances using Loop.
+
+
+  🚨 CRITICAL REMINDER FOR TAPROOT ASSETS USERS:
+  Uninstalling this app permanently erases application data, which includes Taproot Assets and Bitcoin funds.
+  Before uninstalling or re-installing this app, you must backup the application's .tapd data folder in order to restore your taproot assets.
+  Failure to do so will result in permanent loss of funds. We recommend that you make regular backups.
+  Follow this guide to backup your tapd data:
+  https://community.umbrel.com/t/backing-up-taproot-assets-tapd-data-in-lightning-terminal/14360
+
 
   Why use Pool?
 
@@ -30,17 +39,6 @@ description: >-
   - Configurable wait times and "batching" allow for further fee savings
 
   - Refill and offload funds from any number of Lightning channels in a single on-chain transaction
-
-
-  IMPORTANT NOTE FOR UMBREL/LIGHTNING TERMINAL USERS:
-  DO NOT UNDER ANY CIRCUMSTANCE uninstall (or re-install) the "Lightning
-  Terminal" app without first making a manual backup of all local tapd data,
-  if you are using Taproot Assets as part of the "Lightning Terminal" app with
-  Umbrel. Uninstalling Umbrel apps deletes application data. This Taproot
-  Assets application data encumbers Taproot Assets AND bitcoin funds. Receiving
-  and sending tapd assets updates the daemon's funds-custody material. Merely
-  having the lnd seed phrase is NOT enough to restore assets minted or received.
-  WITHOUT BACKUP BEFORE DELETION, FUNDS ARE DESTROYED.
 developer: Lightning Labs
 website: https://lightning.engineering
 dependencies:


### PR DESCRIPTION
In this PR we bump Litd to `v0.12.1-alpha`.

See the release notes here: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.12.1-alpha

I've also updated the description of LiT as discussed in:
https://github.com/getumbrel/umbrel-apps/pull/811#issuecomment-1780111553

In short I've the warning for LiT users using tapd through Umbrel, that we also include in the release notes.
If the format of this warning is incorrect, based on how it should be formatted in the description field, feel very much free to change it!

Happy to address any additional feedback!