### PR TITLE
Update RoboSats to v0.6.0-alpha

### DIFF
--- a/robosats/docker-compose.yml
+++ b/robosats/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 12596
 
   web:
-    image: recksato/robosats-client:0.5.4-alpha@sha256:0f6171884cb581f29c25da0691723ddb87bd8b2f3612ad8a955dc29c39b6bdf0
+    image: recksato/robosats-client:v0.6.0-alpha@sha256:ae5b806bef9bb6dc23899b0d1e667fcc4321f7f85c1623954a3861186000eee0
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: robosats
 category: bitcoin
 name: RoboSats
-version: "v0.5.4-alpha"
+version: "v0.6.0-alpha"
 tagline: Simple and Private Bitcoin P2P Exchange
 description: >-
   RoboSats is a simple and private app to exchange bitcoin for national currencies. 
@@ -34,25 +34,15 @@ description: >-
   You can join other cool Robots and get community support at https://t.me/robosats telegram group.
   
 releaseNotes: >-
-  This update is a minor release that takes Robosats from version 0.5.3-alpha to 0.5.4-alpha with some small enhancements and bug fixes.
+  This is the biggest ever RoboSats update. RoboSats has decentralized! The whole app architecture is new, yet, it should feel as familiar as always.
+  Learn more about why these changes are important on the RoboSats blog https://learn.robosats.com/robosats/update/pre-release-robosats-decentralized/
 
+  - Your RoboSats app connects to multiple trade coordinators simultaneously. This greatly improves robustness and censorship resistance.
 
-  Changes
-
-  - Dependency updates and security fixes.
-
-  - Coordinator serves robot hash_ids needed for >v0.6.0 client side robot identity generator.
-
-  - Recommended and minimum onchain fees for payouts are now more accurate.
-
-  - Devfund node has moved. The new node now has public access to the invoices services (read-only).
-
-  - Fix book re-render on swap/fiat change
-
-  - and many more.
+  - Robot identities are now generated locally. This improves speed by an order of magnitude as well as identity sovereignty.
   
-  
-  Full release notes are available at https://github.com/RoboSats/robosats/releases
+  Full changelog can be found here: https://github.com/Reckless-Satoshi/robosats/compare/v0.5.3-alpha...v0.6.0-alpha
+
 developer: RoboSats
 website: https://learn.robosats.com
 dependencies: []

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -37,9 +37,12 @@ releaseNotes: >-
   This is the biggest ever RoboSats update. RoboSats has decentralized! The whole app architecture is new, yet, it should feel as familiar as always.
   Learn more about why these changes are important on the RoboSats blog https://learn.robosats.com/robosats/update/pre-release-robosats-decentralized/
 
+
   - Your RoboSats app connects to multiple trade coordinators simultaneously. This greatly improves robustness and censorship resistance.
 
+
   - Robot identities are now generated locally. This improves speed by an order of magnitude as well as identity sovereignty.
+  
   
   Full changelog can be found here: https://github.com/Reckless-Satoshi/robosats/compare/v0.5.3-alpha...v0.6.0-alpha
 


### PR DESCRIPTION
Update RoboSats to latest v0.6.0-alpha

Untested. Exactly replicated the steps to update to v0.5.0-alpha https://github.com/getumbrel/umbrel-apps/pull/528