### PR TITLE
Hotfix for public-pool

### DIFF
--- a/public-pool/docker-compose.yml
+++ b/public-pool/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - "2018:2018/tcp"
     volumes:
-      - "${APP_DATA_DIR}/data/db:/public-pool/DB"
+      - "${APP_DATA_DIR}/data/database:/public-pool/DB"
     environment:
       - NODE_ENV=production
       - BITCOIN_RPC_URL=http://${APP_BITCOIN_NODE_IP}

--- a/public-pool/docker-compose.yml
+++ b/public-pool/docker-compose.yml
@@ -8,14 +8,14 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   web:
-    image: smolgrrr/public-pool-ui:0.1.0@sha256:e219808b92a9f52fc5938860a731d317cf6db1d059af3b982b02b48cbe06dc3b
+    image: smolgrrr/public-pool-ui:c2c081d@sha256:3623a1a42cfd0d3cab23ade9bc1bc6ccfadce583303d3a61bd0b3cc421246a36
     restart: on-failure
     stop_grace_period: 30s
     environment:
       - DOMAIN=$DEVICE_DOMAIN_NAME
 
   server:
-    image: sethforprivacy/public-pool:4bb00f2@sha256:0fc82e7123be68650c9e31f57a5a206e622acbcaa170e31219a488818ad6da6b
+    image: sethforprivacy/public-pool:dcfc528@sha256:29dd3493bf30006c3a855a5533226d09705714074f822298443a45a4c8d356c3
     restart: on-failure
     stop_grace_period: 30s
     ports:

--- a/public-pool/umbrel-app.yml
+++ b/public-pool/umbrel-app.yml
@@ -26,6 +26,7 @@ gallery:
 path: ""
 releaseNotes: >-
   This hotfix update disables extra caching, so less powerful devices don't run out of memory.
+  It will result in the reinitiation of the pool's database.
 
 
   Also, this update fixs port/CORs issues when proxied to be accessible over the public internet.

--- a/public-pool/umbrel-app.yml
+++ b/public-pool/umbrel-app.yml
@@ -31,7 +31,7 @@ releaseNotes: >-
   Also, this update fixs port/CORs issues when proxied to be accessible over the public internet.
 
 
-  https://github.com/sethforprivacy/public-pool/pull/1
+  See changes here: https://github.com/sethforprivacy/public-pool/pull/1
 defaultPassword: ""
 submitter: smolgrrr
 submission: https://github.com/getumbrel/umbrel-apps/pull/915

--- a/public-pool/umbrel-app.yml
+++ b/public-pool/umbrel-app.yml
@@ -25,9 +25,13 @@ gallery:
   - 3.jpg
 path: ""
 releaseNotes: >-
-  This hotfix update disables the extra caching, so less powerful devices don't run out of memory.
+  This hotfix update disables extra caching, so less powerful devices don't run out of memory.
 
-  Also, fixs port/CORs issues in the UI when proxied to be accessible over the internet.
+
+  Also, this update fixs port/CORs issues when proxied to be accessible over the public internet.
+
+
+  https://github.com/sethforprivacy/public-pool/pull/1
 defaultPassword: ""
 submitter: smolgrrr
 submission: https://github.com/getumbrel/umbrel-apps/pull/915

--- a/public-pool/umbrel-app.yml
+++ b/public-pool/umbrel-app.yml
@@ -2,14 +2,17 @@ manifestVersion: 1
 id: public-pool
 category: bitcoin
 name: Public Pool
-version: "4bb00f2"
+version: "dcfc528-hotfix"
 tagline: Fully Open Source Solo Bitcoin Mining Pool
 description: >-
-  Fully Open Source Solo Bitcoin Mining Pool
+  Run your own Bitcoin Solo Mining Pool with no fees.
 
+  Connected to your Bitcoin node, and only your node. Contribute to furthering bitcoin mining decentralisation.
 
-  Don't trust. Verify. On steroids.
-developer: benjamin-wilson
+  Allows you to pool together any and all mining hardware, with mining rewards going directly to your chosen bitcoin address. 
+
+  Track total hashrate and your individual works with ease.
+developer: Benjamin Wilson
 website: https://web.public-pool.io/#/
 dependencies:
   - bitcoin
@@ -21,6 +24,10 @@ gallery:
   - 2.jpg
   - 3.jpg
 path: ""
+releaseNotes: >-
+  This hotfix update disables the extra caching, so less powerful devices don't run out of memory.
+
+  Also, fixs port/CORs issues in the UI when proxied to be accessible over the internet.
 defaultPassword: ""
 submitter: smolgrrr
 submission: https://github.com/getumbrel/umbrel-apps/pull/915


### PR DESCRIPTION
This hotfix update disables extra caching, so less powerful devices don't run out of memory.

See changes here: https://github.com/sethforprivacy/public-pool/pull/1

Fresh installs work great, however when I update it appears the DB changes cause an issue- see below.
<img width="896" alt="image" src="https://github.com/getumbrel/umbrel-apps/assets/104137257/17f8502b-08af-43e9-8502-fbc61eccf844">
