### PR TITLE
Update to audiobookshelf 2.6.0

### DIFF
--- a/audiobookshelf/docker-compose.yml
+++ b/audiobookshelf/docker-compose.yml
@@ -9,7 +9,7 @@ services:
 
 
   web:
-    image: ghcr.io/advplyr/audiobookshelf:2.5.0@sha256:43d5c05a7c5d08b60192d9a21b7bd0a27f2f19c296718fea2a0a47075b779773
+    image: ghcr.io/advplyr/audiobookshelf:2.6.0@sha256:73356ac9ffbb85f0b9dd265b8b7c966d9adcb152c8713cadca961d576af13700
     user: 1000:1000
     init: true
     restart: on-failure

--- a/audiobookshelf/umbrel-app.yml
+++ b/audiobookshelf/umbrel-app.yml
@@ -3,7 +3,7 @@ id: audiobookshelf
 name: Audiobookshelf
 tagline: Audiobook and podcast server
 category: media
-version: "2.5.0"
+version: "2.6.0"
 port: 13378
 description: >-
   Features:
@@ -61,6 +61,24 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  This release brings audiobookshelf from version 2.2.22 to version 2.5.0. Full release notes can be found at https://github.com/advplyr/audiobookshelf/releases
+  This release brings audiobookshelf from version 2.5.0 to 2.6.0. 
+
+
+
+  Added
+
+  - SSO via OpenID Connect authentication
+
+  - Simple API caching for /libraries* requests
+
+  - NFO files as book metadata source
+
+  - Czech translations
+
+  - Swedish translations
+
+
+  
+  Full release notes can be found at https://github.com/advplyr/audiobookshelf/releases
 submitter: Jasper
 submission: https://github.com/getumbrel/umbrel-apps/pull/302


### PR DESCRIPTION
Release notes: https://github.com/advplyr/audiobookshelf/releases

- [ ]    x86_64 -> UmbrelOS on proxmox Debian instance
* [x]   Arm64 -> Pi 4 8GB (fresh install and update)

I'm having an issue where audiobookshelf doesnt work at all on my debian instance, neither the old or new one. @nmfretz can you test my update too pls?