### PR TITLE
Update node-red-standalone to 3.1.1

### DIFF
--- a/node-red-standalone/docker-compose.yml
+++ b/node-red-standalone/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       PROXY_AUTH_WHITELIST: "/public/*"
   
   web:
-    image: nodered/node-red:3.0.2-18@sha256:e401cd81a43bca7db51fe8dac2c9cfc9b4ffb922ba424241280f7392e13b06a0
+    image: nodered/node-red:3.1.1@sha256:cf9749f31fdaee0a87a27aebf97ef6c051e1b6e77f021806f876055ae8d0b4c8
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/node-red-standalone/umbrel-app.yml
+++ b/node-red-standalone/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: node-red-standalone
 category: automation
 name: "Node-RED"
-version: "3.0.2-18"
+version: "3.1.1"
 tagline: Wire together the Internet of Things
 description: >-
   Node-RED is a visual programming tool for wiring together hardware
@@ -17,9 +17,21 @@ description: >-
   
   Note: If you would like your 'HTTP In' nodes to be accessible without authentication, then prepend your url with '/public/'. E.g. /public/do-something
 releaseNotes: >-
-  This update does not alter the Node-RED version, which remains at 3.0.2. Instead, it upgrades the underlying Node.js
-  from version 14 to 18. This change is intended to extend compatibility with Node.js modules that were previously
-  unavailable to users on Node.js 14.
+  This update takes Node-RED from 3.0.2 to 3.1.1.
+
+  Whats changed:
+
+  - Default filter to All Catalogues and show nodes for small lists 
+
+  - Ensure junction appears when filtering quick-add list
+
+  - Update message catalogs for JSONata Expression editor 
+
+  - Add tooltip to relevance sort button in user settings UI
+
+  - add more..
+
+  Full release notes here: https://github.com/node-red/node-red/releases/tag/3.1.0
 developer: OpenJS Foundation
 website: https://nodered.org
 dependencies: []


### PR DESCRIPTION
Release notes: https://github.com/node-red/node-red/releases/tag/3.1.0

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (update)

Data persisted across updates.