### PR TITLE
Add FlareSolverr to Prowlarr

### DIFF
--- a/prowlarr/docker-compose.yml
+++ b/prowlarr/docker-compose.yml
@@ -36,3 +36,7 @@ services:
       SONARR_CONFIG_XML: "${APP_PROWLARR_SONARR_CONFIG_XML}"
       READARR_URL: "http://readarr_server_1:8787"
       READARR_CONFIG_XML: "${APP_PROWLARR_READARR_CONFIG_XML}"
+
+  proxy:
+    image: flaresolverr/flaresolverr:v3.3.17@sha256:5f5661db1e69a6f80ac24d47d9fa5580f6f741ee5ec967818396ae0dacecd7ea
+    restart: on-failure


### PR DESCRIPTION
For some indexers, it is required to proxy Prowlarr's traffic through FlareSolverr, as shown on the screenshot below.

![image](https://github.com/getumbrel/umbrel-apps/assets/24453257/6c7c0819-823b-498e-9cb0-d342d9a9f737)

My solution was to add FlareSolverr to Prowlarr's docker-compose, and configure the proxy in Prowlarr as shown below.

![image](https://github.com/getumbrel/umbrel-apps/assets/24453257/012cd455-aa37-4651-a485-d6a24539a327)

From my understanding, it would also be possible to use "getumbrel/media-app-configurator" to configure Prowlarr, however, I have no clue how to do that. Any help would be appreciated.