### PR TITLE
Update node-red to 3.1.1

### DIFF
--- a/node-red/docker-compose.yml
+++ b/node-red/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       PROXY_AUTH_WHITELIST: "/public/*"
   
   web:
-    image: nodered/node-red:2.2.2-12@sha256:7b8e58892801f01af48acfb18c21b845a6f35029e7654ca6e19ba86bbe810d04
+    image: nodered/node-red:3.1.1@sha256:cf9749f31fdaee0a87a27aebf97ef6c051e1b6e77f021806f876055ae8d0b4c8
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/node-red/umbrel-app.yml
+++ b/node-red/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: node-red
 category: automation
 name: "Node-RED (Bitcoin)"
-version: "2.2.2-12"
+version: "3.1.1"
 tagline: Wire together the Internet of Things
 description: >-
   Node-RED is a visual programming tool for wiring together hardware
@@ -33,6 +33,22 @@ gallery:
   - 2.jpg
   - 3.jpg
 path: ""
+releaseNotes: >-
+  This update takes Node-RED from 3.0.2 to 3.1.1.
+
+  Whats changed:
+
+  - Default filter to All Catalogues and show nodes for small lists 
+
+  - Ensure junction appears when filtering quick-add list
+
+  - Update message catalogs for JSONata Expression editor 
+
+  - Add tooltip to relevance sort button in user settings UI
+
+  - add more..
+
+  Full release notes here: https://github.com/node-red/node-red/releases/tag/3.1.0
 defaultUsername: umbrel
 defaultPassword: moneyprintergobrrr
 torOnly: false


### PR DESCRIPTION
Updating the bitcoin specific version of node-red. This hadn't been updated in a while, so I thought it may need a special image/config, but looking at this PR https://github.com/getumbrel/umbrel-apps/issues/36 the only reason i can see they were seperated is due to managing dependencies, so this reflects my other node-red update.

Release notes: https://github.com/node-red/node-red/releases/tag/3.1.0
Node 20 version

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install)
* [x]   Arm64 -> Pi 4 8GB (fresh install)

Data persisted across updates.