### PR TITLE
Update wikijs to 2.5.300

### DIFF
--- a/wikijs/docker-compose.yml
+++ b/wikijs/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
   
   server:
-    image: linuxserver/wikijs:2.5.294@sha256:e9f79a619fb0da03dc2e20d1543a02eb655f09a1a112c6998ebd584ada533d66
+    image: linuxserver/wikijs:2.5.300@sha256:60facd7660fdf186fb8df4645e68d19f64696f4cc19ff618fa30fd7e4bbf18e2
     restart: on-failure
     environment:
       - PUID=1000

--- a/wikijs/umbrel-app.yml
+++ b/wikijs/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: wikijs
 category: developer
 name: WikiJS
-version: "2.5.294"
+version: "2.5.300"
 tagline: Make documentation a joy to write
 description: >-
   The most powerful and extensible open source Wiki software.
@@ -29,5 +29,23 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 torOnly: false
+releaseNotes: >-
+  ✨ New Features
+
+  - add ACR Value option to OIDC Module
+
+  - add markdown-it-pivot-table rendering module 
+
+
+  🐛 Bug Fixes
+
+  - git: Reduce git concurrency to avoid lock file conflicts.
+
+  - add node 18 + 20 compatibility 
+
+  - auth: keycloak authentication post logout redirect for Keycloak 18+
+
+
+  Full release notes here: https://github.com/requarks/wiki/releases/tag/v2.5.300
 submitter: Pranshu Agrawal
 submission: https://github.com/getumbrel/umbrel-apps/pull/273


### PR DESCRIPTION
Release notes: https://github.com/requarks/wiki/releases/tag/v2.5.300

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (update)

Data persisted across updates. 