### PR TITLE
Update FreshRSS to v1.23.1

### DIFF
--- a/freshrss/docker-compose.yml
+++ b/freshrss/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
       APP_HOST: freshrss_server_1
       APP_PORT: 80
+      PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
     image: linuxserver/freshrss:1.22.1@sha256:705b4a5a1b50244ead4002f8c04f0c4e0ae9750a618e75cd73a9258c6b0a381c

--- a/freshrss/docker-compose.yml
+++ b/freshrss/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/freshrss:1.22.1@sha256:705b4a5a1b50244ead4002f8c04f0c4e0ae9750a618e75cd73a9258c6b0a381c
+    image: linuxserver/freshrss:1.23.1@sha256:1d5a55e51551e0b5138fbfefb02c7c8e4fba4c3bb6678fd40bfeb7544ae0aab7
     restart: on-failure
     environment:
       - PUID=1000

--- a/freshrss/umbrel-app.yml
+++ b/freshrss/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: freshrss
 category: social
 name: FreshRSS
-version: "1.22.1"
+version: "1.23.1"
 tagline: A free, self-hostable aggregator for rss feeds
 description: >-
   FreshRSS is an RSS aggregator and reader. It enables you to seamlessly read and follow content from multiple websites at
@@ -23,7 +23,9 @@ description: >-
   
   - and more!
 releaseNotes: >-
-  This release updates FreshRSS from version 1.21.0 to 1.22.1. Full release notes are available at https://github.com/FreshRSS/FreshRSS/releases.
+  🔔 FreshRSS on Umbrel is now configured to allow connections from your other RSS Reader apps like NetNewsWire!
+  
+  This release updates FreshRSS from version 1.22.1 to 1.23.1. Full release notes are available at https://github.com/FreshRSS/FreshRSS/releases.
 developer: FreshRSS Org
 website: https://freshrss.org/
 dependencies: []

--- a/freshrss/umbrel-app.yml
+++ b/freshrss/umbrel-app.yml
@@ -25,6 +25,7 @@ description: >-
 releaseNotes: >-
   🔔 FreshRSS on Umbrel is now configured to allow connections from your other RSS Reader apps like NetNewsWire!
   
+  
   This release updates FreshRSS from version 1.22.1 to 1.23.1. Full release notes are available at https://github.com/FreshRSS/FreshRSS/releases.
 developer: FreshRSS Org
 website: https://freshrss.org/

--- a/lnbits/docker-compose.yml
+++ b/lnbits/docker-compose.yml
@@ -34,4 +34,4 @@ services:
       LNBITS_ADMIN_EXTENSIONS: "ngrok"
       LNBITS_ADMIN_UI: "true"
       SUPER_USER: "$APP_PASSWORD"
-      AUTH_ALLOWED_METHODS: "user-id-only, username-password"
+      AUTH_ALLOWED_METHODS: "user-id-only, username-password, google-auth, github-auth, keycloak-auth"

--- a/lnbits/docker-compose.yml
+++ b/lnbits/docker-compose.yml
@@ -35,3 +35,4 @@ services:
       LNBITS_ADMIN_UI: "true"
       SUPER_USER: "$APP_PASSWORD"
       AUTH_ALLOWED_METHODS: "user-id-only, username-password, google-auth, github-auth, keycloak-auth"
+      OAUTHLIB_INSECURE_TRANSPORT: "1"

--- a/lnbits/docker-compose.yml
+++ b/lnbits/docker-compose.yml
@@ -34,3 +34,4 @@ services:
       LNBITS_ADMIN_EXTENSIONS: "ngrok"
       LNBITS_ADMIN_UI: "true"
       SUPER_USER: "$APP_PASSWORD"
+      AUTH_ALLOWED_METHODS: "user-id-only, username-password"

--- a/lnbits/docker-compose.yml
+++ b/lnbits/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
   
   web:
-    image: lnbitsdocker/lnbits-legend:0.11.3@sha256:7c6ac2b3506c894c5a3f816a333fdfb2fcdd6ee0837285eb1d16297a88bbc70b
+    image: lnbits/lnbits:0.12.1@sha256:5e0cd330f8ce4c8d1145e90b073f321e6068d2b79b70a3029f72030ab626125a
     init: true
     restart: on-failure
     stop_grace_period: 1m

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lnbits
 category: bitcoin
 name: LNbits
-version: "0.11.3"
+version: "0.12.1"
 tagline: Multi-user wallet management system
 description: >-
   LNbits is a simple multi-user and account system for Lightning
@@ -41,14 +41,14 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes:  >-
-  This release updates LNbits to 0.11.3, and includes various bug fixes, improvements, and new features.
+  This release update takes LNBits to 0.12.1, and includes many major changes:
 
 
-  - New service fee settings that lets you earn a transaction fee for all internal or external transaction on an LNbits instance.
+  - New powerful login system (Auth, Login, OAuth, create account with username and password)
 
-  - New funding source: Alby wallet
+  - Better tools for querying transactions
 
-  - Fiat balance in wallet 
+  - Mobile UI improvements 
 
   - LND REST bug fixes
 


### PR DESCRIPTION
Bumps FreshRSS to version 1.23.1 and also whitelists the api route in the proxy so that other RSS feed apps like NetNewsWire can connect.

Tested on arm64 and x86(amd64). Tested adding FreshRSS to NetNewsWire.