### PR TITLE
Update ESPHome to v2023.12.9 and switch to host networking

### DIFF
--- a/esphome/docker-compose.yml
+++ b/esphome/docker-compose.yml
@@ -1,13 +1,9 @@
 version: "3.7"
 
 services:
-  app_proxy:
-    environment:
-      APP_HOST: esphome_server_1
-      APP_PORT: 6052
-
   server:
     image: esphome/esphome:2023.12.9@sha256:0ec7b41a9566e7465d17d6eb2c785158eb7e61a131b21eb91a8ff9f4d14f1a4f
+    network_mode: host
     volumes:
       - ${APP_DATA_DIR}/data:/config
     restart: on-failure

--- a/esphome/docker-compose.yml
+++ b/esphome/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 6052
 
   server:
-    image: esphome/esphome:2023.11.6@sha256:783e2131fcff2c457846339a80f6ed981e58e5f86de3578f742e3bed87f7d5b2
+    image: esphome/esphome:2023.12.9@sha256:0ec7b41a9566e7465d17d6eb2c785158eb7e61a131b21eb91a8ff9f4d14f1a4f
     volumes:
       - ${APP_DATA_DIR}/data:/config
     restart: on-failure

--- a/esphome/umbrel-app.yml
+++ b/esphome/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: esphome
 category: automation
 name: ESPHome
-version: "2023.11.6"
+version: "2023.12.9"
 tagline: Intelligently manage all your ESP8266/ESP32 devices
 description: >-
   ESPHome is a system to control your ESP8266/ESP32 by simple yet powerful configuration files and control them remotely through Home Automation systems.
@@ -21,16 +21,14 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
+  🔔 ESPHome on Umbrel can now automatically find devices on your local network, thanks to a switch to host network mode.
+
+
   ⚠️ As usual, please check that your configurations are still working correctly after updating.
 
   
-  This release updates ESPHome from version 2023.2.4 to 2023.11.6. A full list of new features, new component support, breaking changes, and bug fixes for versions 
-  between 2023.2.4 and 2023.11.6 can be found here: https://github.com/esphome/esphome/releases.
-
-
-  Version 2023.11.6 release notes:
-
-  - Fix write_speaker without speaker in config
+  This release updates ESPHome from version 2023.11.6.4 to 2023.12.9. A full list of new features, new component support, breaking changes, and bug fixes for versions 
+  between 2023.11.6.4 to 2023.12.9 can be found here: https://github.com/esphome/esphome/releases.
   
 submitter: ShonP40
 submission: https://github.com/getumbrel/umbrel-apps/pull/43


### PR DESCRIPTION
- Updates ESPHome to latest stable release: https://github.com/esphome/esphome/releases/tag/2023.12.9
- Switches ESPHome container to host networking mode by popular request.

In general, the plan for apps that require host networking to function properly is to allow `network_mode: host` for now. Later on we will remove host access and instead proxy local mDNS traffic through to apps to allow safer device detection.