### PR TITLE
Update pihole to 2024.02.0

### DIFF
--- a/pi-hole/docker-compose.yml
+++ b/pi-hole/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   server:
-    image: pihole/pihole:2023.10.0@sha256:562766abc805d5005bb2d2aa5d4bbf2d9b347380b1ea4504fb59b2100500f672
+    image: pihole/pihole:2024.02.0@sha256:8077053835c2d2449041adad0c272d6e5fea3df91c5dfc3dae2bd950999c3118
     # Pi-hole doesn't currently support running as non-root
     # https://github.com/pi-hole/docker-pi-hole/issues/685
     # user: "1000:1000"

--- a/pi-hole/umbrel-app.yml
+++ b/pi-hole/umbrel-app.yml
@@ -31,7 +31,7 @@ defaultUsername: ""
 deterministicPassword: true
 torOnly: false
 releaseNotes: >-
-  This is a minor bug-fix release, and includes FTL v5.24, and Core v5.17.3.
+  This is a minor bug-fix release, and includes FTL v5.24, Web 5.12, and Core v5.17.3.
 
 
   Full release notes can be found here: https://pi-hole.net/blog/2024/01/06/pi-hole-ftl-v5-24-and-core-v5-17-3-released/

--- a/pi-hole/umbrel-app.yml
+++ b/pi-hole/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: pi-hole
 category: networking
 name: Pi-hole
-version: "2023.10.0"
+version: "2024.02.0"
 tagline: Block ads on your entire network
 description: >-
   Instead of browser plugins or other software on each computer,
@@ -31,9 +31,9 @@ defaultUsername: ""
 deterministicPassword: true
 torOnly: false
 releaseNotes: >-
-  This is a minor bug-fix release, and includes FTL v5.23, Web v5.20.2, and Core v5.17.2.
+  This is a minor bug-fix release, and includes FTL v5.24, and Core v5.17.3.
 
 
-  Full release notes can be found here: https://pi-hole.net/blog/2023/05/28/pi-hole-ftl-v5-23-web-v5-20-and-core-v5-17-released
+  Full release notes can be found here: https://pi-hole.net/blog/2024/01/06/pi-hole-ftl-v5-24-and-core-v5-17-3-released/
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/9ca55a25e043dcd50d5cb92c6ec756d368bb4794


### PR DESCRIPTION
Release notes: https://pi-hole.net/blog/2024/01/06/pi-hole-ftl-v5-24-and-core-v5-17-3-released/

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (install and update)
* [x]   Arm64 -> Pi 4 8GB (update)