### PR TITLE
[UPDATE] Btcpay server

### DIFF
--- a/btcpay-server/docker-compose.yml
+++ b/btcpay-server/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.5.0@sha256:bbff2b6703ed240da263e6ba01deacf2c6520d371d6a0202e87a9e8c7f97b158
+    image: nicolasdorier/nbxplorer:2.5.2@sha256:a85a697d1cb35fd3736ed3bd4690076141beb32a965569b003b209e0b6fd4631
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -31,7 +31,7 @@ services:
       NBXPLORER_BTCHASTXINDEX: 1
 
   web:
-    image: btcpayserver/btcpayserver:1.12.5@sha256:d854957dc8cca0ac1fff609f06979884bc0fac3e0bdb587e2dbae265349da861
+    image: btcpayserver/btcpayserver:1.13.1@sha256:ee432e652e129d82a76e4de8ff28e90eb5476d01fcb008e3678991c52f5084e9
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -57,7 +57,7 @@ services:
       BTCPAY_TORSERVICES: "btcpayserver:$APP_HIDDEN_SERVICE"
 
   postgres:
-    image: btcpayserver/postgres:13.10@sha256:12b8f625bc64b5b129e0e7a672e5e31fb5d39a7dbe42233eef7ab321568f30e7
+    image: btcpayserver/postgres:13.13@sha256:20d090860c929d4e86dc1068ad542cbae3e7ab3bcbc5c0c8a8b57ec91a5cbe3c
     # This needs to run as root for migrations to succeed
     # user: "1000:1000"
     restart: on-failure

--- a/btcpay-server/umbrel-app.yml
+++ b/btcpay-server/umbrel-app.yml
@@ -33,20 +33,22 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
-releaseNotes: >
-  This update brings BTCPay Server to version 1.13.1, and includes various bug fixes, and improvements.
+releaseNotes: >-
+  This update brings BTCPay Server to version 1.13.1, and includes various new features, bug fixes, and improvements.
 
-  - CSV exports from the Reports were exporting dates in 12-hour format instead of 24-hour format. (#5915, #5922) @TChukwuleta
 
-  - Crash when configuring BTCPay Server with a non-default Postgres schema (Fix #5901) @NicolasDorier
+  Highlights:
 
-  - A payment request with an amount of 0 no longer causes the payment request's page to crash (#5926) @Kukks
+  - It is now possible to customize your instance name and add a contact URL in Server Settings
+  
+  - There is a new Admin overview of the stores on the instance
+  
+  - Onboarding: Invite new users (#5714 #5719 #5874) @dennisreimann @dstrukt
+  
+  - A new option to add item list to keypad
+  
+  - Support for Better Bitcoin QRs (BBQr)
 
-  - Prevent unintentional double payouts (#5931, #5913) @dennisreimann
-
-  - The buyerEmail field in a Payment Request's form will now set the email for the payment request (#5926) @Kukks
-
-  - Added Tether as a supporter to the BTCPay Server Foundation (#5891) @rockstardev
 
   Full release notes can be found at https://github.com/btcpayserver/btcpayserver/releases.
 submitter: Umbrel

--- a/btcpay-server/umbrel-app.yml
+++ b/btcpay-server/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: btcpay-server
 category: bitcoin
 name: BTCPay Server
-version: "1.12.5"
+version: "1.13.1"
 tagline: Accept Bitcoin payments with 0 fees & no 3rd party
 description: >-
   BTCPay Server is a payment processor that allows you to receive
@@ -34,15 +34,19 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >
-  This update brings BTCPay Server to version 1.12.5, and includes various bug fixes, and improvements.
+  This update brings BTCPay Server to version 1.13.1, and includes various bug fixes, and improvements.
 
+  - CSV exports from the Reports were exporting dates in 12-hour format instead of 24-hour format. (#5915, #5922) @TChukwuleta
 
-  - Improved checkout page load time by fetching the recommended fee in the background periodically
+  - Crash when configuring BTCPay Server with a non-default Postgres schema (Fix #5901) @NicolasDorier
 
-  - Improved fee rate approximation by linear interpolation between known block targets
+  - A payment request with an amount of 0 no longer causes the payment request's page to crash (#5926) @Kukks
 
-  - Hide LN Balance when using an internal node and not a server admin
+  - Prevent unintentional double payouts (#5931, #5913) @dennisreimann
 
+  - The buyerEmail field in a Payment Request's form will now set the email for the payment request (#5926) @Kukks
+
+  - Added Tether as a supporter to the BTCPay Server Foundation (#5891) @rockstardev
 
   Full release notes can be found at https://github.com/btcpayserver/btcpayserver/releases.
 submitter: Umbrel


### PR DESCRIPTION
Fix: #1049

Updated containers:
 - nicolasdoriev/nbxplorer:2.5.0 -> 2.5.2
 - btcpayserver/btcpayserver:1.12.5 -> 1.13.1
 - btcpaayserver:13.10 -> 13.13

I have partially tested the app on my Debian Umbrel, but because I don't have a bitcoin node (the synchronization takes Ages!) I can't fully verify that the app is working. It gets to starting the app, but because APP_LIGHTNING_NODE_DATA_DIR is null, it fails. The app should be working for people who have the lightning node. Test it on your machine. Just in case.