### PR TITLE
fix: ensure ord data dir exists before touch

### DIFF
--- a/ordinals/hooks/pre-start
+++ b/ordinals/hooks/pre-start
@@ -5,6 +5,9 @@ APP_DATA_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../data)"
 ORDINALS_DATA_DIR="${APP_DATA_DIR}/ord"
 DESIRED_OWNER="1000:1000"
 
+# Ensure the data directory exists
+mkdir -p "${ORDINALS_DATA_DIR}"
+
 set_correct_permissions() {
 	local -r path="${1}"
 


### PR DESCRIPTION
I could be missing something, but on a new install when the pre-start file runs the data directory doesn't seem created yet so the touch command fails and doesn't create that version check file