### PR TITLE
Update LNDg to v1.8.0

### DIFF
--- a/lndg/docker-compose.yml
+++ b/lndg/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LNDG_PORT
 
   web:
-    image: ghcr.io/cryptosharks131/lndg:v1.7.0@sha256:30bb34fd735d6046fcaf7375ac32ad10b998b34798cb7d4d762c038284b5fc98
+    image: ghcr.io/cryptosharks131/lndg:v1.8.0@sha256:c71ef5e236453a927332b1e2158a78a23c6231443a98e83684c408b750fce213
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/lndg/docker-compose.yml
+++ b/lndg/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LNDG_PORT
 
   web:
-    image: ghcr.io/cryptosharks131/lndg:v1.8.0@sha256:c71ef5e236453a927332b1e2158a78a23c6231443a98e83684c408b750fce213
+    image: ghcr.io/cryptosharks131/lndg:v1.8.0@sha256:a3eda3a7592a8332e0bf3533378a5d2eec41fd0956d1ebc8c0b74ff109d7e631
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/lndg/umbrel-app.yml
+++ b/lndg/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lndg
 category: bitcoin
 name: LNDg
-version: "1.7.0"
+version: "1.8.0"
 tagline: Analyze and automate your Lightning node management
 description: LNDg is your command center for running a profitable and efficient
   routing node. From quickly viewing your node's health, automated rebalancing,
@@ -22,18 +22,18 @@ path: ""
 defaultUsername: lndg-admin
 deterministicPassword: true
 releaseNotes: >-
-  - Updated dashboard to reduce load times
+  - Auto-Refreshing dashboard (optional)
   
-  - Updated AutoFee logic and added two new variables
+  - Trading page for setup and sale of secrets
   
-  - Legacy address generation and view previous addresses
+  - Logs page to easily check on backend processes
   
-  - New chart added to P&L page 
+  - Improvements to the Auto-Fee logic
   
-  - Operator notes for any channel
+  - Fee bump tool added for pending sweeps
   
-  - Estimate a fee bump or broadcast a raw tx
+  - Recycle connections with expiring htlcs within 13 blocks
   
-  - And more... Full details can be found here: https://github.com/cryptosharks131/lndg/releases/tag/v1.7.0
+  - And more... Full details can be found here: https://github.com/cryptosharks131/lndg/releases/tag/v1.8.0
 submitter: cryptosharks131
 submission: https://github.com/getumbrel/umbrel/pull/1189


### PR DESCRIPTION
Updates LNDg to v1.8.0
https://github.com/cryptosharks131/lndg/releases/tag/v1.8.0
https://github.com/cryptosharks131/lndg/pkgs/container/lndg/162090911?tag=v1.8.0