### PR TITLE
Update Back That Mac Up to v1.0.1

### DIFF
--- a/back-that-mac-up/docker-compose.yml
+++ b/back-that-mac-up/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   server:
-    image: getumbrel/umbrel-back-that-mac-up:1.0.0@sha256:f26f349eec8b3e9970a5f012ce30567d577b9459705a86f3592273a15f2ed0af
+    image: getumbrel/umbrel-back-that-mac-up:1.0.1@sha256:a42784b89a57cc128cc0e139be93f18ce8da3e41d219090452d17e44ed0a4c3c
     restart: on-failure
     environment:
       TIME_MACHINE_DIR: "/timemachine"

--- a/back-that-mac-up/umbrel-app.yml
+++ b/back-that-mac-up/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: back-that-mac-up
 category: files
 name: Back That Mac Up
-version: "1.0.0"
+version: "1.0.1"
 tagline: Backup your Mac to your Umbrel using Time Machine
 description: >
   Introducing Back That Mac Up — an official app by Umbrel.
@@ -16,7 +16,8 @@ description: >
 
 
   For seamless backups even when your Mac isn't connected to the same network as your Umbrel, simply install Tailscale on your Umbrel and your Mac, and use smb://umbrel as the server address.
-releaseNotes: ""
+releaseNotes: >-
+  This is a patch release to clarify the instructions in the app and improve the accuracy of current usage indicator.
 developer: Umbrel
 website: https://umbrel.com
 dependencies: []

--- a/back-that-mac-up/umbrel-app.yml
+++ b/back-that-mac-up/umbrel-app.yml
@@ -17,7 +17,7 @@ description: >
 
   For seamless backups even when your Mac isn't connected to the same network as your Umbrel, simply install Tailscale on your Umbrel and your Mac, and use smb://umbrel as the server address.
 releaseNotes: >-
-  This is a patch release to clarify the instructions in the app and improve the accuracy of current usage indicator.
+  This is a patch release to clarify the instructions in the app and improve the accuracy of the current usage indicator.
 developer: Umbrel
 website: https://umbrel.com
 dependencies: []


### PR DESCRIPTION
This is a patch release to clarify the instructions in the app and improve the accuracy of the current usage indicator.

Tested on arm64 and x86.