### PR TITLE
Update Jam to v0.2.0

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   web:
-    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.6-clientserver-v0.9.10@sha256:92f80ceab43eea86fda4b16a90f478069e0cdd85b04bc97e25786764f4b8c4d1
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.2.0-clientserver-v0.9.11@sha256:fd6e763e48f079fa1d302cf9c44c8368d9cef39ed85d2790d52664cee1e75b4c
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: jam
 category: bitcoin
 name: Jam
-version: "0.1.6"
+version: "0.2.0"
 tagline: Your sats. Your privacy. Your profit.
 description: >-
   Jam is a user-interface for JoinMarket with focus on
@@ -13,15 +13,13 @@ description: >-
 
   The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 releaseNotes: >-
-  - Import: Ability to import existing wallets
+  - Feature: You can now renew an expired fidelity bond in a straightforward manner
 
-  - Fees: Fee estimations and limits are now shown before sending collaborative transactions
+  - Fees: Sending funds now allows for customizable fee settings for both direct and collaborative sends
 
-  - New translations: Chinese, Italian, Brazilian Portuguese, German
+  - Version: It's now readily apparent what version of Jam you're running, along with what version of JoinMarket
 
-  - UI: Frozen balances are now shown at the jar level
-
-  - UI: Various interface enhancements and consistent styling
+  - UI: Various UI improvements and bugfixes
 developer: JoinMarket WebUI Org.
 website: https://jamapp.org
 dependencies:


### PR DESCRIPTION
This version includes:
- Jam: [v0.2.0](https://github.com/joinmarket-webui/jam/releases/tag/v0.2.0)
- joinmarket-clientserver: [v0.9.11](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.11)

All notable changes of the UI can be seen in the [Jam v0.2.0 changelog](https://github.com/joinmarket-webui/jam/blob/v0.2.0/CHANGELOG.md)


Would you please be so kind as to take a look at https://github.com/getumbrel/umbrel/issues/1736?
It is very annoying to some users and it would be great to know, if you consider adapting it :pray: 