### PR TITLE
lightning-terminal: update to `v0.12.2-alpha`

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.12.1-alpha@sha256:185f984d1b499a8d2cff4fc65747c7f20402714c112a907d578ceea5f7bd5003
+    image: lightninglabs/lightning-terminal:v0.12.2-alpha@sha256:2f0dc5651936ff703a80bd29537024a727e12f963b39af9b485a81000128c8aa
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.12.1-alpha"
+version: "0.12.2-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -57,9 +57,7 @@ defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
   This release of Lightning Terminal (LiT) includes updates to the versions
-  of the integrated LND, Loop and Taproot Assets daemons. This release also
-  updates the documentation for RPC commands to be more coherent, as well as
-  various minor bug fixes.
+  of the integrated LND, Loop and Taproot Assets daemons.
 
 
   IMPORTANT NOTE: To avoid loss of funds, it's imperative that you read the
@@ -88,7 +86,7 @@ releaseNotes: >-
   feedback from the community.
 
 
-  This release packages LND v0.17.1-beta, Taproot Assets Daemon v0.3.1-alpha,
-  Loop v0.26.5-beta, Pool v0.6.4-beta and Faraday v0.2.11-alpha.
+  This release packages LND v0.17.3-beta, Taproot Assets Daemon v0.3.2-alpha,
+  Loop v0.26.6-beta, Pool v0.6.4-beta and Faraday v0.2.11-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
In this PR we bump Litd to `v0.12.2-alpha`.

See the release notes here: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.12.2-alpha

Thanks a lot for adding the umbrel-specific instructions for taproot assets backup in #859, and for updating the warning message in the umbrel-app.yml file @nmfretz! It looks great, thanks!

Happy to address any feedback regarding this new PR if needed :)!