### PR TITLE
Update robosats to 0.54

### DIFF
--- a/robosats/docker-compose.yml
+++ b/robosats/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 12596
 
   web:
-    image: recksato/robosats-client:0.5.3-alpha@sha256:987994f561aa9606d87147844edafeb758fdd2c575c290a932f7f4033c4c53d4
+    image: recksato/robosats-client:0.5.4-alpha@sha256:0f6171884cb581f29c25da0691723ddb87bd8b2f3612ad8a955dc29c39b6bdf0
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -34,27 +34,22 @@ description: >-
   You can join other cool Robots and get community support at https://t.me/robosats telegram group.
   
 releaseNotes: >-
-  We have introduced a new feature, F2F (Face-to-Face), allowing users to add a location for face-to-face cash trades. 
-  The book page now displays a map with all F2F orders. For privacy reasons, the exact location of your order is slightly randomized (uniform random 15 x 15 Km noise) when you click on the map to locate it. 
-  This means it's not possible to be precise, and the exact location can only be shared on the encrypted chat. 
-  Please note that using high-resolution maps can leak your IP to external tiling servers if you are not using Tor Browser.
+  This update is a minor release that takes Robosats from version 0.5.3-alpha to 0.5.4-alpha with some small enhancements and bug fixes.
 
 
-  Of course, adding a geolocation tag to your order is only a good idea if you want to use face-to-face cash as a payment method. 
-  You can completely disregard this feature if you do not want to use this payment method.
+  Changes
 
+  - Dependency updates and security fixes.
 
-  Bug Fixes and Performance Improvements:
+  - Coordinator serves robot hash_ids needed for >v0.6.0 client side robot identity generator.
 
-  - Dependency updates.
+  - Recommended and minimum onchain fees for payouts are now more accurate.
 
-  - Small bug fixes.
+  - Devfund node has moved. The new node now has public access to the invoices services (read-only).
 
-  - Improved DB Writes performance related to last_login user field.
+  - Fix book re-render on swap/fiat change
 
-  - Fix small bug on order logging that made automatic dispute resolutions fail.
-
-  - Devfund Donation Pubkey has been updated to RoboSats experimental LND2 node.
+  - and many more.
   
   
   Full release notes are available at https://github.com/RoboSats/robosats/releases

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: robosats
 category: bitcoin
 name: RoboSats
-version: "v0.5.3-alpha"
+version: "v0.5.4-alpha"
 tagline: Simple and Private Bitcoin P2P Exchange
 description: >-
   RoboSats is a simple and private app to exchange bitcoin for national currencies. 


### PR DESCRIPTION
Minor release update for Robosats

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (update)
* [x]   Arm64 -> Pi 4 8GB (fresh install and update)

If anyone tests this on a Pi please inspect the web-app and let me know how long it takes for APIs to fetch for you. Mine seem to either take a long-time or fail, which was also occurring with 0.5.3, so I might just let the Robosats team know if it occurs for anyone else too.