### PR TITLE
[FIX] [BUG] Update lnbits docker-compose.yml (#1033)

### DIFF
--- a/lnbits/docker-compose.yml
+++ b/lnbits/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       APP_HOST: lnbits_web_1
       APP_PORT: 3007
       PROXY_AUTH_ADD: "false"
+      PROXY_TRUST_UPSTREAM: "true"
   
   web:
     image: lnbits/lnbits:0.12.2@sha256:ce11b1127ab9a6314ed5a57792dcd938ee189c2f549888f6cdda21a181a12fc9


### PR DESCRIPTION
Add `PROXY_TRUST_UPSTREAM: "true"` in **lnbits/docker-compose.yml** to make lnbits work in clearnet using nginx reverse proxy with SSL certificate.