### PR TITLE
Update octoprint to 1.9.3

### DIFF
--- a/octoprint/docker-compose.yml
+++ b/octoprint/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   web:
-    image: octoprint/octoprint:1.9.2@sha256:80ed8b8a1be8713506e7e29fc5b2ec55241242e28a5d8a474a25d9f2aab0843f
+    image: octoprint/octoprint:1.9.3@sha256:32e81a9d8c73511855ad5b9d7212ef61e0ba7608c47ce215ec2c6402c52423ee
     privileged: true
     volumes:
       - ${APP_DATA_DIR}/data:/octoprint

--- a/octoprint/umbrel-app.yml
+++ b/octoprint/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: octoprint
 category: files
 name: OctoPrint
-version: "1.9.2"
+version: "1.9.3"
 tagline: A snappy web interface for your 3D printer
 description: >-
   OctoPrint provides a snappy web interface for controlling consumer 3D printers.
@@ -16,6 +16,20 @@ repo: https://github.com/OctoPrint/OctoPrint
 support: https://community.octoprint.org/
 port: 5003
 submitter: mateosilguero
+releaseNotes: >-
+  This update brings Octoprint from 1.9.2 to 1.9.3
+
+
+  🔒 Security fixes
+
+  - Fixed possiblity for a malicious admin to configure a specially crafted GCODE script through the Settings that would allow code execution during rendering of that script
+
+
+  🐛 Bug fixes
+
+  - Fix for not being able to extrude/retract from the control panel in the UI after editing the extrusion speed in the printer profile.
+
+  - Pin pydantic dependency to 1.10.12. This works around an issue existing in some environments with pydantic version 1.10.13, which was released on September 26 2023. Said issue causes OctoPrint to no longer be able to start.
 submission: https://github.com/getumbrel/umbrel-apps/pull/449
 gallery:
   - 1.jpg


### PR DESCRIPTION
Release notes: https://github.com/OctoPrint/OctoPrint/releases/tag/1.9.3

This is a requested update. Part of the request is that they've been having trouble connecting via USB- `privileged: true` is specified, and `- /dev:/dev` is correct, maybe this needs to be booted in host mode also?

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install)
* [x]   Arm64 -> Pi 4 8GB (fresh install)
