### PR TITLE
Update Helipad to v0.1.11

### DIFF
--- a/helipad/docker-compose.yml
+++ b/helipad/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 2112
 
   web:
-    image: podcastindexorg/podcasting20-helipad@sha256:6767de3126b0a7d317f7c87766a1f063baa44fb85dc5496c794ff9aff306a4c1
+    image: podcastindexorg/podcasting20-helipad:0.1.11@sha256:b1292d46b4e126ad5c6c20c5630f28d9220ef4c8d90566d17be2232e238b9d4f
     init: true
     restart: on-failure
     stop_grace_period: 1m

--- a/helipad/umbrel-app.yml
+++ b/helipad/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: helipad
 category: bitcoin
 name: Helipad
-version: "0.1.10.5"
+version: "0.1.11"
 tagline: View boosts & boostagrams from Podcasting 2.0 apps
 description: Helipad shows boosts and boostagram messages coming in to your
   Lightning node from your listeners who are using Podcasting 2.0 apps.
@@ -24,14 +24,14 @@ submission: https://github.com/getumbrel/umbrel/pull/1174
 releaseNotes: >-
   This update includes the following improvements:
 
-  - Added Streams mode
+  - Added missing User-Agent header when calling the Podcast Index API
 
-  - Added numerology emojis
+  - Added reply boosts, sent tab, and password protection
 
-  - Added modal to show entire TLV record
+  - Show automated boosts in the Boosts tab
 
-  - Actual sats received shown on mouse hover
+  - Added browser-based reply boosts (e.g. WebLN, Alby)
 
-  - Podcast/episode names shown for remote item boosts
+  - Added icons for LN Beats, Podcast Guru, and TrueFans
 
-  - Balance and sat totals are now number formatted
+  - Added boosts, streams, and sent lists to CSV export and fixed positional params


### PR DESCRIPTION
Updates the Helipad app from `v0.1.10.5` to `v0.1.11`.