### PR TITLE
Update to vaultwarden 1.30.3

### DIFF
--- a/vaultwarden/docker-compose.yml
+++ b/vaultwarden/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: vaultwarden/server:1.30.0@sha256:27638a2ae977d66d99891c06562ff9ba78a60869d2e5a94cf2953f1d03fde12f
+    image: vaultwarden/server:1.30.3@sha256:153defd78a3ede850445d64d6fca283701d0c25978e513c61688cf63bd47a14a
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/vaultwarden/umbrel-app.yml
+++ b/vaultwarden/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: vaultwarden
 category: files
 name: Vaultwarden
-version: "1.30.0"
+version: "1.30.3"
 tagline: Unofficial Bitwarden® compatible server
 description: >-
   Vaultwarden is an alternative
@@ -46,17 +46,19 @@ description: >-
 
   *Please note that Vaultwarden is not associated with the Bitwarden® project nor 8bit Solutions LLC. When using this app, please report any bugs or suggestions to us directly, regardless of whatever clients you are using (mobile, desktop, browser, etc), and do not use Bitwarden®'s official support channels.
 releaseNotes: |
-  This release updates Vaultwarden from v1.29.1 to v1.30.1. 
-  
-  Major changes and New Features:
+  This release updates Vaultwarden from v1.30.0 to v1.30.3. 
 
-  - Added passkey support, allowing the browser extensions to store and use your passkeys, make sure the extension is updated to version 2023.10.0 or newer for passkey support.
+  This is a minor release to fix some issues with push notification device registration and docker healthcheck. As well as some issues with the Login with device feature, and restore the alpine docker tag that was missing on the latest release.
   
-  - Updated web vault to 2023.10.0.
+  Changes:
 
-  - Fixed crashes in ARMv6 devices
+  - Fix push device registration
   
-  - Fixed crashes when trying to create/edit a cipher in the mobile applications.
+  - Decrease JWT Refresh/Auth token
+
+  - Prevent generating an error during ws close 
+  
+  - Fix attachment upload size check
 
 
   The full release notes are available at https://github.com/dani-garcia/vaultwarden/releases


### PR DESCRIPTION
Release notes: https://github.com/dani-garcia/vaultwarden/releases

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (update)
* [x]   Arm64 -> Pi 4 8GB (update)