### PR TITLE
Update SABnzbd to 4.1.0-hotfix1

### DIFF
--- a/sabnzbd/docker-compose.yml
+++ b/sabnzbd/docker-compose.yml
@@ -14,8 +14,9 @@ services:
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
       # sabnzdb offers no way to change the default download directory via environment variables
-      # and the sabnzbd.ini is not generated until after going through the setup wizard
-      # so we have instructions in the app description to change the download directory from /config/Downloads to /downloads
+      # and the sabnzbd.ini is not generated until after going through the setup wizard, which automatically sets the download directory to /config/Downloads
+      # users then need to manually change the download directory to /downloads in Settings > Folders
+      # This must be done in order to integrate easily properly with other apps like Sonarr and Radarr
       - ${UMBREL_ROOT}/data/storage/downloads:/downloads
     environment:
       - PUID=1000

--- a/sabnzbd/docker-compose.yml
+++ b/sabnzbd/docker-compose.yml
@@ -13,7 +13,10 @@ services:
     stop_grace_period: 1m
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
-      - ${UMBREL_ROOT}/data/storage/downloads:/config/Downloads
+      # sabnzdb offers no way to change the default download directory via environment variables
+      # and the sabnzbd.ini is not generated until after going through the setup wizard
+      # so we have instructions in the app description to change the download directory from /config/Downloads to /downloads
+      - ${UMBREL_ROOT}/data/storage/downloads:/downloads
     environment:
       - PUID=1000
       - PGID=1000

--- a/sabnzbd/umbrel-app.yml
+++ b/sabnzbd/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: sabnzbd
 category: networking
 name: SABnzbd
-version: "4.1.0"
+version: "4.1.0-hotfix1"
 tagline: The automated Usenet download tool
 description: >-
   SABnzbd makes Usenet as simple and streamlined as possible by automating everything we can. All you have to do is add an .nzb.
@@ -16,9 +16,9 @@ description: >-
   🛠️ SET-UP INSTRUCTIONS 🛠️
 
 
-  1. Set the Downloads Folder: During the quick-start wizard, you'll see default download directories ('/config/Downloads/complete' and '/config/Downloads/incomplete'). Please use these as your download folders.
-  These directories are pre-configured to map to the main 'downloads' folder on your Umbrel device. This means any files downloaded by SABnzbd will be automatically saved in the 'downloads' folder on your Umbrel device.
-  To access these downloaded files, you can use the File Explorer app, which is available in the Umbrel App Store.
+  1. Set the Downloads Folder: During the quick-start wizard, you'll see default download directories ('/config/Downloads/complete' and '/config/Downloads/incomplete'). You will need to change these to 
+  `downloads/complete` and `downloads/incomplete` as shown in the second gallery image above.
+  These directories are pre-configured to map to the main 'downloads' folder on your Umbrel device and to also work seamlessly with other apps like Sonarr and Radarr.
 
 
   2. Integrating with Other Applications: If you want to integrate SABnzbd with other applications such as Sonarr or Radarr, you'll need to use the IP address of your Umbrel device as the 'Host' and use 9876 as the 'Port'.
@@ -29,7 +29,24 @@ dependencies: []
 repo: https://github.com/sabnzbd/sabnzbd
 support: https://forums.sabnzbd.org/
 port: 9876
-releaseNotes: ""
+releaseNotes: >-
+  This is a hotfix release for SABnzbd 4.1.0 on Umbrel. It makes it easier to configure SABnzbd with apps like Sonarr and Radarr.
+  
+
+  🚨 If you are already running SABnzbd 4.1.0 on Umbrel, please update your app and then follow these steps to re-configure your downloads folder path.
+  You may see errors in the UI when first opening SABnzbd after updating. This is expected and will be fixed after following these steps.
+
+
+  1. In the SABnzbd app, navigate to Settings > Folders.
+
+
+  2. Change the 'Temporary Download Folder' to `downloads/incomplete` and the 'Completed Download Folder' to `downloads/complete`.
+
+
+  3. Click 'Save Changes'.
+
+
+  You are now set!
 permissions:
   - STORAGE_DOWNLOADS
 gallery:

--- a/sabnzbd/umbrel-app.yml
+++ b/sabnzbd/umbrel-app.yml
@@ -17,7 +17,7 @@ description: >-
 
 
   1. Set the Downloads Folder: During the quick-start wizard, you'll see default download directories ('/config/Downloads/complete' and '/config/Downloads/incomplete'). You will need to change these to 
-  `downloads/complete` and `downloads/incomplete` as shown in the second gallery image above.
+  `downloads/complete` and `downloads/incomplete` as shown in the second gallery image above. You can change these by navigating to Settings > Folders in the SABnzbd app.
   These directories are pre-configured to map to the main 'downloads' folder on your Umbrel device and to also work seamlessly with other apps like Sonarr and Radarr.
 
 
@@ -34,7 +34,7 @@ releaseNotes: >-
   
 
   🚨 If you are already running SABnzbd 4.1.0 on Umbrel, please update your app and then follow these steps to re-configure your downloads folder path.
-  You may see errors in the UI when first opening SABnzbd after updating. This is expected and will be fixed after following these steps.
+  You may see errors in the UI when first opening SABnzbd after updating. No data has been lost. This is expected and will be fixed after following these steps.
 
 
   1. In the SABnzbd app, navigate to Settings > Folders.


### PR DESCRIPTION
This PR binds the main umbrel downloads folder to `/downloads` within the sabnzbd container. This increases the friction on initial app set-up, but decreases the friction when pairing SABnzbd with other apps like radarr and sonarr. No data is lost with this change in configuration.