### PR TITLE
pi-hole: fixed the systemd service check in the pre-install hook

### DIFF
--- a/pi-hole/hooks/pre-install
+++ b/pi-hole/hooks/pre-install
@@ -5,7 +5,7 @@ RESOLVED_SERVICE_NAME="systemd-resolved"
 RESOLVED_CONF_FILE="/etc/systemd/resolved.conf"
 
 # Check if the 'systemd-resolved' service is running
-if ! systemctl is-active --quiet service "${RESOLVED_SERVICE_NAME}"; then
+if ! systemctl is-active --quiet "${RESOLVED_SERVICE_NAME}.service"; then
 	echo "Service '${RESOLVED_SERVICE_NAME}' is not running"
 	exit
 fi


### PR DESCRIPTION
The old code was checking two systemd units - one called "service" and the other the actual one it was supposed to be checking.  If you want to restrict the check to units of type "service" you need to append ".service" to the unit name, _not_ add it as a separate argument.