### PR TITLE
Update photoprism to 231128

### DIFF
--- a/photoprism/docker-compose.yml
+++ b/photoprism/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       PROXY_AUTH_WHITELIST: "/originals/*,/import/*"
   
   web:
-    image: photoprism/photoprism:230923@sha256:64a0c712fc2e46e93e01c18fae8a00f947440dc67c88b603f35cedd57b406eac
+    image: photoprism/photoprism:231128@sha256:cf45026f3381b13cc638ed556d1f717340267d1a832794380f49998fd3a899c8
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: "1m"

--- a/photoprism/umbrel-app.yml
+++ b/photoprism/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: photoprism
 category: files
 name: PhotoPrism
-version: "230923"
+version: "231128"
 tagline: Self-host your photo and video library
 description: >-
   PhotoPrism® is a privately hosted app for browsing, organizing, and
@@ -42,8 +42,19 @@ defaultUsername: "admin"
 deterministicPassword: true
 torOnly: false
 releaseNotes: >-
-  Our latest release includes a redesigned Places view, with the search box moved to the top and a preview for selected clusters at the bottom. We've also added support for Samsung/Google Motion Photos, so you can view them like Apple Live Photos after re-indexing your library. Beyond those highlights, you'll get many usability improvements, new search filters, and fixes for recently discovered issues. A big thank you to everyone who contributed!
+  Our latest service release provides updated dependencies and fixes for recently discovered issues.
 
+  What's new?
+
+  - Improved camera and lens information in the cards view details
+
+  - Fixed cards view rendering when a lens has no model description
+
+  - Improved performance when extracting still images for creating thumbnails
+
+  - Improved SVG conversion using RSVG instead of ImageMagick
+
+  - and many more...
 
   Full release notes can be found at: https://github.com/photoprism/photoprism/releases/
 submitter: Umbrel


### PR DESCRIPTION
Release notes: https://github.com/photoprism/photoprism/releases/

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (update)

Data persisted across updates. Test with a folder of images.