### PR TITLE
Update home assistant to 2023.11.3

### DIFF
--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   server:
-    image: homeassistant/home-assistant:2023.9.3@sha256:067490d7b65cfa8b9e494a9447b0e5a7876be83ead7ec01738681c55d66e7cfe
+    image: homeassistant/home-assistant:2023.11.2@sha256:400f20c77f52ac31334c1e73a2f19b2d6e5820757d1d476f01960b1efed31949
     network_mode: host
     # UI at default port 8123
     privileged: true

--- a/home-assistant/umbrel-app.yml
+++ b/home-assistant/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: home-assistant
 category: automation
 name: Home Assistant
-version: "2023.9.3"
+version: "2023.11.3"
 tagline: Home automation that puts local control & privacy first
 description: >-
   Open source home automation that puts local control and privacy
@@ -38,9 +38,7 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  This release included major updates to climate, humidifier, and water heater dialogs with circular sliders and status indicators.
-  The tile card and template sensor features were expanded, allowing easier control and setup from the dashboard and UI.
-  The onboarding process was also redesigned to simplify the initial Home Assistant experience.
+  This release includes many fixes and new features that can be seen in the 2023.11.3 release notes.
   
   Read more at: https://github.com/home-assistant/core/releases
 submitter: Umbrel

--- a/nextcloud/docker-compose.yml
+++ b/nextcloud/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "${APP_DATA_DIR}/data/redis:/data"
 
   web:
-    image: nextcloud:27.1.4@sha256:bd277bec9a8cf7cc009865e15410c05e0f66ccb6269ed96841cc95dd37c214fe
+    image: nextcloud:27.1.4-apache@sha256:bd277bec9a8cf7cc009865e15410c05e0f66ccb6269ed96841cc95dd37c214fe
     # Currently needs to be run as root, if we run as uid 1000 this fails
     # https://github.com/nextcloud/docker/blob/05026b029d37fc5cd488d4a4a2a79480e39841ba/21.0/apache/entrypoint.sh#L53-L77
     # user: "1000:1000"
@@ -51,7 +51,7 @@ services:
       - redis
 
   cron:
-    image: nextcloud:27.1.4@sha256:bd277bec9a8cf7cc009865e15410c05e0f66ccb6269ed96841cc95dd37c214fe
+    image: nextcloud:25.0.1-apache@sha256:bd277bec9a8cf7cc009865e15410c05e0f66ccb6269ed96841cc95dd37c214fe
     # Currently needs to be run as root, if we run as uid 1000 this fails
     # https://github.com/nextcloud/docker/blob/05026b029d37fc5cd488d4a4a2a79480e39841ba/21.0/apache/entrypoint.sh#L53-L77
     # user: "1000:1000"

--- a/nextcloud/docker-compose.yml
+++ b/nextcloud/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "${APP_DATA_DIR}/data/redis:/data"
 
   web:
-    image: nextcloud:27.1.4-apache@sha256:bd277bec9a8cf7cc009865e15410c05e0f66ccb6269ed96841cc95dd37c214fe
+    image: nextcloud:27.1.4@sha256:bd277bec9a8cf7cc009865e15410c05e0f66ccb6269ed96841cc95dd37c214fe
     # Currently needs to be run as root, if we run as uid 1000 this fails
     # https://github.com/nextcloud/docker/blob/05026b029d37fc5cd488d4a4a2a79480e39841ba/21.0/apache/entrypoint.sh#L53-L77
     # user: "1000:1000"
@@ -51,7 +51,7 @@ services:
       - redis
 
   cron:
-    image: nextcloud:27.1.4-apache@sha256:bd277bec9a8cf7cc009865e15410c05e0f66ccb6269ed96841cc95dd37c214fe
+    image: nextcloud:27.1.4@sha256:bd277bec9a8cf7cc009865e15410c05e0f66ccb6269ed96841cc95dd37c214fe
     # Currently needs to be run as root, if we run as uid 1000 this fails
     # https://github.com/nextcloud/docker/blob/05026b029d37fc5cd488d4a4a2a79480e39841ba/21.0/apache/entrypoint.sh#L53-L77
     # user: "1000:1000"

--- a/nextcloud/docker-compose.yml
+++ b/nextcloud/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "${APP_DATA_DIR}/data/redis:/data"
 
   web:
-    image: nextcloud:25.0.1-apache@sha256:a200319b132c01ec3486e0dcaf052092b560ec30ac9b78115607696dd201f704
+    image: nextcloud:27.1.4-apache@sha256:bd277bec9a8cf7cc009865e15410c05e0f66ccb6269ed96841cc95dd37c214fe
     # Currently needs to be run as root, if we run as uid 1000 this fails
     # https://github.com/nextcloud/docker/blob/05026b029d37fc5cd488d4a4a2a79480e39841ba/21.0/apache/entrypoint.sh#L53-L77
     # user: "1000:1000"
@@ -51,7 +51,7 @@ services:
       - redis
 
   cron:
-    image: nextcloud:25.0.1-apache@sha256:a200319b132c01ec3486e0dcaf052092b560ec30ac9b78115607696dd201f704
+    image: nextcloud:27.1.4-apache@sha256:bd277bec9a8cf7cc009865e15410c05e0f66ccb6269ed96841cc95dd37c214fe
     # Currently needs to be run as root, if we run as uid 1000 this fails
     # https://github.com/nextcloud/docker/blob/05026b029d37fc5cd488d4a4a2a79480e39841ba/21.0/apache/entrypoint.sh#L53-L77
     # user: "1000:1000"

--- a/nextcloud/umbrel-app.yml
+++ b/nextcloud/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: nextcloud
 category: files
 name: Nextcloud
-version: "25.0.1"
+version: "27.1.4"
 tagline: Productivity platform that keeps you in control
 description: >-
   Nextcloud puts your data at your fingertips, under your control.
@@ -25,8 +25,7 @@ description: >-
 
   Note: After logging in to Nextcloud please change the password to something secure before sharing the address with anyone.
 releaseNotes: >-
-  ⚠️ This update may take a while. It migrates Nextcloud from v22 to v25 and can take several minutes depending on your Internet connection speed, your server hardware, and how many files you have stored in Nextcloud.
-
+  This update takes Nextcloud from v25.0.1 to v27.1.4.
 
   - Full changelog can be found here: https://nextcloud.com/changelog/
 developer: Nextcloud GmbH


### PR DESCRIPTION
Release notes: https://github.com/home-assistant/core/releases/tag/2023.11.3

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (fresh install and update)

Data persisted across update.