### PR TITLE
Update electrs to v0.10.2

### DIFF
--- a/electrs/docker-compose.yml
+++ b/electrs/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         ipv4_address: $APP_ELECTRS_IP
   
   electrs:
-    image: getumbrel/electrs:v0.10.1@sha256:79cdac6a7bcdb51f8e4c6450411e42a90db3665939b6e33cbfb1c30ef3df00d3
+    image: getumbrel/electrs:v0.10.2@sha256:bcd3066e795b0f242540481736705b5e86fa159b539fdd562f08007bd112faf9
     restart: always
     environment:
       ELECTRS_LOG_FILTERS: "INFO"

--- a/electrs/umbrel-app.yml
+++ b/electrs/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: electrs
 category: bitcoin
 name: Electrs
-version: "0.10.1"
+version: "0.10.2"
 tagline: A simple and efficient Electrum Server
 description: >
   Run your personal Electrum server and connect your Electrum-compatible wallet,
@@ -30,7 +30,18 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >
-  This update from version 0.9.14 to 0.10.1 brings a variety of improvements, including optimizations to indexing and index querying. 
-  Read more at: https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#0101-nov-01-2023
+  This update from version 0.10.1 to 0.10.2 brings a variety of improvements, including:
+  
+
+  - Use batched RPC to fetch mempool entries & transactions
+
+  - Avoid redundant recomputation of fee histogram bins
+
+  - Don't flush when nothing is written to DB
+
+  - Update dependencies
+
+
+  Read more at: https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#0102-dec-31-2023
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/242


### PR DESCRIPTION
Release notes: https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#0102-dec-31-2023

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (fresh install)