### PR TITLE
[FIX] a critical issue with Jackett

### DIFF
--- a/jackett/docker-compose.yml
+++ b/jackett/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       APP_HOST: jackett_server_1
       APP_PORT: 9117
-      PROXY_AUTH_WHITELIST: "/api/*"
+      PROXY_AUTH_WHITELIST: "/api/* /dl/*"
 
   server:
     image: linuxserver/jackett:0.21.2163@sha256:d1d5afd50a2ac0084e49eb57be551179281e965df2d9efc07a7b110d97c29d6a

--- a/jackett/docker-compose.yml
+++ b/jackett/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/* /dl/*"
 
   server:
-    image: linuxserver/jackett:0.21.2163@sha256:d1d5afd50a2ac0084e49eb57be551179281e965df2d9efc07a7b110d97c29d6a
+    image: linuxserver/jackett:0.21.2446@sha256:fb4a593a24655004354787d5184a223102e14b75e71e531ee0d3e281266ddfd9
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/config

--- a/jackett/umbrel-app.yml
+++ b/jackett/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jackett
 category: media
 name: Jackett
-version: "0.21.2163"
+version: "0.21.2446"
 tagline: API support for your favorite torrent trackers
 description: >-
   Jackett works as a proxy server: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious, etc) into tracker-site-specific http queries,

--- a/jackett/umbrel-app.yml
+++ b/jackett/umbrel-app.yml
@@ -34,7 +34,11 @@ gallery:
   - 3.jpg
 path: ""
 releaseNotes: >-
-  This release updates Jackett from version 0.21.1289 to 0.21.2163. The full release notes are available at https://github.com/Jackett/Jackett/releases.
+  This release updates Jackett from version 0.21.2163 to 0.21.2446.
+  It includes a fix for an issue where private/proxied indexers could not be used with companion apps like Sonarr and Radarr.
+  
+  
+  The full release notes are available at https://github.com/Jackett/Jackett/releases.
 permissions:
   - STORAGE_DOWNLOADS
 torOnly: false


### PR DESCRIPTION
Jacket, in its Torznab feed sets the torrent url as http://<jackett>/dl/..., which is protected by umbrel's app proxy. This PR removes protection for dl/*

(Based on app-proxy's source code, the whitelist can be separated with /[, ]*/)