### PR TITLE
Update invidious image version

### DIFF
--- a/invidious/docker-compose.yml
+++ b/invidious/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ceramicwhite/invidious:build-1c0b420@sha256:71d18b8b637fa37ae859e20402a97559c45ea1d2be08bd7035159118432f43ce
+    image: ceramicwhite/invidious:build-08390ac@sha256:4907e660d6ea31d9a9e696a50fe2d7c7ef968b6fb5fbbd9efe257d580b5985d6
     restart: on-failure
     stop_grace_period: 1m
     user: "1000:1000"

--- a/invidious/umbrel-app.yml
+++ b/invidious/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: invidious
 category: social
 name: Invidious
-version: "2024.1.10-1c0b420"
+version: "2024.3.31-08390ac"
 tagline: Browse YouTube without tracking or ads
 description: >-
   An open source alternative front-end to YouTube
@@ -26,7 +26,7 @@ description: >-
    - Import watch history from NewPipe
    - Export subscriptions to NewPipe and Freetube
    - Import/Export Invidious user data
-  
+
   Technical features:
    - Embedded video support
    - Developer API
@@ -48,16 +48,6 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  - Add option to disable force_resolve in make_client
-
-    Some websites such as archive.org and textcaptcha.com
-    does not support IPv6 and as such requests fail when Invidious requests
-    with IPv6 to those services.
-
-  - Reenable force_resolve on pubsub subscribe request
-
-  - Make force_resolve false by default in make_client
-
-  - Remove missed explicit force_resolve=false
+  - Workaround used to fetch streaming URLs (see https://github.com/iv-org/invidious/issues/4498)
 submitter: Jasper
 submission: https://github.com/getumbrel/umbrel-apps/pull/129


### PR DESCRIPTION
Workaround used to fetch streaming URLs (see https://github.com/iv-org/invidious/issues/4498)