### PR TITLE
Update Frigate with config.yml

### DIFF
--- a/frigate/data/config/config.yml
+++ b/frigate/data/config/config.yml
@@ -1,0 +1,14 @@
+mqtt:
+  enabled: False
+
+cameras:
+  name_of_your_camera: # <------ Name the camera
+    ffmpeg:
+      inputs:
+        - path: rtsp://10.0.10.10:554/rtsp # <----- The stream you want to use for detection
+          roles:
+            - detect
+    detect:
+      enabled: False # <---- disable detection until you have a working camera feed
+      width: 1280 # <---- update for your camera's resolution
+      height: 720 # <---- update for your camera's resolution


### PR DESCRIPTION
This is a fix for Frigate that was impacting new installs. The config.yml was commited blank in the last update PR accidentally when attempting to handle a breaking change: https://github.com/getumbrel/umbrel-apps/pull/1014

New installs that were impacted can uninstall and re-install the app.