### PR TITLE
Update homebridge to 2023-01-08

### DIFF
--- a/homebridge/docker-compose.yml
+++ b/homebridge/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   server:
-    image: oznu/homebridge:2023-01-08@sha256:f46e9c82e4f3449e18c2b61014ba13474343fed703537983db0f59a2a4b97c31
+    image: homebridge/homebridge:2023-11-28@sha256:45d955145ff1bfee30ebbeffdc4e638b4cc0acd2fe702bfca5ae763c35d2befe
     # container runs as root
     network_mode: host
     # available at port 8581

--- a/homebridge/umbrel-app.yml
+++ b/homebridge/umbrel-app.yml
@@ -39,7 +39,7 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  This release uses Homebridge's 2023-11-23 image, and takes it to v1.7.0.
+  This release uses Homebridge's 2023-11-28 image, which takes it to v1.7.0.
 
   Read the full release notes for additional information and detailed changes at https://github.com/homebridge/homebridge/releases
 submitter: Umbrel

--- a/homebridge/umbrel-app.yml
+++ b/homebridge/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: homebridge
 category: automation
 name: Homebridge
-version: "2023-01-08"
+version: "2023-11-28"
 tagline: "HomeKit support for the impatient"
 description: >-
   Bringing HomeKit support where there is none. Homebridge allows you to integrate with smart home devices that do not natively support HomeKit.
@@ -38,6 +38,9 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 torOnly: false
-releaseNotes: ""
+releaseNotes: >-
+  This release uses Homebridge's 2023-11-23 image, and takes it to v1.7.0.
+
+  Read the full release notes for additional information and detailed changes at https://github.com/homebridge/homebridge/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps


### PR DESCRIPTION
Release notes: https://github.com/homebridge/homebridge/releases/tag/v1.7.0

Moved from oznu/homebridge to homebridge/homebridge image repo

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (fresh install and update)

Data persisted across update.