### PR TITLE
Update home-assistant to 2024.3.0

### DIFF
--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   server:
-    image: homeassistant/home-assistant:2024.2.1@sha256:5808ca4b75d89950a705119370198c53f83ab7de3c3632e2948e1305d27d649d
+    image: homeassistant/home-assistant:2024.3.0@sha256:0471da64037a0d0c82b35af23fe632373324bac01decd3475921c2796f2a9968
     network_mode: host
     # UI at default port 8123
     privileged: true

--- a/home-assistant/umbrel-app.yml
+++ b/home-assistant/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: home-assistant
 category: automation
 name: Home Assistant
-version: "2024.2.1"
+version: "2024.3.0"
 tagline: Home automation that puts local control & privacy first
 description: >-
   Open source home automation that puts local control and privacy
@@ -40,7 +40,16 @@ torOnly: false
 releaseNotes: >-
   This release includes many new features and changes.
 
+  
+  - Drag-and-drop rearrangement of cards and sections
 
-  The Home-Assistant release blog-post summarises them here: https://www.home-assistant.io/blog/2024/02/07/release-20242/
+  - A new experimental sections view
+
+  - New energy graph for individual devices
+
+  - New integrations and much more... 
+  
+
+  The Home-Assistant release blog-post summarises them here: https://www.home-assistant.io/blog/2024/03/06/release-20243/
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/9d79cffae608c6a6ab077f859c1c531a581cf926


### PR DESCRIPTION
Release notes: https://www.home-assistant.io/blog/2024/03/06/release-20243/

* [x]   x86_64 -> UmbrelOS on proxmox Debian instance (fresh install and update)
* [x]   Arm64 -> Pi 4 8GB (update)