### PR TITLE
Update Jellyfin to 10.8.13

### DIFF
--- a/jellyfin/docker-compose.yml
+++ b/jellyfin/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: linuxserver/jellyfin:10.8.11@sha256:09bd29e51d205076ee5027d9828359112b8d091c8324610f43beb438f1f94131
+    image: linuxserver/jellyfin:10.8.13@sha256:deb61ff251882fb21e5187b7d1988e84ea438626300041f7d9474a5dc0618e24
     restart: on-failure
     hostname: "${DEVICE_HOSTNAME}"
     environment:

--- a/jellyfin/umbrel-app.yml
+++ b/jellyfin/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jellyfin
 category: media
 name: Jellyfin
-version: "10.8.11"
+version: "10.8.13"
 tagline: The Free Software Media System
 description: >-
   Jellyfin is the volunteer-built media solution that puts you in control of your media. Stream to any device from your own server, with no strings attached. Your media, your server, your way.
@@ -40,6 +40,9 @@ releaseNotes: >-
   
   This update is a hotfix release with no new features or major improvements.
 
+
+  - NOTICE: The customizable FFmpeg binary path in the WebUI/API has been REMOVED for security reasons.
+  
 
   Full release notes can be found here: https://github.com/jellyfin/jellyfin/releases
 torOnly: false


### PR DESCRIPTION
Release notes: https://github.com/jellyfin/jellyfin/releases

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (fresh install and update)

Data persisted across updates.