### PR TITLE
Update Ordinals to v0.15.0

### DIFF
--- a/ordinals/docker-compose.yml
+++ b/ordinals/docker-compose.yml
@@ -8,12 +8,12 @@ services:
       PROXY_AUTH_ADD: "false"
 
   ord:
-    image: nmfretz/ord:v0.5.1@sha256:0bbe9b14a8b05b783f0f2d967845a213e85f89f1b6ae3434bd2a8d60a271fddf
+    image: nmfretz/ord:v0.15.0@sha256:526066ae7e2a69a639142cb07d0f45ceff94dd57b2a9f7fcd2062705e5b62b50
     # This needs to run as root
     # user: "1000:1000"
     restart: on-failure
     # First-inscription-height may not be needed in the future
     command: "--first-inscription-height 767430 --data-dir /var/lib/ord --bitcoin-data-dir /var/lib/bitcoind --rpc-url ${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_RPC_PORT} --chain ${APP_BITCOIN_NETWORK} server --http"
     volumes:
-      - ${APP_DATA_DIR}/data:/var/lib/ord
+      - ${APP_DATA_DIR}/data/ord:/var/lib/ord
       - ${APP_BITCOIN_DATA_DIR}:/var/lib/bitcoind:ro

--- a/ordinals/hooks/pre-start
+++ b/ordinals/hooks/pre-start
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DATA_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../data)"
+ORDINALS_DATA_DIR="${APP_DATA_DIR}/ord"
+DESIRED_OWNER="1000:1000"
+
+set_correct_permissions() {
+	local -r path="${1}"
+
+	if [[ -d "${path}" ]]; then
+		owner=$(stat -c "%u:%g" "${path}")
+
+		if [[ "${owner}" != "${DESIRED_OWNER}" ]]; then
+			chown -R "${DESIRED_OWNER}" "${path}"
+		fi
+	fi
+}
+
+if [[ -f "${APP_DATA_DIR}/index.redb" ]]; then
+  rm -f "${APP_DATA_DIR}/index.redb"
+  mkdir -p "${ORDINALS_DATA_DIR}"
+  # set correct permissions for both data and ord
+  set_correct_permissions "${APP_DATA_DIR}"
+fi
+
+
+
+
+
+

--- a/ordinals/umbrel-app.yml
+++ b/ordinals/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ordinals
 category: bitcoin
 name: Ordinals
-version: "0.5.1"
+version: "0.15.0"
 tagline: Trustlessly view Ordinal inscriptions using your Bitcoin node.
 description: >
   A block explorer to trustlessly view Ordinal inscriptions. Search blocks, transactions, outputs, and individual satoshis.
@@ -12,7 +12,12 @@ description: >
 
 
   Disclaimer: The Ordinals app does not control, filter, or moderate the content hosted on the Bitcoin blockchain. Consequently, you may come across NSFW (Not Safe For Work), objectionable, or unlawful material while using the app.
-releaseNotes: ""
+releaseNotes: >-
+  🚨 This update requires a full re-indexing of the ord database due to a significant new release of ord that alters the database schema.
+  This is handled for you automatically by Umbrel when you update the app. 
+
+
+  This release updates Ord from version 0.5.1 to 0.15.0. Full release notes for Ord can be found at: https://github.com/ordinals/ord/releases
 developer: Casey Rodarmor
 website: https://ordinals.com/
 dependencies:


### PR DESCRIPTION
Updates Ord from v0.5.1 to v0.15.0.

This update requires a full re-indexing of the ord database due to newer version of ord altering the database schema.
Re-indexing on update from v0.5.1 will happen automatically for users on app update.

Tested on arm64 and x86.
Tested re-index logic.