### PR TITLE
Update Thunderhub to v0.13.30

### DIFF
--- a/thunderhub/docker-compose.yml
+++ b/thunderhub/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: apotdevin/thunderhub:v0.13.29@sha256:793ed1cb0760bdc7c017408d62e49e00261ff223ad305bf6be81954650d2fd3a
+    image: apotdevin/thunderhub:v0.13.30@sha256:486cf816bf6dd92780037842ff42036ee6254c787353225416be30c4e17a5630
     # We now have to run as root to avoid schema.gql permission errors
     # user: "1000:1000"
     restart: on-failure

--- a/thunderhub/umbrel-app.yml
+++ b/thunderhub/umbrel-app.yml
@@ -28,6 +28,12 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  This update brings Thunderhub from version 0.13.29 to 0.13.30. Full release notes can be found at https://github.com/apotdevin/thunderhub/releases
+  - Chore: extra error log
+  
+  - Fix: Boltz swap claim transaction fees
+  
+  - Fix: adding safety on object lookups
+  
+  Full release notes can be found at https://github.com/apotdevin/thunderhub/releases/tag/v0.13.30
 submitter: Anthony Potdevin
 submission: https://github.com/getumbrel/umbrel/pull/343

--- a/thunderhub/umbrel-app.yml
+++ b/thunderhub/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: thunderhub
 category: bitcoin
 name: ThunderHub
-version: "0.13.29"
+version: "0.13.30"
 tagline: Take full control of your Lightning node
 description: >-
   ThunderHub allows you to take full control of your Lightning node
@@ -14,7 +14,7 @@ description: >-
 
   Managing and monitoring your node has never been easier with transaction reports, graphs and a huge assortment of different features all bundled inside of this great tool.
 developer: Anthony Potdevin
-website: https://apotdevin.com
+website: https://thunderhub.io/
 dependencies:
   - lightning
 repo: https://github.com/apotdevin/thunderhub
@@ -28,6 +28,6 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  This update brings Thunderhub from version 0.13.23 to 0.13.29. Full release notes can be found at https://github.com/apotdevin/thunderhub/releases
+This update brings Thunderhub from version 0.13.29 to 0.13.30. Full release notes can be found at https://github.com/apotdevin/thunderhub/releases
 submitter: Anthony Potdevin
 submission: https://github.com/getumbrel/umbrel/pull/343

--- a/thunderhub/umbrel-app.yml
+++ b/thunderhub/umbrel-app.yml
@@ -28,11 +28,11 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  - Chore: extra error log
+  - Chore: Extra error log
   
   - Fix: Boltz swap claim transaction fees
   
-  - Fix: adding safety on object lookups
+  - Fix: Adding safety on object lookups
   
   Full release notes can be found at https://github.com/apotdevin/thunderhub/releases/tag/v0.13.30
 submitter: Anthony Potdevin

--- a/thunderhub/umbrel-app.yml
+++ b/thunderhub/umbrel-app.yml
@@ -28,6 +28,6 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-This update brings Thunderhub from version 0.13.29 to 0.13.30. Full release notes can be found at https://github.com/apotdevin/thunderhub/releases
+  This update brings Thunderhub from version 0.13.29 to 0.13.30. Full release notes can be found at https://github.com/apotdevin/thunderhub/releases
 submitter: Anthony Potdevin
 submission: https://github.com/getumbrel/umbrel/pull/343


### PR DESCRIPTION
This updates ThunderHub from v0.13.29 to v0.13.30. Contains an important fix for Boltz Swaps.