### PR TITLE
Update invoice ninja to 5.7.62

### DIFF
--- a/invoice-ninja/config/nginx.conf
+++ b/invoice-ninja/config/nginx.conf
@@ -2,6 +2,8 @@ server {
     listen 80 default_server;
     server_name _;
 
+    server_tokens off;
+
     client_max_body_size 100M;
 
     root /var/www/app/public/;
@@ -13,6 +15,10 @@ server {
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location = /robots.txt  { access_log off; log_not_found off; }
+
+    location ~* /storage/.*\.php$ {
+        return 503;
+    }
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;

--- a/invoice-ninja/docker-compose.yml
+++ b/invoice-ninja/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - ${APP_DATA_DIR}/data/storage:/var/www/app/storage:rw,delegated
     environment:
       APP_URL: "http://${APP_DOMAIN}"
-      APP_KEY: base64:lrrBX5qhQxalWMY6SvSD8LJobCQwcPfotj/oyxqqRCY=
+      APP_KEY: "${APP_KEY:-unset}"
       REQUIRE_HTTPS: "false"
       DB_HOST: invoice-ninja_db_1
       DB_DATABASE: invoiceninja

--- a/invoice-ninja/docker-compose.yml
+++ b/invoice-ninja/docker-compose.yml
@@ -26,7 +26,6 @@ services:
       - ${APP_DATA_DIR}/data/storage:/var/www/app/storage:rw,delegated
     environment:
       APP_URL: "http://${APP_DOMAIN}"
-      APP_DEBUG: "true"
       APP_KEY: base64:lrrBX5qhQxalWMY6SvSD8LJobCQwcPfotj/oyxqqRCY=
       REQUIRE_HTTPS: "false"
       DB_HOST: invoice-ninja_db_1

--- a/invoice-ninja/docker-compose.yml
+++ b/invoice-ninja/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - app
 
   app:
-    image: invoiceninja/invoiceninja:5.7.62@sha256:3cdb189a3d20bcbe871bc55f6ca169fb3bded63dc1b829effb360cfaa0d8e0a7
+    image: invoiceninja/invoiceninja:5.8.15@sha256:59a283bb7fab29d432047264b12066de4f13eae78fb03f8f5126bcbf75c20570
     # We're forced to run user/group 1500
     # More detail here: https://github.com/invoiceninja/dockerfiles/blob/ad3ffc227d63740330f761dad6e8c87768577847/alpine/5/Dockerfile#L70-L80
     user: "1500:1500"

--- a/invoice-ninja/docker-compose.yml
+++ b/invoice-ninja/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ${APP_DATA_DIR}/data/public:/var/www/app/public:ro
 
   app:
-    image: invoiceninja/invoiceninja:5.5.93@sha256:59af42c410467154e6c50322f1d2ab048297b2d01e862f41bc9f1db4829c6086
+    image: invoiceninja/invoiceninja:5.7.62@sha256:3cdb189a3d20bcbe871bc55f6ca169fb3bded63dc1b829effb360cfaa0d8e0a7
     # We're forced to run user/group 1500
     # More detail here: https://github.com/invoiceninja/dockerfiles/blob/ad3ffc227d63740330f761dad6e8c87768577847/alpine/5/Dockerfile#L70-L80
     user: "1500:1500"
@@ -26,6 +26,9 @@ services:
       - ${APP_DATA_DIR}/data/storage:/var/www/app/storage:rw,delegated
     environment:
       APP_URL: "http://${APP_DOMAIN}"
+      APP_DEBUG: "true"
+      APP_KEY: base64:lrrBX5qhQxalWMY6SvSD8LJobCQwcPfotj/oyxqqRCY=
+      REQUIRE_HTTPS: "false"
       DB_HOST: invoice-ninja_db_1
       DB_DATABASE: invoiceninja
       DB_USERNAME: invoiceninja
@@ -44,4 +47,3 @@ services:
       MYSQL_USER: invoiceninja
       MYSQL_PASSWORD: moneyprintergobrrr
       MYSQL_DATABASE: invoiceninja
-

--- a/invoice-ninja/docker-compose.yml
+++ b/invoice-ninja/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ${APP_DATA_DIR}/data/storage:/var/www/app/storage:rw,delegated
     environment:
       APP_URL: "http://${APP_DOMAIN}"
-      APP_KEY: "${APP_KEY:-unset}"
+      APP_KEY: $APP_KEY
       REQUIRE_HTTPS: "false"
       DB_HOST: invoice-ninja_db_1
       DB_DATABASE: invoiceninja

--- a/invoice-ninja/docker-compose.yml
+++ b/invoice-ninja/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     volumes:
       - ${APP_DATA_DIR}/config/nginx.conf:/etc/nginx/conf.d/nginx.conf:ro
       - ${APP_DATA_DIR}/data/public:/var/www/app/public:ro
+    depends_on:
+      - app
 
   app:
     image: invoiceninja/invoiceninja:5.7.62@sha256:3cdb189a3d20bcbe871bc55f6ca169fb3bded63dc1b829effb360cfaa0d8e0a7
@@ -34,6 +36,8 @@ services:
       DB_PASSWORD: moneyprintergobrrr
       IN_USER_EMAIL: "admin@example.com"
       IN_PASSWORD: $APP_PASSWORD
+    depends_on:
+      - db
 
   db:
     image: mariadb:10.5.12@sha256:dfcba5641bdbfd7cbf5b07eeed707e6a3672f46823695a0d3aba2e49bbd9b1dd

--- a/invoice-ninja/docker-compose.yml
+++ b/invoice-ninja/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ${APP_DATA_DIR}/data/storage:/var/www/app/storage:rw,delegated
     environment:
       APP_URL: "http://${APP_DOMAIN}"
-      APP_KEY: $APP_KEY
+      APP_KEY: "${APP_KEY:-unset}"
       REQUIRE_HTTPS: "false"
       DB_HOST: invoice-ninja_db_1
       DB_DATABASE: invoiceninja

--- a/invoice-ninja/exports.sh
+++ b/invoice-ninja/exports.sh
@@ -1,2 +1,5 @@
-# Generate a new APP_KEY
-export NEW_APP_KEY=$(docker run --rm -it invoiceninja/invoiceninja php artisan key:generate --show)
+LARAVEL_APP_KEY_FILE_PATH="$(readlink -f $(dirname "${BASH_SOURCE[0]}"))/data/laravel-app-key.txt"
+
+if [[ -f "${LARAVEL_APP_KEY_FILE_PATH}" ]]; then
+  export APP_KEY=$(cat "${LARAVEL_APP_KEY_FILE_PATH}")
+fi

--- a/invoice-ninja/exports.sh
+++ b/invoice-ninja/exports.sh
@@ -1,5 +1,7 @@
 LARAVEL_APP_KEY_FILE_PATH="$(readlink -f $(dirname "${BASH_SOURCE[0]}"))/data/laravel-app-key.txt"
 
 if [[ -f "${LARAVEL_APP_KEY_FILE_PATH}" ]]; then
-  export APP_KEY=$(cat "${LARAVEL_APP_KEY_FILE_PATH}")
+  # we remove newlines/carriage-returns from the output which cause laravel to fail to parse the APP_KEY.
+  # these may be introduced by users accidentally editing the file.
+  export APP_KEY=$(cat "${LARAVEL_APP_KEY_FILE_PATH}" | tr -d '\r\n')
 fi

--- a/invoice-ninja/exports.sh
+++ b/invoice-ninja/exports.sh
@@ -1,0 +1,2 @@
+# Generate a new APP_KEY
+export NEW_APP_KEY=$(docker run --rm -it invoiceninja/invoiceninja php artisan key:generate --show)

--- a/invoice-ninja/hooks/pre-start
+++ b/invoice-ninja/hooks/pre-start
@@ -31,6 +31,8 @@ LARAVEL_APP_KEY_FILE_PATH="${APP_DATA_DIR}/laravel-app-key.txt"
 
 # We only generate and save the Laravel APP_KEY if it doesn't exist already
 if [[ ! -f "${LARAVEL_APP_KEY_FILE_PATH}" ]]; then
+	#  generates a laravel APP_KEY using the invoice-ninja container --> php artisan key:generate --show
 	APP_KEY=$("${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" run --rm app php artisan key:generate --show)
-	echo "${APP_KEY}" > "${LARAVEL_APP_KEY_FILE_PATH}"
+	# we remove the color codes and newlines from the output which cause laravel to fail to parse the APP_KEY
+	echo "${APP_KEY}" | sed 's/\x1b\[[0-9;]*m//g' | tr -d '\r\n' > "${LARAVEL_APP_KEY_FILE_PATH}"
 fi

--- a/invoice-ninja/hooks/pre-start
+++ b/invoice-ninja/hooks/pre-start
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# We're forced to run user/group 1500
+# More detail here: https://github.com/invoiceninja/dockerfiles/blob/ad3ffc227d63740330f761dad6e8c87768577847/alpine/5/Dockerfile#L70-L80
+# So we set the owner of the data directories to 1500:1500
 APP_DATA_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)/data"
 
 DESIRED_OWNER="1500:1500"
@@ -22,3 +25,12 @@ invoiceninja_correct_permission() {
 
 invoiceninja_correct_permission "${PUBLIC_DATA_DIR}"
 invoiceninja_correct_permission "${STORAGE_DATA_DIR}"
+
+LARAVEL_APP_KEY_FILE_PATH="${APP_DATA_DIR}/laravel-app-key.txt"
+
+
+# We only generate and save the Laravel APP_KEY if it doesn't exist already
+if [[ ! -f "${LARAVEL_APP_KEY_FILE_PATH}" ]]; then
+	APP_KEY=$("${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" run --rm app php artisan key:generate --show)
+	echo "${APP_KEY}" > "${LARAVEL_APP_KEY_FILE_PATH}"
+fi

--- a/invoice-ninja/umbrel-app.yml
+++ b/invoice-ninja/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: invoice-ninja
 category: finance
 name: Invoice Ninja
-version: "v5.7.62"
+version: "v5.8.15"
 tagline: We’ll help with the invoicing
 description: |-
   Invoicing, Quotes, Expenses, Tasks.
@@ -20,7 +20,7 @@ gallery:
 - 3.jpg
 path: ''
 releaseNotes: >-
-  This release takes invoice-ninja from version 5.5.93 to 5.7.62.
+  This release takes invoice-ninja from version 5.5.93 to 5.8.15.
 
 
   Full release notes here: https://github.com/invoiceninja/invoiceninja/releases

--- a/invoice-ninja/umbrel-app.yml
+++ b/invoice-ninja/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: invoice-ninja
 category: finance
 name: Invoice Ninja
-version: "v5.5.93"
+version: "v5.7.62"
 tagline: We’ll help with the invoicing
 description: |-
   Invoicing, Quotes, Expenses, Tasks.
@@ -19,6 +19,11 @@ gallery:
 - 2.jpg
 - 3.jpg
 path: ''
+releaseNotes: >-
+  This release takes invoice-ninja from version 5.5.93 to 5.7.62.
+
+
+  Full release notes here: https://github.com/invoiceninja/invoiceninja/releases
 deterministicPassword: true
 defaultUsername: admin@example.com
 submitter: Umbrel


### PR DESCRIPTION
Release notes: https://github.com/invoiceninja/invoiceninja/releases

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (fresh install and update)

**I'm having two slight issues**

- Invoice ninja requires app_key now: I've hardcoded it for the moment, and not sure on the best way to do with it so it persists for users in future updates. See my idea for exports.sh (doesn't work)

- After installing you will get nginx errors for a min or so, not a big issue, but a lil confusing.