### PR TITLE
Add widgets

### DIFF
--- a/back-that-mac-up/umbrel-app.yml
+++ b/back-that-mac-up/umbrel-app.yml
@@ -20,7 +20,7 @@ releaseNotes: >-
   🎉 New widgets are here for umbrelOS 1.0.
 
 
-  This update brings a new widgets for Back That Mac Up, allowing you to see your Time Machine usage at a glance right from your Umbrel's home screen.
+  This update brings a new widget for Back That Mac Up, allowing you to see your Time Machine usage at a glance right from your Umbrel's home screen.
 
 
   With umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.

--- a/back-that-mac-up/umbrel-app.yml
+++ b/back-that-mac-up/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: back-that-mac-up
 category: files
 name: Back That Mac Up
-version: "1.0.1"
+version: "1.1.0"
 tagline: Backup your Mac to your Umbrel using Time Machine
 description: >
   Introducing Back That Mac Up — an official app by Umbrel.

--- a/back-that-mac-up/umbrel-app.yml
+++ b/back-that-mac-up/umbrel-app.yml
@@ -17,7 +17,13 @@ description: >
 
   For seamless backups even when your Mac isn't connected to the same network as your Umbrel, simply install Tailscale on your Umbrel and your Mac, and use smb://umbrel as the server address.
 releaseNotes: >-
-  This is a patch release to clarify the instructions in the app and improve the accuracy of the current usage indicator.
+  🎉 New widgets are here for umbrelOS 1.0.
+
+
+  This update brings a new widgets for Back That Mac Up, allowing you to see your Time Machine usage at a glance right from your Umbrel's home screen.
+
+
+  With umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
 developer: Umbrel
 website: https://umbrel.com
 dependencies: []

--- a/back-that-mac-up/umbrel-app.yml
+++ b/back-that-mac-up/umbrel-app.yml
@@ -17,13 +17,13 @@ description: >
 
   For seamless backups even when your Mac isn't connected to the same network as your Umbrel, simply install Tailscale on your Umbrel and your Mac, and use smb://umbrel as the server address.
 releaseNotes: >-
-  🎉 New widgets are here for umbrelOS 1.0.
+  🎉 Widgets are here for umbrelOS 1.0.
 
 
   This update brings a new widget for Back That Mac Up, allowing you to see your Time Machine usage at a glance right from your Umbrel's home screen.
 
 
-  With umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
+  After updating to umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
 developer: Umbrel
 website: https://umbrel.com
 dependencies: []

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -42,7 +42,7 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  🎉 New widgets are here for umbrelOS 1.0
+  🎉 New widgets are here for umbrelOS 1.0.
 
 
   This update brings two new widgets for the Bitcoin Node app, allowing you to keep an eye on your node's stats and sync progress right from your dashboard:

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -47,7 +47,9 @@ releaseNotes: >-
 
   This update brings two new widgets for the Bitcoin Node app, allowing you to keep an eye on your node's stats and its sync progress right from your Umbrel's home screen:
 
+
   - Node Stats: A widget that displays the number of peer connections, mempool size, hashrate, and blockchain size of your node.
+
 
   - Sync Progress: A widget that shows your node's synchronization progress.
 

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -45,7 +45,7 @@ releaseNotes: >-
   🎉 New widgets are here for umbrelOS 1.0.
 
 
-  This update brings two new widgets for the Bitcoin Node app, allowing you to keep an eye on your node's stats and sync progress right from your dashboard:
+  This update brings two new widgets for the Bitcoin Node app, allowing you to keep an eye on your node's stats and its sync progress right from your Umbrel's home screen:
 
   - Node Stats: A widget that displays the number of peer connections, mempool size, hashrate, and blockchain size of your node.
 

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bitcoin
 category: bitcoin
 name: Bitcoin Node
-version: "26.0"
+version: "26.0-w"
 tagline: Run your personal node powered by Bitcoin Core
 description: >-
   Run your Bitcoin node and independently store and validate

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -42,19 +42,17 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  What's new in Bitcoin Core version 26.0?
+  🎉 New widgets are here for umbrelOS 1.0
 
 
-  - P2P and network changes
+  This update brings two new widgets for the Bitcoin Node app, allowing you to keep an eye on your node's stats and sync progress right from your dashboard:
 
-  - Pruning changes: Improved handling of prune budget when using assumeutxo with -prune.
+  - Node Stats: A widget that displays the number of peer connections, mempool size, hashrate, and blockchain size of your node.
 
-  - New and updated RPCs
-  
-  - and more!
+  - Sync Progress: A widget that shows your node's synchronization progress.
 
 
-  Read the full release notes for additional information and detailed changes at https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-26.0.md
+  You can enable up to three widgets right from your dashboard by right clicking on the dashboard and selecting "Edit widgets", or by clicking on the widget selector in the Dock. 
 widgets:
   - id: "stats"
     type: "four-stats"

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -42,7 +42,7 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  🎉 New widgets are here for umbrelOS 1.0.
+  🎉 Widgets are here for umbrelOS 1.0.
 
 
   This update brings two new widgets for the Bitcoin Node app, allowing you to keep an eye on your node's stats and its sync progress right from your Umbrel's home screen:
@@ -54,7 +54,7 @@ releaseNotes: >-
   - Sync Progress: A widget that shows your node's synchronization progress.
 
 
-  With umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
+  After updating to umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
 widgets:
   - id: "stats"
     type: "four-stats"

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -52,7 +52,7 @@ releaseNotes: >-
   - Sync Progress: A widget that shows your node's synchronization progress.
 
 
-  You can enable up to three widgets right from your dashboard by right clicking on the dashboard and selecting "Edit widgets", or by clicking on the widget selector in the Dock. 
+  With umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
 widgets:
   - id: "stats"
     type: "four-stats"

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: lightning
 category: bitcoin
 name: Lightning Node
-version: "v0.17.4-beta"
+version: "v0.17.4-beta-w"
 tagline: Run your personal Lightning Network node
 description: >-
   Run your personal Lightning Network node, and join the future of Bitcoin today.

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -22,22 +22,19 @@ description: >-
 
   An official app from Umbrel.
 releaseNotes: >-
-  This release updates LND from version 0.17.3-beta to 0.17.4-beta. 
+  🎉 New widgets are here for umbrelOS 1.0.
 
 
-  This is a hot fix release that fixes multiple bugs: Channel open hanging until restart, a memory leak when using polling mode for bitcoind, sync getting lost for pruned nodes and the REST proxy not working when TLS certificate encryption is turned on.
+  This update brings three new widgets for the Lightning Node app, allowing you to keep an eye on your node's stats, bitcoin wallet, and lightning wallet right from your Umbrel's home screen:
+
+  - Node Stats: A widget that displays the number of peer connections, number of active channels, max send, and max receive.
+
+  - Bitcoin Wallet: A widget that shows the balance of your Bitcoin wallet and has shortcuts to send and receive Bitcoin in the Lightning Node app.
+
+  - Lightning Wallet: A widget that shows the balance of your Lightning wallet and has shortcuts to send and receive Lightning payments in the Lightning Node app.
 
 
-  Full release notes are found at https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/
-
-
-  🔔 In case you missed it, a previous release of the Lightning Node app (v0.17.0-beta) brought the option to run your node in hybrid mode or Tor-only mode, along with the ability to open private channels, receive keysend payments, bugfixes, and more!
-
-
-  - Hybrid mode allows your node to make connections to peers (other nodes) over both Tor and clearnet, enhancing both latency and connection stability. This is enabled by default for new users, while existing users can activate it in Advanced Settings.
-  
-
-  - You can now now choose to open private channels, which offer increased privacy but limited routing capabilities compared to public channels.
+  With umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
 developer: Umbrel
 website: https://umbrel.com
 dependencies:

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -27,9 +27,12 @@ releaseNotes: >-
 
   This update brings three new widgets for the Lightning Node app, allowing you to keep an eye on your node's stats, bitcoin wallet, and lightning wallet right from your Umbrel's home screen:
 
+
   - Node Stats: A widget that displays the number of peer connections, number of active channels, max send, and max receive.
 
+
   - Bitcoin Wallet: A widget that shows the balance of your Bitcoin wallet and has shortcuts to send and receive Bitcoin in the Lightning Node app.
+
 
   - Lightning Wallet: A widget that shows the balance of your Lightning wallet and has shortcuts to send and receive Lightning payments in the Lightning Node app.
 

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -22,7 +22,7 @@ description: >-
 
   An official app from Umbrel.
 releaseNotes: >-
-  🎉 New widgets are here for umbrelOS 1.0.
+  🎉 Widgets are here for umbrelOS 1.0.
 
 
   This update brings three new widgets for the Lightning Node app, allowing you to keep an eye on your node's stats, Bitcoin balance, and Lightning balance right from your Umbrel's home screen:
@@ -37,7 +37,7 @@ releaseNotes: >-
   - Lightning Wallet: A widget that shows the balance of your Lightning wallet and has shortcuts to send and receive Lightning payments in the Lightning Node app.
 
 
-  With umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
+  After updating to umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
 developer: Umbrel
 website: https://umbrel.com
 dependencies:

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -25,10 +25,10 @@ releaseNotes: >-
   🎉 New widgets are here for umbrelOS 1.0.
 
 
-  This update brings three new widgets for the Lightning Node app, allowing you to keep an eye on your node's stats, bitcoin wallet, and lightning wallet right from your Umbrel's home screen:
+  This update brings three new widgets for the Lightning Node app, allowing you to keep an eye on your node's stats, Bitcoin balance, and Lightning balance right from your Umbrel's home screen:
 
 
-  - Node Stats: A widget that displays the number of peer connections, number of active channels, max send, and max receive.
+  - Node Stats: A widget that displays the number of peer connections, number of active channels, max send, and max receive for your node.
 
 
   - Bitcoin Wallet: A widget that shows the balance of your Bitcoin wallet and has shortcuts to send and receive Bitcoin in the Lightning Node app.

--- a/nostr-relay/umbrel-app.yml
+++ b/nostr-relay/umbrel-app.yml
@@ -22,9 +22,17 @@ description: >
   
   Nostr Relay is powered by the open source nostr-rs-relay project — a Rust implementation of Nostr relay. It currently supports the entire relay protocol, including NIP-01, NIP-02, NIP-03, NIP-05, NIP-09, NIP-11, NIP-12, NIP-15, NIP-16, NIP-20, NIP-22, NIP-26, NIP-28, and NIP-33.
 releaseNotes: >-
-  This update brings a brand new feature that allows you to sync your private relay with your public relays,
-  backing up your past and future Nostr activity, even if the connection between your client and your private
-  relay is lost. Just tap the globe icon, enter your NIP-05 or npub address, and that's it!
+  🎉 New widgets are here for umbrelOS 1.0.
+
+
+  This update brings two new widgets for Nostr Relay, allowing you to see your latest notes and latest event kinds at a glance right from your Umbrel's home screen:
+
+  - Latest Notes: A widget that displays the latest notes that are synced to your Nostr Relay.
+
+  - Latest Events: A widget that shows the latest event kinds that are synced to your Nostr Relay, including posts, reactions, profile updates, and more.
+
+
+  With umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
 developer: Umbrel
 website: https://umbrel.com
 dependencies: []

--- a/nostr-relay/umbrel-app.yml
+++ b/nostr-relay/umbrel-app.yml
@@ -22,7 +22,7 @@ description: >
   
   Nostr Relay is powered by the open source nostr-rs-relay project — a Rust implementation of Nostr relay. It currently supports the entire relay protocol, including NIP-01, NIP-02, NIP-03, NIP-05, NIP-09, NIP-11, NIP-12, NIP-15, NIP-16, NIP-20, NIP-22, NIP-26, NIP-28, and NIP-33.
 releaseNotes: >-
-  🎉 New widgets are here for umbrelOS 1.0.
+  🎉 Widgets are here for umbrelOS 1.0.
 
 
   This update brings two new widgets for Nostr Relay, allowing you to see your latest notes and latest event kinds at a glance right from your Umbrel's home screen:
@@ -34,7 +34,7 @@ releaseNotes: >-
   - Latest Events: A widget that shows the latest event kinds that are synced to your Nostr Relay, including posts, reactions, profile updates, and more.
 
 
-  With umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
+  After updating to umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
 developer: Umbrel
 website: https://umbrel.com
 dependencies: []

--- a/nostr-relay/umbrel-app.yml
+++ b/nostr-relay/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: nostr-relay
 category: social
 name: Nostr Relay
-version: "1.1.0"
+version: "1.2.0"
 tagline: Backup all your Nostr activity with your private relay
 description: >
   Introducing Nostr Relay — an official app by Umbrel.

--- a/nostr-relay/umbrel-app.yml
+++ b/nostr-relay/umbrel-app.yml
@@ -27,7 +27,9 @@ releaseNotes: >-
 
   This update brings two new widgets for Nostr Relay, allowing you to see your latest notes and latest event kinds at a glance right from your Umbrel's home screen:
 
+
   - Latest Notes: A widget that displays the latest notes that are synced to your Nostr Relay.
+
 
   - Latest Events: A widget that shows the latest event kinds that are synced to your Nostr Relay, including posts, reactions, profile updates, and more.
 

--- a/transmission/docker-compose.yml
+++ b/transmission/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 9091
 
   server:
-    image: linuxserver/transmission:4.0.4@sha256:760b2d364dbfb6d84c9688f624dc48f98665b15e9e41be2170715afcc525e329
+    image: linuxserver/transmission:4.0.5@sha256:412881528fbbffa64da33b20ee0884985a27f601436036c420c934c1d8b4bb9a
     environment:
       - PUID=1000
       - PGID=1000

--- a/transmission/umbrel-app.yml
+++ b/transmission/umbrel-app.yml
@@ -33,12 +33,20 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  This release updates Transmission from version 4.0.3 to 4.0.4.
+  🎉 New widgets are here for umbrelOS 1.0.
 
-  This is a bugfix-only release.
-  
 
-  Full release notes are available at https://github.com/transmission/transmission/releases
+  This update brings two new widgets for Transmission, allowing you to monitor the status of your torrents right from your Umbrel's home screen:
+
+  - Status: A widget that displays the number of downloading, seeding, stopped, and queued torrents.
+
+  - Active Torrents Monitor: A widget that shows your active torrents and their download and upload speeds.
+
+
+  With umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
+
+
+  This release also updates Transmission to version 4.0.5. Full release notes are available at https://github.com/transmission/transmission/releases
 permissions:
   - STORAGE_DOWNLOADS
 widgets:

--- a/transmission/umbrel-app.yml
+++ b/transmission/umbrel-app.yml
@@ -33,7 +33,7 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  🎉 New widgets are here for umbrelOS 1.0.
+  🎉 Widgets are here for umbrelOS 1.0.
 
 
   This update brings two new widgets for Transmission, allowing you to monitor the status of your torrents right from your Umbrel's home screen:
@@ -45,7 +45,7 @@ releaseNotes: >-
   - Active Torrents Monitor: A widget that shows your active torrents and their download and upload speeds.
 
 
-  With umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
+  After updating to umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
 
 
   This release also updates Transmission to version 4.0.5. Full release notes are available at https://github.com/transmission/transmission/releases

--- a/transmission/umbrel-app.yml
+++ b/transmission/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: transmission
 category: networking
 name: Transmission
-version: "4.0.4"
+version: "4.0.5"
 tagline: A fast, easy and free BitTorrent client
 description: >-
   Transmission is designed for easy, powerful use. We've set the defaults to just work and it only takes a few clicks to configure advanced features like watch directories, bad peer blocklists, and the web interface. When Ubuntu chose Transmission as its default BitTorrent client, one of the most-cited reasons was its easy learning curve.

--- a/transmission/umbrel-app.yml
+++ b/transmission/umbrel-app.yml
@@ -38,7 +38,9 @@ releaseNotes: >-
 
   This update brings two new widgets for Transmission, allowing you to monitor the status of your torrents right from your Umbrel's home screen:
 
+
   - Status: A widget that displays the number of downloading, seeding, stopped, and queued torrents.
+
 
   - Active Torrents Monitor: A widget that shows your active torrents and their download and upload speeds.
 


### PR DESCRIPTION
🎉 Widgets are here for umbrelOS 1.0.
- Bitcoin Node
- Lightning Node
- Nostr Relay
- Back That Mac Up
- Transmission

After updating to umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.