### PR TITLE
feat: bump n8n to 1.18.1

### DIFF
--- a/n8n/docker-compose.yml
+++ b/n8n/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       PROXY_AUTH_WHITELIST: "/webhook-test/*,/webhook/*"
 
   server:
-    image: n8nio/n8n:1.9.3@sha256:35f27c4692019f1bf363bc15f4834d7429053e5cb9f493046495cc64936a224c
+    image: n8nio/n8n:1.18.1@sha256:85320dd3baa2e752084f9a1dd584a249036dd3b20bed59495d9c55ed62950fa5
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/home/node/.n8n

--- a/n8n/umbrel-app.yml
+++ b/n8n/umbrel-app.yml
@@ -4,42 +4,8 @@ category: automation
 name: n8n
 version: "1.18.1"
 releaseNotes: >-
-  Version Update Highlights (1.9.3 to 1.18.1):
-
-
-  Bug Fixes:
-    - AWS DynamoDB Node: Improve error message parsing.
-  
-    - core: Prevent error messages due to statistics about data loading.
-  
-    - core: Tighten checks for multi-main setup usage.
-  
-    - core: Use AbortController to notify nodes to abort execution.
-  
-    - editor: Disable context menu actions in read-only mode.
-  
-    - editor: Fix cloud plan data loading on instance.
-  
-    - editor: Fix credential icon for old node type version.
-  
-    - editor: Fix icon for unknown node type.
-  
-    - editor: Fix mouse position in workflow previews.
-  
-    - editor: Suppress dev server websocket messages in workflow view.
-  
-    - Google Sheets Node: Fix issue with paired items not being set correctly.
-  
-    - Google Sheets Node: Read operation execute for each item.
-  
-    - HTTP Request Node: Enable expressions for binary input data fields.
-  
-    - Microsoft SQL Node: Prevent double escaping table name.
-  
-    - Notion Node: Fix broken Notion node parameters.
-  
-  
-  Full details for changes made since version 1.9.3 can be found at https://github.com/n8n-io/n8n/blob/master/CHANGELOG.md
+  This release updates n8n from version 1.9.3 to 1.18.1. A full list of new features, performance improvements, and bug fixes for versions 
+  between 1.9.3 to 1.18.1can be found at https://github.com/n8n-io/n8n/blob/master/CHANGELOG.md
 tagline: Build complex workflows, really fast
 description: >-
   n8n is an extendable workflow automation tool. With a fair-code distribution model, n8n will always have visible source code, 

--- a/n8n/umbrel-app.yml
+++ b/n8n/umbrel-app.yml
@@ -5,7 +5,7 @@ name: n8n
 version: "1.18.1"
 releaseNotes: >-
   This release updates n8n from version 1.9.3 to 1.18.1. A full list of new features, performance improvements, and bug fixes for versions 
-  between 1.9.3 to 1.18.1can be found at https://github.com/n8n-io/n8n/blob/master/CHANGELOG.md
+  between 1.9.3 to 1.18.1 can be found at https://github.com/n8n-io/n8n/blob/master/CHANGELOG.md
 tagline: Build complex workflows, really fast
 description: >-
   n8n is an extendable workflow automation tool. With a fair-code distribution model, n8n will always have visible source code, 

--- a/n8n/umbrel-app.yml
+++ b/n8n/umbrel-app.yml
@@ -2,47 +2,44 @@ manifestVersion: 1
 id: n8n
 category: automation
 name: n8n
-version: "1.9.3"
+version: "1.18.1"
 releaseNotes: >-
-  Version Update Highlights (1.4.0 to 1.9.3):
+  Version Update Highlights (1.9.3 to 1.18.1):
 
 
   Bug Fixes:
-    - Improved handling of content-type and content-disposition headers (1.8.0)
-    - Enhanced security by addressing CVE issues (1.7.0)
-    - Fixed issues with various nodes, such as Google Cloud Firestore, HubSpot, and Zoho CRM (1.7.0)
-    - Improved error handling for HTTP Request and Webhook Nodes (1.7.0, 1.5.0)
-    - Resolved issues related to SSL certificates (1.5.0)
-    - Fixed MongoDB and PostgreSQL Node issues (1.5.0)
-    - Addressed issues with Date & Time Node and Microsoft Excel 365 Node (1.5.0)
-    - Fixed Agile CRM Node issues (1.5.0)
-
-
-  Features:
-    - Introduced support for in-transit encryption (TLS) on Redis connections (1.6.0)
-    - Added support for floating licenses (1.6.0)
-    - Enhanced user authentication and security with MFA (1.5.0)
-    - Added support for token credentials in Strapi Node (1.5.1)
-    - Introduced external secrets storage for credentials (1.5.0)
-    - Improved user management with filtering, selection, and pagination (1.5.0)
-    - Introduced a command to trigger license refresh on workers (1.5.0)
-    - Added RSA option for SSH key generation (1.5.0)
-    - Overhauled nodes like Linear, Microsoft Outlook, and Set (1.8.0)
-    - Introduced Tournament as the new default expression evaluator (1.8.0)
-    - Introduced an initial workflow history API (1.8.0)
-    - Added object store service (1.8.0)
-    - Introduced onboarding flow (1.9.0)
-    - Added telemetry for user cloud activity (1.9.0)
-    - Implemented an option for enabling WAL mode for SQLite (1.7.0)
-
-
-  Performance Improvements:
-    - Optimized execution management to prevent orphan executions (1.6.0)
-    - Improved efficiency by skipping unneeded calls on pruning cycles (1.8.0)
-    - These highlights showcase the major changes and improvements made across the versions, including bug fixes, security enhancements, and new features to enhance the user experience and reliability of the platform.
-
-
-  Full details for changes made since version 1.4.0 can be found at https://github.com/n8n-io/n8n/blob/master/CHANGELOG.md?plain=1#L1-L186
+    - AWS DynamoDB Node: Improve error message parsing.
+  
+    - core: Prevent error messages due to statistics about data loading.
+  
+    - core: Tighten checks for multi-main setup usage.
+  
+    - core: Use AbortController to notify nodes to abort execution.
+  
+    - editor: Disable context menu actions in read-only mode.
+  
+    - editor: Fix cloud plan data loading on instance.
+  
+    - editor: Fix credential icon for old node type version.
+  
+    - editor: Fix icon for unknown node type.
+  
+    - editor: Fix mouse position in workflow previews.
+  
+    - editor: Suppress dev server websocket messages in workflow view.
+  
+    - Google Sheets Node: Fix issue with paired items not being set correctly.
+  
+    - Google Sheets Node: Read operation execute for each item.
+  
+    - HTTP Request Node: Enable expressions for binary input data fields.
+  
+    - Microsoft SQL Node: Prevent double escaping table name.
+  
+    - Notion Node: Fix broken Notion node parameters.
+  
+  
+  Full details for changes made since version 1.9.3 can be found at https://github.com/n8n-io/n8n/blob/master/CHANGELOG.md
 tagline: Build complex workflows, really fast
 description: >-
   n8n is an extendable workflow automation tool. With a fair-code distribution model, n8n will always have visible source code, 


### PR DESCRIPTION
Update N8N version to 1.4.0.
This is the latest stable version.
There are many new features from version 1 and this update is important.

[N8N 1.18.1 change log](https://github.com/n8n-io/n8n/releases/tag/n8n%401.18.1)