### PR TITLE
Update heimdall to 2.5.8

### DIFF
--- a/heimdall/docker-compose.yml
+++ b/heimdall/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: lscr.io/linuxserver/heimdall:2.5.6@sha256:dc4f01cd09a9a2f1dbb9c2029d1300070861355754004ac70b33723bd42ff957
+    image: linuxserver/heimdall:2.5.8@sha256:462bf7fb9d11bbd8ee90924cac613efae85a6f666c371a9bc345386f83cdf404
     volumes:
       - ${APP_DATA_DIR}/config:/config
     environment:

--- a/heimdall/umbrel-app.yml
+++ b/heimdall/umbrel-app.yml
@@ -3,7 +3,7 @@ id: heimdall
 name: Heimdall
 tagline: Organize your most used web sites in a simple way
 category: files
-version: "2.5.6"
+version: "2.5.8"
 port: 7392
 description: >-
   Heimdall is a dashboard for all your web applications. It doesn't need to be limited to applications though, you can add links to anything you like.
@@ -28,21 +28,19 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >
-  This release updates Heimdall from v2.5.5 to v2.5.6. It includes many bug fixes and performance improvements, as well as the following new features:
+  This release updates Heimdall from v2.5.6 to v2.5.8. It includes many bug fixes and performance improvements, as well as the following new features:
 
-  - fix: Add more error handling for app test
+  - Fix and add SVG support 
 
-  - fix: Update jquery, jquery-ui
+  - Add issue-pr workflows
   
-  - use jquery-sortablejs instead of jquery-ui
+  - Fix sortable tooltip 
 
-  - fix language setting only available in view
+  - Remove register route
   
-  - fix: Route titlecolour error
+  - Add Trianglify background option
 
-  - Update Korean and Chinese language
-
-  - Added Ukrainian translation
+  - Validate icons to be images
 
 
   The full release notes are available at https://github.com/linuxserver/Heimdall/releases


### PR DESCRIPTION
New PR as I accidently had two updates rolled into the last Heimdall PR.
Release notes: https://github.com/linuxserver/Heimdall/releases

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (fresh install and update)

Data persisted across update.