### PR TITLE
export core-lightning datadir

### DIFF
--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data/app:${APP_CONFIG_DIR}
-      - ${APP_DATA_DIR}/data/lightningd:${APP_CORE_LIGHTNING_DATA_DIR}
+      - ${APP_CORE_LIGHTNING_DATA_DIR}:${CORE_LIGHTNING_PATH}
       - ${APP_CORE_LIGHTNING_REST_CERT_DIR}:${APP_REST_CERT_VOLUME_DIR}
     environment:
       SINGLE_SIGN_ON: "true"
@@ -29,15 +29,15 @@ services:
       COMMANDO_CONFIG: ${COMMANDO_CONFIG}
       APP_CONFIG_DIR: ${APP_CONFIG_DIR}
       APP_MODE: ${APP_MODE}
-      DEVICE_DOMAIN_NAME: ${DEVICE_DOMAIN_NAME} 
+      DEVICE_DOMAIN_NAME: ${DEVICE_DOMAIN_NAME}
       LOCAL_HOST: http://${DEVICE_DOMAIN_NAME}
-      CA_CERT: ${APP_CORE_LIGHTNING_DATA_DIR}/bitcoin/ca.pem
-      CLIENT_KEY: ${APP_CORE_LIGHTNING_DATA_DIR}/bitcoin/client-key.pem
-      CLIENT_CERT: ${APP_CORE_LIGHTNING_DATA_DIR}/bitcoin/client.pem
+      CA_CERT: ${CORE_LIGHTNING_PATH}/bitcoin/ca.pem
+      CLIENT_KEY: ${CORE_LIGHTNING_PATH}/bitcoin/client-key.pem
+      CLIENT_CERT: ${CORE_LIGHTNING_PATH}/bitcoin/client.pem
     networks:
       default:
         ipv4_address: ${APP_CORE_LIGHTNING_IP}
-  
+
   c-lightning-rest:
     image: saubyk/c-lightning-rest:0.10.5@sha256:51941e2b5e82fae87a833fbee658961ca223a40d63e3f685f55c3538764652ec
     restart: on-failure
@@ -49,7 +49,7 @@ services:
       LN_PATH: "${CORE_LIGHTNING_PATH}"
     volumes:
       - "${APP_CORE_LIGHTNING_REST_CERT_DIR}:/usr/src/app/certs"
-      - "${APP_DATA_DIR}/data/lightningd:${CORE_LIGHTNING_PATH}"
+      - "${APP_CORE_LIGHTNING_DATA_DIR}:${CORE_LIGHTNING_PATH}"
     networks:
       default:
         ipv4_address: ${APP_CORE_LIGHTNING_REST_IP}
@@ -64,7 +64,7 @@ services:
       - --bitcoin-rpcconnect=${APP_BITCOIN_NODE_IP}
       - --bitcoin-rpcuser=${APP_BITCOIN_RPC_USER}
       - --bitcoin-rpcpassword=${APP_BITCOIN_RPC_PASS}
-      - --bitcoin-rpcport=${APP_BITCOIN_RPC_PORT} 
+      - --bitcoin-rpcport=${APP_BITCOIN_RPC_PORT}
       - --lightning-dir=${CORE_LIGHTNING_PATH}
       - --proxy=${TOR_PROXY_IP}:${TOR_PROXY_PORT}
       - --bind-addr=${APP_CORE_LIGHTNING_DAEMON_IP}:9735
@@ -76,7 +76,7 @@ services:
       - --experimental-offers
       - --grpc-port=${APP_CORE_LIGHTNING_DAEMON_GRPC_PORT}
     volumes:
-      - "${APP_DATA_DIR}/data/lightningd:${CORE_LIGHTNING_PATH}"
+      - "${APP_CORE_LIGHTNING_DATA_DIR}:${CORE_LIGHTNING_PATH}"
     networks:
       default:
         ipv4_address: ${APP_CORE_LIGHTNING_DAEMON_IP}

--- a/core-lightning/exports.sh
+++ b/core-lightning/exports.sh
@@ -6,6 +6,8 @@ export APP_CORE_LIGHTNING_DAEMON_IP="10.21.21.96"
 export APP_CORE_LIGHTNING_DAEMON_PORT="9736"
 export APP_CORE_LIGHTNING_DAEMON_GRPC_PORT="2105"
 export APP_CORE_LIGHTNING_WEBSOCKET_PORT="2106"
+export APP_CORE_LIGHTNING_DATA_DIR="${EXPORTS_APP_DIR}/data/lightningd"
+
 
 export APP_CORE_LIGHTNING_REST_CERT_DIR="${EXPORTS_APP_DIR}/data/c-lightning-rest/certs"
 
@@ -19,7 +21,6 @@ export APP_CORE_LIGHTNING_REST_HIDDEN_SERVICE="$(cat "${rest_hidden_service_file
 
 export APP_CONFIG_DIR="/data/app"
 export APP_MODE="production"
-export APP_CORE_LIGHTNING_DATA_DIR="/root/.lightning"
 export APP_REST_CERT_VOLUME_DIR="/c-lightning-rest/certs"
 export CORE_LIGHTNING_PATH="/root/.lightning"
 export COMMANDO_CONFIG="/root/.lightning/.commando-env"


### PR DESCRIPTION
Applications that want to connect to core-lightning via grpc need access to the datadirectory in order to authorize.

The `APP_CORE_LIGHTNING_DATA_DIR` variable was used internally in the app service, but that can be replaced with `CORE_LIGHTNING_PATH`.
