### PR TITLE
Update Bitcoin Knots to v26.1

### DIFF
--- a/bitcoin-knots/docker-compose.yml
+++ b/bitcoin-knots/docker-compose.yml
@@ -41,7 +41,7 @@ services:
         ipv4_address: $APP_BITCOIN_KNOTS_IP
 
   bitcoind:
-    image: retropexx/bitcoind:v25.1@sha256:4091eb570744d24f4234a0efc6d8b6aaf7de1c86d1a6e3077525d59bbd98336e
+    image: retropexx/bitcoind:v26.1@sha256:14d3acf5f5d3030631161e37d8f8115f489acf94340cd6bc45328584442603e4
     command: "${APP_BITCOIN_KNOTS_COMMAND}"
     restart: unless-stopped
     stop_grace_period: 15m30s

--- a/bitcoin-knots/umbrel-app.yml
+++ b/bitcoin-knots/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bitcoin-knots
 category: bitcoin
 name: Bitcoin Knots
-version: "25.1"
+version: "26.1"
 tagline: Run your personal node powered by Bitcoin Knots
 description: >-
   Take control of your digital sovereignty by running a Bitcoin node that aligns with your needs and preferences. 


### PR DESCRIPTION
Update Bitcoin Knots to [v26.1](https://github.com/bitcoinknots/bitcoin/releases/tag/v26.1.knots20240325)

**note:** I could not test this update because it is no longer possible to install umbrel on linux and I no longer have my umbrel VMs available.