### PR TITLE
Update gitea to 1.21.5

### DIFF
--- a/gitea/docker-compose.yml
+++ b/gitea/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: gitea/gitea:1.21.0-rootless@sha256:89e4d9f64c030a1415454259f58c517e81bbe9710db1e12a17849e2c198df301
+    image: gitea/gitea:1.21.5-rootless@sha256:874a8d88bb65f90c33fcafe4efe2de17039de1347c00f284e6f2a883a7caa55f
     user: "1000:1000"
     restart: on-failure
     ports:

--- a/gitea/umbrel-app.yml
+++ b/gitea/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: gitea
 category: developer
 name: Gitea
-version: "1.21.0"
+version: "1.21.5"
 tagline: A painless self-hosted Git service
 description: >-
   Gitea is a painless self-hosted Git service. It is similar to
@@ -42,26 +42,21 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >
-  This release updates Gitea from 1.20.3 to 1.21.0. Please review breaking changes for 1.21.0 listed in the full release notes before updating https://github.com/go-gitea/gitea/releases/tag/v1.21.0.
+  This release updates Gitea from 1.21.0 to 1.21.5.
 
 
-  Version 1.21.0 release notes highlights:
+  SECURITY
 
-  
-  FEATURES 
-  
-  - User details page
+  - Prevent anonymous container access if RequireSignInView is enabled
 
-  - Chore(actions): support cron schedule task 
-
-  - Add Retry button when creating a mirror-repo fails 
+  - Update go dependencies and fix go-git
   
   
   ENHANCEMENTS
   
-  - Render email addresses as such if followed by punctuation
+  - Make loading animation less aggressive
 
-  - Show error toast when file size exceeds the limits
+  - Avoid duplicate JS error messages on UI
   
   - Fix citation error when the file size is larger than 1024 bytes
   
@@ -70,10 +65,9 @@ releaseNotes: >
   - Remove set tabindex on view issue
 
 
-  And more!
+  And more bugfixes, misc changes.
 
-  A full list of new features, improvements, and bug fixes
-  for versions between 1.20.3 and 1.21.0 can be found here: https://github.com/go-gitea/gitea/releases.
+  A full list of new features, improvements, and bug fixes can be found here: https://github.com/go-gitea/gitea/releases.
 torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/d62e00353917143a3a10d3b376859f51b665d150


### PR DESCRIPTION
https://github.com/go-gitea/gitea/releases

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (install and update)
* [x]   Arm64 -> Pi 4 8GB (update)