### PR TITLE
Update home-assistant to 2023.11.3

### DIFF
--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   server:
-    image: homeassistant/home-assistant:2023.9.3@sha256:067490d7b65cfa8b9e494a9447b0e5a7876be83ead7ec01738681c55d66e7cfe
+    image: homeassistant/home-assistant:2023.11.3@sha256:feffc0b8227dbbf9d1bf61c465ff54b24aff2c990a1e54ea7219c4b300260ef9
     network_mode: host
     # UI at default port 8123
     privileged: true

--- a/home-assistant/umbrel-app.yml
+++ b/home-assistant/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: home-assistant
 category: automation
 name: Home Assistant
-version: "2023.9.3"
+version: "2023.11.3"
 tagline: Home automation that puts local control & privacy first
 description: >-
   Open source home automation that puts local control and privacy
@@ -38,9 +38,7 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  This release included major updates to climate, humidifier, and water heater dialogs with circular sliders and status indicators.
-  The tile card and template sensor features were expanded, allowing easier control and setup from the dashboard and UI.
-  The onboarding process was also redesigned to simplify the initial Home Assistant experience.
+  This release includes many fixes and new features that can be seen in the 2023.11.3 release notes.
   
   Read more at: https://github.com/home-assistant/core/releases
 submitter: Umbrel


### PR DESCRIPTION
Release notes: https://github.com/home-assistant/core/releases/tag/2023.11.3

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (fresh install and update)

Data persisted across update.