### PR TITLE
Hotfix for Public-Pool (ZMQ)

### DIFF
--- a/public-pool/docker-compose.yml
+++ b/public-pool/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - DOMAIN=$DEVICE_DOMAIN_NAME
 
   server:
-    image: sethforprivacy/public-pool:dcfc528@sha256:29dd3493bf30006c3a855a5533226d09705714074f822298443a45a4c8d356c3
+    image: sethforprivacy/public-pool:ef2d2b8@sha256:dddd4e9c4273f5e964c84052dfbb74a044169968aaae9e2a48ad02c663bf7c88
     restart: on-failure
     stop_grace_period: 30s
     ports:
@@ -29,7 +29,6 @@ services:
       - BITCOIN_RPC_PASSWORD=${APP_BITCOIN_RPC_PASS}
       - BITCOIN_RPC_PORT=${APP_BITCOIN_RPC_PORT}
       - BITCOIN_RPC_TIMEOUT=10000
-      - BITCOIN_ZMQ_HOST="tcp://${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_ZMQ_RAWBLOCK_PORT}"
       - API_PORT=2019
       - STRATUM_PORT=2018
       - NETWORK=mainnet

--- a/public-pool/umbrel-app.yml
+++ b/public-pool/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: public-pool
 category: bitcoin
 name: Public Pool
-version: "dcfc528-hotfix"
+version: "ef2d2b8-hotfix"
 tagline: Fully Open Source Solo Bitcoin Mining Pool
 description: >-
   Run your own Bitcoin Solo Mining Pool with no fees.
@@ -25,14 +25,9 @@ gallery:
   - 3.jpg
 path: ""
 releaseNotes: >-
-  This hotfix update disables extra caching, so less powerful devices don't run out of memory.
-  It will result in the reinitiation of the pool's database.
+  This hotfix update resolves an issue that was causing public-pool to persist old-blocks.
 
-
-  Also, this update fixs port/CORs issues when proxied to be accessible over the public internet.
-
-
-  See changes here: https://github.com/sethforprivacy/public-pool/pull/1
+  See changes here: https://github.com/benjamin-wilson/public-pool/commit/dadb03ed1cba6334acc009b79a389fb7b71e8567 
 defaultPassword: ""
 submitter: smolgrrr
 submission: https://github.com/getumbrel/umbrel-apps/pull/915


### PR DESCRIPTION
Hot-fix patch fixes public-pool persisting on old blocks.

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install)
* [x]   Arm64 -> Pi 4 8GB (fresh install and update)