### PR TITLE
Update Node-RED to v3.1.3

### DIFF
--- a/node-red-standalone/docker-compose.yml
+++ b/node-red-standalone/docker-compose.yml
@@ -1,15 +1,8 @@
 version: "3.7"
 
 services:
-  # app_proxy:
-  #   environment:
-  #     APP_HOST: node-red-standalone_web_1
-  #     APP_PORT: 1881
-  #     # Used to allow (HTTP In) flows to be publicly exposed
-  #     PROXY_AUTH_WHITELIST: "/public/*"
-  
   web:
-    image: nodered/node-red:3.1.1@sha256:cf9749f31fdaee0a87a27aebf97ef6c051e1b6e77f021806f876055ae8d0b4c8
+    image: nodered/node-red:3.1.3@sha256:75e48924159f6c6bf4221017069a8b496cab8d0b21d3d0b1fcaf058af8294865
     network_mode: host
     restart: on-failure
     stop_grace_period: 1m

--- a/node-red-standalone/docker-compose.yml
+++ b/node-red-standalone/docker-compose.yml
@@ -1,15 +1,16 @@
 version: "3.7"
 
 services:
-  app_proxy:
-    environment:
-      APP_HOST: node-red-standalone_web_1
-      APP_PORT: 1881
-      # Used to allow (HTTP In) flows to be publicly exposed
-      PROXY_AUTH_WHITELIST: "/public/*"
+  # app_proxy:
+  #   environment:
+  #     APP_HOST: node-red-standalone_web_1
+  #     APP_PORT: 1881
+  #     # Used to allow (HTTP In) flows to be publicly exposed
+  #     PROXY_AUTH_WHITELIST: "/public/*"
   
   web:
     image: nodered/node-red:3.1.1@sha256:cf9749f31fdaee0a87a27aebf97ef6c051e1b6e77f021806f876055ae8d0b4c8
+    network_mode: host
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/node-red-standalone/umbrel-app.yml
+++ b/node-red-standalone/umbrel-app.yml
@@ -14,12 +14,7 @@ description: >-
 
   The flows created in Node-RED are stored using JSON which can be easily imported and exported for sharing with others. An online flow library allows you to share your best flows with the world. 
 releaseNotes: >-
-  🔔 Node-RED on umbrel now runs in host network mode...
-
-
-  This a minor maintenance update for Node-RED.
-
-
+  🔔 Node-RED on Umbrel can now automatically find devices on your local network, thanks to a switch to host network mode.
   Full release notes here: https://github.com/node-red/node-red/releases/tag/3.1.0
 developer: OpenJS Foundation
 website: https://nodered.org

--- a/node-red-standalone/umbrel-app.yml
+++ b/node-red-standalone/umbrel-app.yml
@@ -15,6 +15,8 @@ description: >-
   The flows created in Node-RED are stored using JSON which can be easily imported and exported for sharing with others. An online flow library allows you to share your best flows with the world. 
 releaseNotes: >-
   🔔 Node-RED on Umbrel can now automatically find devices on your local network, thanks to a switch to host network mode.
+
+  
   Full release notes here: https://github.com/node-red/node-red/releases/tag/3.1.0
 developer: OpenJS Foundation
 website: https://nodered.org

--- a/node-red-standalone/umbrel-app.yml
+++ b/node-red-standalone/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: node-red-standalone
 category: automation
 name: "Node-RED"
-version: "3.1.1"
+version: "3.1.3"
 tagline: Wire together the Internet of Things
 description: >-
   Node-RED is a visual programming tool for wiring together hardware
@@ -12,24 +12,13 @@ description: >-
   It provides a browser-based editor that makes it easy to wire together flows using the wide range of nodes in the palette that can be deployed to its runtime in a single-click. A built-in library allows you to save useful functions, templates or flows for re-use.
 
 
-  The flows created in Node-RED are stored using JSON which can be easily imported and exported for sharing with others. An online flow library allows you to share your best flows with the world.
-
-  
-  Note: If you would like your 'HTTP In' nodes to be accessible without authentication, then prepend your url with '/public/'. E.g. /public/do-something
+  The flows created in Node-RED are stored using JSON which can be easily imported and exported for sharing with others. An online flow library allows you to share your best flows with the world. 
 releaseNotes: >-
-  This update takes Node-RED from 3.0.2 to 3.1.1.
+  🔔 Node-RED on umbrel now runs in host network mode...
 
-  Whats changed:
 
-  - Default filter to All Catalogues and show nodes for small lists 
+  This a minor maintenance update for Node-RED.
 
-  - Ensure junction appears when filtering quick-add list
-
-  - Update message catalogs for JSONata Expression editor 
-
-  - Add tooltip to relevance sort button in user settings UI
-
-  - add more..
 
   Full release notes here: https://github.com/node-red/node-red/releases/tag/3.1.0
 developer: OpenJS Foundation


### PR DESCRIPTION
This PR bumps node-RED to v3.1.3 and also switches the node-RED container to host network mode by popular request, in order to facilitate automatic device discovery.