### PR TITLE
Update btcpay to 1.12.5

### DIFF
--- a/btcpay-server/docker-compose.yml
+++ b/btcpay-server/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.4.3@sha256:9abbebd57166b8202123334e87cff538b3f537a1b644b6ff97a381597a642d9c
+    image: nicolasdorier/nbxplorer:2.5.0@sha256:bbff2b6703ed240da263e6ba01deacf2c6520d371d6a0202e87a9e8c7f97b158
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -31,7 +31,7 @@ services:
       NBXPLORER_BTCHASTXINDEX: 1
 
   web:
-    image: btcpayserver/btcpayserver:1.12.3@sha256:c214c65957b1125b69e0b10ff2ef841a541e32e6dd58012068bb6851700c076d
+    image: btcpayserver/btcpayserver:1.12.5@sha256:d854957dc8cca0ac1fff609f06979884bc0fac3e0bdb587e2dbae265349da861
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/btcpay-server/umbrel-app.yml
+++ b/btcpay-server/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: btcpay-server
 category: bitcoin
 name: BTCPay Server
-version: "1.12.3"
+version: "1.12.5"
 tagline: Accept Bitcoin payments with 0 fees & no 3rd party
 description: >-
   BTCPay Server is a payment processor that allows you to receive
@@ -34,10 +34,16 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >
-  🚨 If you are using plugins, you will most likely find them disabled after this update, because new versions compatible with BTCPay Server v1.12 are required. Please see the "Manage Plugins" section once updated.
+  This update brings BTCPay Server to version 1.12.5, and includes various bug fixes, and improvements.
 
 
-  This update brings BTCPay Server to version 1.12.3, and includes various bug fixes, improvements, and new features.
+  - Improved checkout page load time by fetching the recommended fee in the background periodically
+
+  - Improved fee rate approximation by linear interpolation between known block targets
+
+  - Hide LN Balance when using an internal node and not a server admin
+
+
   Full release notes can be found at https://github.com/btcpayserver/btcpayserver/releases/tag/v1.11.7.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/353

--- a/btcpay-server/umbrel-app.yml
+++ b/btcpay-server/umbrel-app.yml
@@ -44,6 +44,6 @@ releaseNotes: >
   - Hide LN Balance when using an internal node and not a server admin
 
 
-  Full release notes can be found at https://github.com/btcpayserver/btcpayserver/releases/tag/v1.11.7.
+  Full release notes can be found at https://github.com/btcpayserver/btcpayserver/releases.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/353


### PR DESCRIPTION
https://github.com/btcpayserver/btcpayserver/releases

* [ ]   x86_64 -> UmbrelOS on proxmox Debian instance
* [x]   Arm64 -> Pi 4 8GB (install and update)

@nmfretz do you mind checking btcpay on a linux instance for me please. should be fine, but im having issues with my linux instance at the moment so i couldn't check.