### PR TITLE
Update Ordinals to  v0.17.1

### DIFF
--- a/ordinals/docker-compose.yml
+++ b/ordinals/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     # user: "1000:1000"
     restart: on-failure
     # First-inscription-height may not be needed in the future
-    command: "--first-inscription-height 767430 --index-runes --data-dir /var/lib/ord --bitcoin-data-dir /var/lib/bitcoind --rpc-url ${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_RPC_PORT} --chain ${APP_BITCOIN_NETWORK} server --http"
+    command: "--first-inscription-height 767430 --index-runes --data-dir /var/lib/ord --bitcoin-data-dir /var/lib/bitcoind --bitcoin-rpc-url ${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_RPC_PORT} --chain ${APP_BITCOIN_NETWORK} server --http"
     volumes:
       - ${APP_DATA_DIR}/data/ord:/var/lib/ord
       - ${APP_BITCOIN_DATA_DIR}:/var/lib/bitcoind:ro

--- a/ordinals/docker-compose.yml
+++ b/ordinals/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     # user: "1000:1000"
     restart: on-failure
     # First-inscription-height may not be needed in the future
-    command: "--first-inscription-height 767430 --data-dir /var/lib/ord --bitcoin-data-dir /var/lib/bitcoind --rpc-url ${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_RPC_PORT} --chain ${APP_BITCOIN_NETWORK} server --http"
+    command: "--first-inscription-height 767430 --index-runes --data-dir /var/lib/ord --bitcoin-data-dir /var/lib/bitcoind --rpc-url ${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_RPC_PORT} --chain ${APP_BITCOIN_NETWORK} server --http"
     volumes:
       - ${APP_DATA_DIR}/data/ord:/var/lib/ord
       - ${APP_BITCOIN_DATA_DIR}:/var/lib/bitcoind:ro

--- a/ordinals/docker-compose.yml
+++ b/ordinals/docker-compose.yml
@@ -8,12 +8,22 @@ services:
       PROXY_AUTH_ADD: "false"
 
   ord:
-    image: nmfretz/ord:v0.17.1@sha256:805913e44217e539a42d1716b72d746ddbd50b7676d80c02c4d8e1e75a0d3ba9
+    image: nmfretz/ord:v0.17.1@sha256:ee391d9152c0ac6f0f6909c19fc14e747af72abf9813d6a79b22d6f4a55ef29c
     # This needs to run as root
     # user: "1000:1000"
     restart: on-failure
-    # First-inscription-height may not be needed in the future
-    command: "--first-inscription-height 767430 --index-runes --data-dir /var/lib/ord --bitcoin-data-dir /var/lib/bitcoind --bitcoin-rpc-url ${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_RPC_PORT} --chain ${APP_BITCOIN_NETWORK} server --http"
+    command: "ord server --http"
     volumes:
       - ${APP_DATA_DIR}/data/ord:/var/lib/ord
       - ${APP_BITCOIN_DATA_DIR}:/var/lib/bitcoind:ro
+    environment:
+      ORD_DATA_DIR: "/var/lib/ord"
+      ORD_BITCOIN_DATA_DIR: "/var/lib/bitcoind"
+      ORD_COOKIE_FILE: "/var/lib/bitcoind/.cookie"
+      ORD_BITCOIN_RPC_USERNAME: "${APP_BITCOIN_RPC_USER}"
+      ORD_BITCOIN_RPC_PASSWORD: "${APP_BITCOIN_RPC_PASS}"
+      ORD_BITCOIN_RPC_URL: "${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_RPC_PORT}"
+      ORD_CHAIN: "${APP_BITCOIN_NETWORK}"
+      # First-inscription-height may not be needed in the future
+      ORD_FIRST_INSCRIPTION_HEIGHT: "767430"
+      ORD_INDEX_RUNES: "true"

--- a/ordinals/docker-compose.yml
+++ b/ordinals/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   ord:
-    image: nmfretz/ord:v0.15.0@sha256:526066ae7e2a69a639142cb07d0f45ceff94dd57b2a9f7fcd2062705e5b62b50
+    image: nmfretz/ord:v0.17.1@sha256:805913e44217e539a42d1716b72d746ddbd50b7676d80c02c4d8e1e75a0d3ba9
     # This needs to run as root
     # user: "1000:1000"
     restart: on-failure

--- a/ordinals/docker-compose.yml
+++ b/ordinals/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       ORD_BITCOIN_RPC_PASSWORD: "${APP_BITCOIN_RPC_PASS}"
       ORD_BITCOIN_RPC_URL: "${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_RPC_PORT}"
       ORD_CHAIN: "${APP_BITCOIN_NETWORK}"
-      # First-inscription-height may not be needed in the future
+      # First-inscription-height may not be needed in the future. It would be nice to remove it so that other chains like testnet are not impacted.
       ORD_FIRST_INSCRIPTION_HEIGHT: "767430"
       ORD_INDEX_RUNES: "true"
+      # TODO: consider index-sats

--- a/ordinals/hooks/pre-start
+++ b/ordinals/hooks/pre-start
@@ -24,6 +24,11 @@ if [[ -f "${APP_DATA_DIR}/index.redb" ]]; then
   set_correct_permissions "${APP_DATA_DIR}"
 fi
 
+# re-index the ordinals data for runes
+if [[ ! -f "${APP_DATA_DIR}/INDEXED_0-17-1" ]]; then
+	rm -f "${ORDINALS_DATA_DIR}/index.redb"
+	touch "${APP_DATA_DIR}/INDEXED_0-17-1"
+fi
 
 
 

--- a/ordinals/hooks/pre-start
+++ b/ordinals/hooks/pre-start
@@ -17,6 +17,7 @@ set_correct_permissions() {
 	fi
 }
 
+# handle generating the correct ord data dir for pre-0.15.0 versions
 if [[ -f "${APP_DATA_DIR}/index.redb" ]]; then
   rm -f "${APP_DATA_DIR}/index.redb"
   mkdir -p "${ORDINALS_DATA_DIR}"
@@ -25,9 +26,12 @@ if [[ -f "${APP_DATA_DIR}/index.redb" ]]; then
 fi
 
 # re-index the ordinals data for runes
-if [[ ! -f "${APP_DATA_DIR}/INDEXED_0-17-1" ]]; then
-	rm -f "${ORDINALS_DATA_DIR}/index.redb"
-	touch "${APP_DATA_DIR}/INDEXED_0-17-1"
+# for installs post 0.17.1 this file will be harmlessly created 
+if [[ ! -f "${APP_DATA_DIR}/AT_LEAST_0-17-1" ]]; then
+    if [[ -f "${ORDINALS_DATA_DIR}/index.redb" ]]; then
+        rm -f "${ORDINALS_DATA_DIR}/index.redb"
+    fi
+    touch "${APP_DATA_DIR}/AT_LEAST_0-17-1"
 fi
 
 

--- a/ordinals/umbrel-app.yml
+++ b/ordinals/umbrel-app.yml
@@ -3,15 +3,15 @@ id: ordinals
 category: bitcoin
 name: Ordinals
 version: "0.17.1"
-tagline: Trustlessly view Ordinal inscriptions using your Bitcoin node.
+tagline: Run your own index, block explorer, and command-line wallet for Ordinals
 description: >
-  A block explorer to trustlessly view Ordinal inscriptions. Search blocks, transactions, outputs, and individual satoshis.
+  Run your own index, block explorer, and command-line wallet for Ordinals. The app automatically connects to your Bitcoin node on umbrelOS for trustless operation. Simply install the app and wait for Ordinals to index inscriptions and runes.
+  
+
+  Use the block explorer to view Ordinal inscriptions. Search blocks, transactions, outputs, and individual satoshis.
 
 
-  Simply install the app and wait for Ordinals to connect to your Bitcoin node and index inscriptions.
-
-
-  This app also includes the ord command-line tool for advanced users.
+  Advanced users can use the command-line to create wallets, create and manage inscriptions, and more. A future umbrelOS update will allow you to run commands from a Terminal directly within the umbrelOS interface!
 
 
   Disclaimer: The Ordinals app does not control, filter, or moderate the content hosted on the Bitcoin blockchain. Consequently, you may come across NSFW (Not Safe For Work), objectionable, or unlawful material while using the app.
@@ -21,6 +21,7 @@ releaseNotes: >-
 
 
   Advanced users: running ord commands via the Terminal has now been simplified. From inside the ord container, simply type the command you want to run as listed in the ord help menu. For example, to create a wallet, run `ord wallet create`.
+  An upcoming umbrelOS update will allow you to run commands from a Terminal right from the umbrelOS interface.
 
 
   Full release notes for Ord can be found at: https://github.com/ordinals/ord/releases

--- a/ordinals/umbrel-app.yml
+++ b/ordinals/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ordinals
 category: bitcoin
 name: Ordinals
-version: "0.15.0"
+version: "0.17.1"
 tagline: Trustlessly view Ordinal inscriptions using your Bitcoin node.
 description: >
   A block explorer to trustlessly view Ordinal inscriptions. Search blocks, transactions, outputs, and individual satoshis.
@@ -13,11 +13,11 @@ description: >
 
   Disclaimer: The Ordinals app does not control, filter, or moderate the content hosted on the Bitcoin blockchain. Consequently, you may come across NSFW (Not Safe For Work), objectionable, or unlawful material while using the app.
 releaseNotes: >-
-  🚨 This update requires a full re-indexing of the ord database due to a significant new release of ord that alters the database schema.
+  🚨 This update requires a full re-indexing of the ord database to prepare for upcoming runes.
   This is handled for you automatically by Umbrel when you update the app. 
 
 
-  This release updates Ord from version 0.5.1 to 0.15.0. Full release notes for Ord can be found at: https://github.com/ordinals/ord/releases
+  This release updates Ord from version 0.15.0 to 0.17.1. Full release notes for Ord can be found at: https://github.com/ordinals/ord/releases
 developer: Casey Rodarmor
 website: https://ordinals.com/
 dependencies:

--- a/ordinals/umbrel-app.yml
+++ b/ordinals/umbrel-app.yml
@@ -11,13 +11,19 @@ description: >
   Simply install the app and wait for Ordinals to connect to your Bitcoin node and index inscriptions.
 
 
+  This app also includes the ord command-line tool for advanced users.
+
+
   Disclaimer: The Ordinals app does not control, filter, or moderate the content hosted on the Bitcoin blockchain. Consequently, you may come across NSFW (Not Safe For Work), objectionable, or unlawful material while using the app.
 releaseNotes: >-
-  🚨 This update requires a full re-indexing of the ord database to prepare for upcoming runes.
+  🚨 This update requires a full re-indexing of the ord database to prepare for upcoming runes!
   This is handled for you automatically by Umbrel when you update the app. 
 
 
-  This release updates Ord from version 0.15.0 to 0.17.1. Full release notes for Ord can be found at: https://github.com/ordinals/ord/releases
+  Advanced users: running ord commands via the Terminal has now been simplified. From inside the ord container, simply type the command you want to run as listed in the ord help menu. For example, to create a wallet, run `ord wallet create`.
+
+
+  Full release notes for Ord can be found at: https://github.com/ordinals/ord/releases
 developer: Casey Rodarmor
 website: https://ordinals.com/
 dependencies:


### PR DESCRIPTION
- update ord from 0.15.0 to 0.17.1
- built 0.17.1 image using the [official Dockerfile in the ord repo](https://github.com/ordinals/ord/blob/cb4de8dedf8485d265e6cd0edab7c2c894685190/Dockerfile). Had previously been using a custom Dockerfile because the ord repo did not include one in the past. The official Dockerfile does not include an entrypoint with the ord command, so I have added it to the command in the compose file.
- moved appropriate cli flags to environment variables. Users will now see accurate config values when running `ord settings` and can now run ord commands without passing data-dir/config/rpc options. For example `ord wallet create`.
- added --index-runes
- modified the pre-start hook to nuke index.db for users updating so that reindexing for runes occurs automatically.