### PR TITLE
lightning-terminal: update to `v0.12.4-alpha`

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.12.3-alpha@sha256:1de0b3d155cd77ea7b84a1163eccb5e304b6117262f6d8ef353a12f2d0dc280b
+    image: lightninglabs/lightning-terminal:v0.12.4-alpha@sha256:b113bc6369c56404cbc2ff803b40046689a66dfdae16aecb979f164389b95dd3
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.12.3-alpha"
+version: "0.12.4-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -57,10 +57,7 @@ defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
   This release of Lightning Terminal (LiT) includes updates to the versions of
-  the integrated LND, Loop and Taproot Assets daemons. This release also
-  includes updates to the Lightning Node Connect implementation, to make
-  connections more robust and more optimised. Furthermore, an issue when
-  starting up LiT has been fixed with this release.
+  the integrated Loop and Faraday daemons.
 
 
   IMPORTANT NOTE: To avoid loss of funds, it's imperative that you read the
@@ -90,6 +87,6 @@ releaseNotes: >-
 
 
   This release packages LND v0.17.4-beta, Taproot Assets Daemon v0.3.3-alpha,
-  Loop v0.27.0-beta, Pool v0.6.4-beta and Faraday v0.2.11-alpha.
+  Loop v0.28.0-beta, Pool v0.6.4-beta and Faraday v0.2.13-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
In this PR we bump Litd to `v0.12.4-alpha`.

See the release notes here: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.12.4-alpha

Happy to address any feedback if needed :)!