### PR TITLE
Update jackett to 0.21.1289

### DIFF
--- a/jackett/docker-compose.yml
+++ b/jackett/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: lscr.io/linuxserver/jackett:0.21.1000@sha256:e18a335d79676933b9f3f08ec4aa4b760d991ae59b6f2203da68cac7771aceaf
+    image: linuxserver/jackett:0.21.1289@sha256:abcbb4df3064fd6a0aeb29bbb0be1f7e18be321b1c85009c94f65efdfb399add
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/config

--- a/jackett/umbrel-app.yml
+++ b/jackett/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jackett
 category: media
 name: Jackett
-version: "0.21.1000"
+version: "0.21.1289"
 tagline: API support for your favorite torrent trackers
 description: >-
   Jackett works as a proxy server: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious, etc) into tracker-site-specific http queries,
@@ -33,6 +33,10 @@ gallery:
   - 2.jpg
   - 3.jpg
 path: ""
+releaseNotes: >-
+  This release updates Heimdall from v0.21.1000 to v0.21.1289. It includes many bug fixes and performance improvements, as well as the following new features:
+
+  The full release notes are available at https://github.com/Jackett/Jackett/releases
 permissions:
   - STORAGE_DOWNLOADS
 torOnly: false

--- a/jackett/umbrel-app.yml
+++ b/jackett/umbrel-app.yml
@@ -34,7 +34,7 @@ gallery:
   - 3.jpg
 path: ""
 releaseNotes: >-
-  This release updates Heimdall from v0.21.1000 to v0.21.1289. It includes many bug fixes and performance improvements, as well as the following new features:
+  This release updates Jackett from v0.21.1000 to v0.21.1289. It includes many bug fixes and performance improvements, as well as the following new features:
 
   The full release notes are available at https://github.com/Jackett/Jackett/releases
 permissions:

--- a/jackett/umbrel-app.yml
+++ b/jackett/umbrel-app.yml
@@ -34,9 +34,7 @@ gallery:
   - 3.jpg
 path: ""
 releaseNotes: >-
-  This release updates Jackett from v0.21.1000 to v0.21.1289. It includes many bug fixes and performance improvements, as well as the following new features:
-
-  The full release notes are available at https://github.com/Jackett/Jackett/releases
+  This release updates Jackett from v0.21.1000 to v0.21.1289. The full release notes are available at https://github.com/Jackett/Jackett/releases.
 permissions:
   - STORAGE_DOWNLOADS
 torOnly: false


### PR DESCRIPTION
Release notes: https://github.com/Jackett/Jackett/releases

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (fresh install and update)

Data persisted across update.