### PR TITLE
Update esphome to 2023.11.6

### DIFF
--- a/esphome/docker-compose.yml
+++ b/esphome/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 6052
 
   server:
-    image: esphome/esphome:2023.2.4@sha256:8428b83a5713e79bad44bc2f3c740a3dc3d446dc5bb08643dfdca4dda31c2b5d
+    image: esphome/esphome:2023.11.6@sha256:783e2131fcff2c457846339a80f6ed981e58e5f86de3578f742e3bed87f7d5b2
     volumes:
       - ${APP_DATA_DIR}/data:/config
     restart: on-failure

--- a/esphome/umbrel-app.yml
+++ b/esphome/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: esphome
 category: automation
 name: ESPHome
-version: "2023.2.4"
+version: "2023.11.6"
 tagline: Intelligently manage all your ESP8266/ESP32 devices
 description: >-
   ESPHome is a system to control your ESP8266/ESP32 by simple yet powerful configuration files and control them remotely through Home Automation systems.
@@ -21,17 +21,13 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  This release updates ESPHome from version 2022.6.2 to 2023.2.4. A full list of new features, new component support, breaking changes, and bug fixes for versions 
-  between 2022.6.2 and 2023.2.4 can be found here: https://github.com/esphome/esphome/releases.
+  This release updates ESPHome from version 2023.2.4 to 2023.11.6. A full list of new features, new component support, breaking changes, and bug fixes for versions 
+  between 2023.2.4 and 2023.11.6 can be found here: https://github.com/esphome/esphome/releases.
 
 
-  Version 2023.2.4 release notes:
+  Version 2023.11.6 release notes:
 
-  - BL0939 state_class set for energy sensors
-
-  - fix wiegand tag parity
-
-  - Fix multiple remote_receivers with triggers esphome#4477 by @jesserockz
-
+  - Fix write_speaker without speaker in config
+  
 submitter: ShonP40
 submission: https://github.com/getumbrel/umbrel-apps/pull/43

--- a/esphome/umbrel-app.yml
+++ b/esphome/umbrel-app.yml
@@ -21,6 +21,9 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
+  ⚠️ As usual, please check that your configurations are still working correctly after updating.
+
+  
   This release updates ESPHome from version 2023.2.4 to 2023.11.6. A full list of new features, new component support, breaking changes, and bug fixes for versions 
   between 2023.2.4 and 2023.11.6 can be found here: https://github.com/esphome/esphome/releases.
 


### PR DESCRIPTION
Release notes: https://github.com/esphome/esphome/releases

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install)
* [x]   Arm64 -> Pi 4 8GB (fresh install and update)