### PR TITLE
Update docker-compose.yml

### DIFF
--- a/librespeed/docker-compose.yml
+++ b/librespeed/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   app_proxy:
     environment:
-      APP_HOST: librespeed_server_1
+      APP_HOST: librespeed-server-1
       APP_PORT: 80
 
   server:


### PR DESCRIPTION
Typo in APP_HOST name causes librespeed-app_proxy-1 docker container to not find the docker host.   Changed underscores to dashes:
librespeed-server-1