### PR TITLE
Update qbittorrent to 4.6.2

### DIFF
--- a/qbittorrent/docker-compose.yml
+++ b/qbittorrent/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: hotio/qbittorrent:release-4.6.0@sha256:78ac9dfad4e1bbb7233e11e09781c929e692d92d5de8f499c0f4477eee266622
+    image: hotio/qbittorrent:release-4.6.2@sha256:9fec00002f576ea20faea2934b4cce9e5aec06a64ffe46ba077bca5644be1b0a
     environment:
       - PUID=1000
       - PGID=1000

--- a/qbittorrent/umbrel-app.yml
+++ b/qbittorrent/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: qbittorrent
 category: networking
 name: qBittorrent
-version: "4.6.0"
+version: "4.6.2"
 tagline: Free and reliable P2P Bittorrent client
 description: >-
   qBittorrent is an open-source software alternative to µTorrent. It's designed to meet the needs of most users while using as little CPU and memory as possible.
@@ -14,7 +14,10 @@ description: >-
 
   ⚠️ qBittorrent downloads torrents over the Clearnet, not Tor.
 releaseNotes: >-
-  This release updates qBittorrent from version 4.5.2 to 4.6.0. Read the full release notes at https://www.qbittorrent.org/news#sun-oct-22th-2023---qbittorrent-v4.6.0-release
+  This release updates qBittorrent from version 4.6.0 to 4.6.2. 
+  
+  
+  Read the full release notes at https://www.qbittorrent.org/news#mon-nov-27th-2023---qbittorrent-v4.6.2-release
 developer: qBittorrent
 website: https://qbittorrent.org/
 dependencies: []


### PR DESCRIPTION
Release notes: https://www.qbittorrent.org/news#mon-nov-27th-2023---qbittorrent-v4.6.2-release

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (update)

Starting from v4.6.1 the default password is no longer adminadmin, so you cannot log in and the moment without pulling the new password from the .config directory directly. Will need to add that to umbrel-app.yml