### PR TITLE
Update heimdall to 2.5.8

### DIFF
--- a/ghostfolio/docker-compose.yml
+++ b/ghostfolio/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3334
 
   server:
-    image: ghostfolio/ghostfolio:2.14.0@sha256:7172bd8d94dc1f774a85ab2f7660abb5408d7a3a7301e117589f09e7b03b71e3
+    image: ghostfolio/ghostfolio:2.27.1@sha256:ac29524248f2c584dd1fcec17ae23fb0343e6988aa2708517d5efad4d18a4067
     restart: on-failure
     environment:
       NODE_ENV: production

--- a/ghostfolio/umbrel-app.yml
+++ b/ghostfolio/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ghostfolio
 category: finance
 name: Ghostfolio
-version: "2.14.0"
+version: "2.27.1"
 tagline: Manage your wealth like a boss
 description: >-
   Ghostfolio is a privacy-first, open source dashboard for your personal finances.
@@ -31,32 +31,17 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: >
-  This release upgrades Ghostfolio from v1.287.0 to v2.14.0, and includes numerous bug fixes, performance improvements, and exciting new features. Here's what's new in the latest version:
+  This release upgrades Ghostfolio from v2.14.0 to v2.27.1, and includes numerous bug fixes, performance improvements, and exciting new features. Here's what's new in the latest version:
   
-
-  Added:
-
-    - Added the OpenFIGI data enhancer for Financial Instrument Global Identifier (FIGI)
-    - Added figi, figiComposite and figiShareClass to the asset profile model
 
   Changed:
 
-    - Moved the fees on account level feature from experimental to general availability
-    - Moved the interest on account level feature from experimental to general availability
-    - Moved the search for a holding from experimental to general availability
-    - Improved the error message in the activities import for csv files
-    - Removed the application version from the client
-    - Allowed to edit today’s historical market data in the asset profile details dialog of the admin control panel
+    - Reverted Nx from version 17.1.3 to 17.0.2
+    - Extended the chart in the account detail dialog by historical cash balances
+    - Improved the error log for a timeout in the data source request
+    - Improved the language localization for German (de)
+    - Upgraded angular from version 16.2.12 to 17.0.4
 
-  Fixed:
-
-    - Fixed the style of the active page in the header navigation
-    - Trimmed text in i18n service to query messages.*.xlf files on the server
-
-  Special Thanks
-
-    @dl90
-    @dtslvr
 
   For full release notes and additional changes from previous versions, please visit: https://github.com/ghostfolio/ghostfolio/releases
 submitter: BeauAgst

--- a/heimdall/docker-compose.yml
+++ b/heimdall/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: lscr.io/linuxserver/heimdall:2.5.6@sha256:dc4f01cd09a9a2f1dbb9c2029d1300070861355754004ac70b33723bd42ff957
+    image: linuxserver/heimdall:2.5.8@sha256:462bf7fb9d11bbd8ee90924cac613efae85a6f666c371a9bc345386f83cdf404
     volumes:
       - ${APP_DATA_DIR}/config:/config
     environment:

--- a/heimdall/umbrel-app.yml
+++ b/heimdall/umbrel-app.yml
@@ -3,7 +3,7 @@ id: heimdall
 name: Heimdall
 tagline: Organize your most used web sites in a simple way
 category: files
-version: "2.5.6"
+version: "2.5.8"
 port: 7392
 description: >-
   Heimdall is a dashboard for all your web applications. It doesn't need to be limited to applications though, you can add links to anything you like.
@@ -28,21 +28,19 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >
-  This release updates Heimdall from v2.5.5 to v2.5.6. It includes many bug fixes and performance improvements, as well as the following new features:
+  This release updates Heimdall from v2.5.6 to v2.5.8. It includes many bug fixes and performance improvements, as well as the following new features:
 
-  - fix: Add more error handling for app test
+  - Fix and add SVG support 
 
-  - fix: Update jquery, jquery-ui
+  - Add issue-pr workflows
   
-  - use jquery-sortablejs instead of jquery-ui
+  - Fix sortable tooltip 
 
-  - fix language setting only available in view
+  - Remove register route
   
-  - fix: Route titlecolour error
+  - Add Trianglify background option
 
-  - Update Korean and Chinese language
-
-  - Added Ukrainian translation
+  - Validate icons to be images
 
 
   The full release notes are available at https://github.com/linuxserver/Heimdall/releases


### PR DESCRIPTION
Release notes: https://github.com/linuxserver/Heimdall/releases

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (fresh install and update)

Data persisted across update.