### PR TITLE
Update ln markers version

### DIFF
--- a/lnmarkets/docker-compose.yml
+++ b/lnmarkets/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LNMARKETS_PORT
   
   lnmarkets:
-    image: ghcr.io/ln-markets/umbrel:v2.0.0@sha256:47b836cd23f7aa9f31aa4ae99ba66f74ffc513388016e31a00f6cb0767144bae
+    image: ghcr.io/ln-markets/umbrel:v2.0.1@sha256:d087c3c0c43a671668de18368721130029134dde261895b1cbac472891a8e307
     init: true
     user: 1000:1000
     restart: on-failure

--- a/lnmarkets/docker-compose.yml
+++ b/lnmarkets/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_LNMARKETS_PORT
   
   lnmarkets:
-    image: ghcr.io/ln-markets/umbrel:v2.0.1@sha256:d087c3c0c43a671668de18368721130029134dde261895b1cbac472891a8e307
+    image: ghcr.io/ln-markets/umbrel:v2.0.1@sha256:391798e0a18ec8135abf94037f879fa83e8394fa3a8881fec3aa934338e978d2
     init: true
     user: 1000:1000
     restart: on-failure

--- a/lnmarkets/umbrel-app.yml
+++ b/lnmarkets/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lnmarkets
 category: bitcoin
 name: LN Markets
-version: "2.0.0"
+version: "2.0.1"
 tagline: The first instant settlement Bitcoin trading platform
 description: >-
   LN Markets is the first instant settlement Bitcoin trading platform. More info: linktr.ee/lnmarkets
@@ -27,4 +27,4 @@ path: ""
 submitter: LN Markets
 submission: https://github.com/getumbrel/umbrel/pull/879
 releaseNotes: >-
-  - Allow to login with both deprecated and correct LNURL method
+  - This is a minor bugfix release.


### PR DESCRIPTION
New version of LNM with a small fix, the image sha is pointing to the arm64 version.