### PR TITLE
Update FreshRSS to v1.23.1

### DIFF
--- a/freshrss/docker-compose.yml
+++ b/freshrss/docker-compose.yml
@@ -5,9 +5,10 @@ services:
     environment:
       APP_HOST: freshrss_server_1
       APP_PORT: 80
+      PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/freshrss:1.22.1@sha256:705b4a5a1b50244ead4002f8c04f0c4e0ae9750a618e75cd73a9258c6b0a381c
+    image: linuxserver/freshrss:1.23.1@sha256:1d5a55e51551e0b5138fbfefb02c7c8e4fba4c3bb6678fd40bfeb7544ae0aab7
     restart: on-failure
     environment:
       - PUID=1000

--- a/freshrss/umbrel-app.yml
+++ b/freshrss/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: freshrss
 category: social
 name: FreshRSS
-version: "1.22.1"
+version: "1.23.1"
 tagline: A free, self-hostable aggregator for rss feeds
 description: >-
   FreshRSS is an RSS aggregator and reader. It enables you to seamlessly read and follow content from multiple websites at
@@ -23,7 +23,10 @@ description: >-
   
   - and more!
 releaseNotes: >-
-  This release updates FreshRSS from version 1.21.0 to 1.22.1. Full release notes are available at https://github.com/FreshRSS/FreshRSS/releases.
+  🔔 FreshRSS on Umbrel is now configured to allow connections from your other RSS Reader apps like NetNewsWire!
+  
+  
+  This release updates FreshRSS from version 1.22.1 to 1.23.1. Full release notes are available at https://github.com/FreshRSS/FreshRSS/releases.
 developer: FreshRSS Org
 website: https://freshrss.org/
 dependencies: []


### PR DESCRIPTION
Bumps FreshRSS to version 1.23.1 and also whitelists the /api route in the proxy so that other RSS feed apps like NetNewsWire can connect.

Tested on arm64 and x86(amd64). Tested adding FreshRSS to NetNewsWire.