### PR TITLE
Update Immich to 1.88.2

### DIFF
--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   app_proxy:
     environment:
       APP_HOST: immich_server_1
-      APP_PORT: 8080
+      APP_PORT: 3001
       PROXY_AUTH_WHITELIST: "/api/*,/search/*"
 
   server:

--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*,/search/*"
 
   server:
-    image: ghcr.io/immich-app/immich-server:v1.88.2@sha256:d91f7b58ccc9fe57a62e037e98882fe88abd36c8e8a1949f7af0db13049d0e92
+    image: ghcr.io/immich-app/immich-server:v1.88.2@sha256:ac214c6c4e7f6c2133b885d9e6ebc7696cbcf96a148c95746eef15eef0cea71a
     command: [ "start.sh", "immich" ]
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
@@ -36,7 +36,7 @@ services:
     restart: on-failure
 
   microservices:
-    image: ghcr.io/immich-app/immich-server:v1.88.2@sha256:d91f7b58ccc9fe57a62e037e98882fe88abd36c8e8a1949f7af0db13049d0e92
+    image: ghcr.io/immich-app/immich-server:v1.88.2@sha256:ac214c6c4e7f6c2133b885d9e6ebc7696cbcf96a148c95746eef15eef0cea71a
     # This service cannot run under 1000:1000
     # And because the uploads are shared
     # We'll run immich specific services as root
@@ -52,7 +52,7 @@ services:
     restart: on-failure
 
   machine-learning:
-    image: ghcr.io/immich-app/immich-machine-learning:v1.88.2@sha256:d63de8141e64d77423a23c28ffc9c622420c7fd506fa0dc061f6ff6fac7b2f8e
+    image: ghcr.io/immich-app/immich-machine-learning:v1.88.2@sha256:134b6d16b76acd2b6a6ee43c6866668c1c00c33fb3c989bbae5ad867acc2f71b
     volumes:
       - ${APP_DATA_DIR}/data/model-cache:/cache
     environment:

--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -29,8 +29,6 @@ services:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
     environment:
       <<: *env
-    ports:
-      - 2283:3001
     depends_on:
       - redis
       - postgres

--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -13,24 +13,24 @@ x-environment: &env
   REVERSE_GEOCODING_PRECISION: "3"
   PUBLIC_LOGIN_PAGE_MESSAGE: ""
   TYPESENSE_API_KEY: &typesense_api_key "any-text-for-self-hosted-typesense"
-  IMMICH_SERVER_URL: &immich_server_url "http://immich_server_1:3001"
-  IMMICH_WEB_URL: &immich_web_url "http://immich_web_1:3000"
   IMMICH_MACHINE_LEARNING_URL: "http://immich_machine-learning_1:3003"
 
 services:
   app_proxy:
     environment:
-      APP_HOST: immich_proxy_1
+      APP_HOST: immich_server_1
       APP_PORT: 8080
       PROXY_AUTH_WHITELIST: "/api/*,/search/*"
 
   server:
-    image: ghcr.io/immich-app/immich-server:v1.85.0@sha256:b4c9bc6778a142d9ee1ef61c30a498dc2e84d3aabb50a7d4516d9af346db2743
+    image: ghcr.io/immich-app/immich-server:v1.88.2@sha256:d91f7b58ccc9fe57a62e037e98882fe88abd36c8e8a1949f7af0db13049d0e92
     command: [ "start.sh", "immich" ]
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
     environment:
       <<: *env
+    ports:
+      - 2283:3001
     depends_on:
       - redis
       - postgres
@@ -38,7 +38,7 @@ services:
     restart: on-failure
 
   microservices:
-    image: ghcr.io/immich-app/immich-server:v1.85.0@sha256:b4c9bc6778a142d9ee1ef61c30a498dc2e84d3aabb50a7d4516d9af346db2743
+    image: ghcr.io/immich-app/immich-server:v1.88.2@sha256:d91f7b58ccc9fe57a62e037e98882fe88abd36c8e8a1949f7af0db13049d0e92
     # This service cannot run under 1000:1000
     # And because the uploads are shared
     # We'll run immich specific services as root
@@ -54,15 +54,9 @@ services:
     restart: on-failure
 
   machine-learning:
-    image: ghcr.io/immich-app/immich-machine-learning:v1.85.0@sha256:1fc3e645169ada10d73b6a740434b5821f19003d436a8aeb7a5b9482c9b2f704
+    image: ghcr.io/immich-app/immich-machine-learning:v1.88.2@sha256:d63de8141e64d77423a23c28ffc9c622420c7fd506fa0dc061f6ff6fac7b2f8e
     volumes:
       - ${APP_DATA_DIR}/data/model-cache:/cache
-    environment:
-      <<: *env
-    restart: on-failure
-
-  web:
-    image: ghcr.io/immich-app/immich-web:v1.85.0@sha256:10778b177594390e1a9ec0d5e80150fb9c6855ff964a7ceb2eded4728abaa821
     environment:
       <<: *env
     restart: on-failure
@@ -74,16 +68,6 @@ services:
       TYPESENSE_DATA_DIR: "/data"
     volumes:
       - ${APP_DATA_DIR}/data/tsdata:/data
-    restart: on-failure
-
-  proxy:
-    image: ghcr.io/immich-app/immich-proxy:v1.85.0@sha256:80e290eefe53271738cc6558b5b51296ac1cde94f1144eed873c61817a764928
-    environment:
-      IMMICH_SERVER_URL: *immich_server_url
-      IMMICH_WEB_URL: *immich_web_url
-    depends_on:
-      - server
-      - web
     restart: on-failure
 
   redis:

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: immich
 category: files
 name: Immich
-version: "v1.85.0"
+version: "v1.88.2"
 tagline: High-performance photo and video backup solution
 description: >-
   An open-source and high-performance self-hosted backup solution for the videos and photos on your mobile device
@@ -45,39 +45,9 @@ description: >-
   
   - User-defined storage structure
 releaseNotes: >-
-  ⚠️ The server and mobile app must be on the same version for the application to work correctly. After updating, you may need to re-run
-  metadata extraction for videos impacted by a bug that has now been fixed.
-  
+  In this release we have simplified how Immich is deployed, beautified our app interface with a new font, namely Overpass,
+  and finally released version 2 of our command line interface (CLI), which has been in the works for the past six months.
 
-  Welcome to release v1.85.0 of Immich. This release introduces many bug fixes across the app, server, and web, along with new features.
-  The most notable changes include:
-
-  - Changing the /server-info/stats endpoint to /server-info/statistics.
-
-  - Introducing global activity in a shared album and activity on the mobile app and album’s option.
-
-  - Adding a new option to shuffle slideshow, allowing you to randomize the order.
-
-  - Fixing a notable issue: Bulk data fetching for initial sync on the mobile app was causing the app to crash due to an out-of-memory error when dealing with a very large gallery.
-
-  - Introducing a new mobile app bar and user profile screen.
-
-  - Adding a shared link with password option.
-
-  - Introducing shared album activity on the web.
-
-  - Adding a custom scan interval for the external library.
-
-  - Fixing a notable issue: The app was unable to download machine learning models from the S3 bucket.
-
-  - Introducing asset stacking.
-
-  - Adding shared links on mobile.
-
-  - Introducing new storage template variables.
-
-  - Adding a custom theme.
-  
 
   Full release notes are found at: https://github.com/immich-app/immich/releases
 developer: Alex Tran

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -45,6 +45,9 @@ description: >-
   
   - User-defined storage structure
 releaseNotes: >-
+  ⚠️ Your mobile app must be on at least version 1.88.0 to work with this release of Immich.
+
+  
   In this release we have simplified how Immich is deployed, beautified our app interface with a new font, namely Overpass,
   and finally released version 2 of our command line interface (CLI), which has been in the works for the past six months.
 


### PR DESCRIPTION
For compatibility with mobile clients, Immich must be updated. See https://github.com/getumbrel/umbrel-apps/issues/865

1.88.0 of immich includes a breaking change, including breaking login functionality for mobile clients.

See documentation on update path here: https://github.com/immich-app/immich/discussions/5086

This PR performs the update as documented.