### PR TITLE
circuitbreaker: bump release to v0.5.1

### DIFF
--- a/circuitbreaker/docker-compose.yml
+++ b/circuitbreaker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 9235
       
   web:
-    image: ghcr.io/lightningequipment/circuitbreaker:v0.5.0@sha256:0e5ba7c4f7be9921123d8ae4f1f120a2ebc2502d185a75ff93537b071fe6366b
+    image: ghcr.io/lightningequipment/circuitbreaker:v0.5.1@sha256:1c73f4785dad73e279cfb06ec12b004df61f5905446cec06079ace5618490a1d
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/circuitbreaker/umbrel-app.yml
+++ b/circuitbreaker/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: circuitbreaker
 category: bitcoin
 name: Circuit Breaker
-version: "v0.5.0"
+version: "v0.5.1"
 tagline: Your Lightning Node's Firewall
 description: >-
   It allows nodes to protect themselves from being flooded with HTLCs. 
@@ -38,13 +38,15 @@ description: >-
 
   WARNING: See queue mode warning.
 releaseNotes: >-
-  This release updates circuitbreaker to v0.5.0, which adds functionality to track granular HTLC forwarding information that is not saved by LND. This detailed information about HTLC forwards is also valuable for node operators looking to gain a more detailed understanding of their forwarding flow.
+  This release updates circuitbreaker to v0.5.1, which adds functionality to track granular HTLC forwarding information that is not saved by LND. This detailed information about HTLC forwards is also valuable for node operators looking to gain a more detailed understanding of their forwarding flow.
 
 
   Specifically, it will persist timestamped forwarding history records for successful and failed HTLCs (LND only saves successful forwards, and does not keep timestamps). By default, circuitbreaker will only store 100,000 records so the maximum amount of space that these records will take is approximately 14MB.  This value can be changed using the `--fwdhistorylimit` flag, which allows zero values to disable the feature completely.
 
 
   This feature was developed as part of the ongoing protocol work to research mitigation of channel jamming attacks against the network (https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-August/004034.html). Volunteers interested in contributing to this research through running *local-only* analysis of the data circuitbreaker collects can express interest at https://docs.google.com/forms/d/e/1FAIpQLScm2xs4hNsrkI8UCBS4aTdO03YrmWT2X0-j6zXWpkZ7keKiUw/viewform?usp=sf_link or contact carla@chaincode.com for details.
+
+  The v0.5.1 release contains a bugfix for the v0.5.0 release which logs HTLCs that are forwarded along unknown outgoing channels rather than shutting down.
 developer: Joost Jager
 website: https://github.com/joostjager
 dependencies: 


### PR DESCRIPTION
Bumping circuitbreaker release to include a bugfix. Left release notes from 0.5.0 so that the new feature is still described, happy to update if not!