### PR TITLE
App Submission: Firefly III Data Importer

### DIFF
--- a/firefly-iii-importer/docker-compose.yml
+++ b/firefly-iii-importer/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: firefly-importer_importer_1
+      APP_PORT: 8080
+
+  importer:
+    image: fireflyiii/data-importer:version-1.4.0@sha256:05f8e99dbafe57f7f2158298253d20c9fb27733abeec9e9c17ad8e951760464d
+    restart: on-failure
+    environment:
+      # firefly-iii container:
+      - FIREFLY_III_URL=http://firefly-iii_server_1:8080
+      - VANITY_URL=http://${DEVICE_DOMAIN_NAME}:30009

--- a/firefly-iii-importer/docker-compose.yml
+++ b/firefly-iii-importer/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   app_proxy:
     environment:
-      APP_HOST: firefly-importer_importer_1
+      APP_HOST: firefly-iii-importer_importer_1
       APP_PORT: 8080
 
   importer:

--- a/firefly-iii-importer/hooks/pre-start
+++ b/firefly-iii-importer/hooks/pre-start
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Delay starting Firefly III Importer until Firefly III main app has started
+
+FIREFLY_CONTAINER_NAME="firefly-iii_server_1"
+
+while true; do
+    if [ "$(docker ps -q -f name=$FIREFLY_CONTAINER_NAME)" ]; then
+        # If firefly-iii server container is running then we break and exit so that the importer can start
+        echo "$FIREFLY_CONTAINER_NAME is running"
+        break
+    else
+        # If the container is not running, wait for 2 seconds and then check again
+        echo "Waiting for $FIREFLY_CONTAINER_NAME to start..."
+        sleep 2
+    fi
+done

--- a/firefly-iii-importer/hooks/pre-start
+++ b/firefly-iii-importer/hooks/pre-start
@@ -11,8 +11,8 @@ while true; do
         echo "$FIREFLY_CONTAINER_NAME is running"
         break
     else
-        # If the container is not running, wait for 2 seconds and then check again
+        # If the container is not running, wait for 5 seconds and then check again
         echo "Waiting for $FIREFLY_CONTAINER_NAME to start..."
-        sleep 2
+        sleep 5
     fi
 done

--- a/firefly-iii-importer/umbrel-app.yml
+++ b/firefly-iii-importer/umbrel-app.yml
@@ -5,8 +5,7 @@ name: Firefly III Importer
 version: "1.4.0"
 tagline: Import your transactions into Firefly III
 description: >-
-  Firefly III is a manager for your personal finances. It is self-hosted and open source. This means that it's free, it has no ads and no tracking.
-  The data importer is built to help you import transactions into Firefly III. It is separated from Firefly III for security and maintenance reasons.
+  Firefly III is a manager for your personal finances. The data importer is built to help you import transactions into Firefly III. It is separated from Firefly III for security and maintenance reasons.
 
 
   The data importer does not connect to your bank directly. Instead, it uses Nordigen and SaltEdge to connect to over 6000 banks worldwide. These services are free for Firefly III users, but require registration. Keep in mind these services have their own privacy and data usage policies.

--- a/firefly-iii-importer/umbrel-app.yml
+++ b/firefly-iii-importer/umbrel-app.yml
@@ -1,0 +1,35 @@
+manifestVersion: 1.1
+id: firefly-iii-importer
+category: finance
+name: Firefly III Importer
+version: "1.4.0"
+tagline: Import your transactions into Firefly III
+description: >-
+  Firefly III is a manager for your personal finances. It is self-hosted and open source. This means that it's free, it has no ads and no tracking.
+  The data importer is built to help you import transactions into Firefly III. It is separated from Firefly III for security and maintenance reasons.
+
+
+  The data importer does not connect to your bank directly. Instead, it uses Nordigen and SaltEdge to connect to over 6000 banks worldwide. These services are free for Firefly III users, but require registration. Keep in mind these services have their own privacy and data usage policies.
+
+  
+  The data importer can import CSV files you've downloaded from your bank.
+
+  
+  You can run the data importer once, for a bulk import. You can also run it regularly to keep up with new transactions.
+developer: Firefly III
+website: https://www.firefly-iii.org/
+dependencies:
+  - firefly-iii
+repo: https://github.com/firefly-iii/data-importer
+support: https://docs.firefly-iii.org/references/data-importer/json/
+port: 30010
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+path: ""
+deterministicPassword: false
+torOnly: false
+releaseNotes: ""
+submitter: Umbrel
+submission: https://github.com/getumbrel/umbrel-apps/pull/

--- a/firefly-iii-importer/umbrel-app.yml
+++ b/firefly-iii-importer/umbrel-app.yml
@@ -31,4 +31,4 @@ deterministicPassword: false
 torOnly: false
 releaseNotes: ""
 submitter: Umbrel
-submission: https://github.com/getumbrel/umbrel-apps/pull/
+submission: https://github.com/getumbrel/umbrel-apps/pull/948


### PR DESCRIPTION
Repo: https://github.com/firefly-iii/data-importer
Website: https://docs.firefly-iii.org/explanation/data-importer/about/introduction/

I have added this as a separate app instead of including the data importer as a service within the Firefly III compose file. This way there is an obvious way for users to get to the importer app (by installing it and having the app visible on their dashboard). If the importer was a service within the Firefly III compose file, then it would be invisibly running on port 30010 and we would need to provide instructions in the app description on how to access it (e.g., navigate to http://umbrel.local/30010) which isn't great UX.

Tested in production on arm64 and x86.