### PR TITLE
Update Ordinals to v0.18.2

### DIFF
--- a/ordinals/docker-compose.yml
+++ b/ordinals/docker-compose.yml
@@ -25,6 +25,6 @@ services:
       ORD_BITCOIN_RPC_URL: "${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_RPC_PORT}"
       ORD_CHAIN: "${APP_BITCOIN_NETWORK}"
       # First-inscription-height may not be needed in the future. It would be nice to remove it so that other chains like testnet are not impacted.
-      ORD_FIRST_INSCRIPTION_HEIGHT: "767430"
+      # ORD_FIRST_INSCRIPTION_HEIGHT: "767430"
       ORD_INDEX_RUNES: "true"
       # TODO: consider index-sats

--- a/ordinals/docker-compose.yml
+++ b/ordinals/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     # This needs to run as root
     # user: "1000:1000"
     restart: on-failure
+    stop_grace_period: 15m30s
     command: "ord server --http"
     volumes:
       - ${APP_DATA_DIR}/data/ord:/var/lib/ord

--- a/ordinals/docker-compose.yml
+++ b/ordinals/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   ord:
-    image: mayankchhabra/ord:0.18.1@sha256:9cc88552cca2b59ed6417790ec1b43f4dbfaf0c9ea3fdf79bf055dcd6dcb60b8
+    image: nmfretz/ord:0.18.2@sha256:9f9445ae39df02c31ccf5e604f2539f148ccbd38703e717e1208b08583b9d406
     # This needs to run as root
     # user: "1000:1000"
     restart: on-failure

--- a/ordinals/hooks/pre-start
+++ b/ordinals/hooks/pre-start
@@ -43,35 +43,42 @@ fi
 # for installs post 0.18.2, the AT_LEAST_0-18-2 file will be harmlessly created
 
 if [[ ! -f "${APP_DATA_DIR}/AT_LEAST_0-18-2" ]]; then
-    declare -a dirs=("" "/testnet3" "/regtest" "/signet")  # Array of bitcoin network subdirectories
+    echo "AT_LEAST_0-18-2 not found, proceeding with wallet database migration if necessary..."
+    # declare bitcoin network directories
+    declare -a dirs=("" "/testnet3" "/regtest" "/signet")
     for dir in "${dirs[@]}"; do
-        if [[ -d "${ORDINALS_DATA_DIR}${dir}" ]]; then
-            has_wallets=false
-            files_to_move=()  # Array to store files that need to be moved
+        dir_path="${ORDINALS_DATA_DIR}${dir}"
+        echo "Checking directory: ${dir_path}"
+        if [[ -d "${dir_path}" ]]; then
+            echo "${dir_path} exists."
+            files_to_move=()  # an array to store wallet database files to migrate
 
-            # We iterate over files to find .redb files that are not index.redb (these are wallet database files)
-            for file in "${ORDINALS_DATA_DIR}${dir}"/*.redb; do
-                if [[ "$(basename "${file}")" != "index.redb" ]]; then
-                    files_to_move+=("${file}")  # Add file to array
-                    has_wallets=true
+            # Iterate over .redb files that are not index.redb
+            for file in "${dir_path}"/*.redb; do
+                if [[ -f "${file}" && "$(basename "${file}")" != "index.redb" ]]; then
+                    files_to_move+=("${file}")
+                    echo "Adding ${file} to move list."
                 fi
             done
 
-            if [[ "${has_wallets}" == true ]]; then
-                # We only create the wallets subdirectory if there are wallets to move so that we mimic the behavior of ord 0.18.2 which only creates the wallets subdirectory once a wallet database is created
-                mkdir -p "${ORDINALS_DATA_DIR}${dir}/wallets"
-                # Move all collected wallet .redb files
+            # We only create the wallets directory if there are files to move. This mimics the behavior of ord 0.18.2, which only creates the wallets directory when a wallet database is created.
+            if [[ ${#files_to_move[@]} -gt 0 ]]; then 
+                mkdir -p "${dir_path}/wallets"
+                echo "Creating wallets directory in ${dir_path}/wallets"
                 for file in "${files_to_move[@]}"; do
-                    mv "${file}" "${ORDINALS_DATA_DIR}${dir}/wallets/"
+                    echo "Moving ${file} to ${dir_path}/wallets/"
+                    mv "${file}" "${dir_path}/wallets/"
                 done
+            else
+                echo "No wallet files to move in ${dir_path}."
             fi
+        else
+            echo "${dir_path} does not exist, skipping."
         fi
     done
-    touch "${APP_DATA_DIR}/AT_LEAST_0-18-2"  # Set the flag that the migration has been done
+    touch "${APP_DATA_DIR}/AT_LEAST_0-18-2"
+    echo "Wallet database migration complete, flag file created."
+else
+    echo "Migration flag file already exists, skipping wallet database migration."
 fi
-
-
-
-
-
 

--- a/ordinals/hooks/pre-start
+++ b/ordinals/hooks/pre-start
@@ -37,6 +37,40 @@ if [[ ! -f "${APP_DATA_DIR}/AT_LEAST_0-18-1" ]]; then
     touch "${APP_DATA_DIR}/AT_LEAST_0-18-1"
 fi
 
+# migrate all wallet database files to ord/wallets, ord/testnet3/wallets, ord/regtest/wallets, and ord/signet/wallets for pre-0.18.2 versions: https://github.com/ordinals/ord/releases/tag/0.18.2
+# the default unnamed wallet from `ord wallet create` is called ord.redb, but users can create named wallets as <anything>.redb
+# we assume that all .redb files except index.redb are wallet database files
+# for installs post 0.18.2, the AT_LEAST_0-18-2 file will be harmlessly created
+
+if [[ ! -f "${APP_DATA_DIR}/AT_LEAST_0-18-2" ]]; then
+    declare -a dirs=("" "/testnet3" "/regtest" "/signet")  # Array of bitcoin network subdirectories
+    for dir in "${dirs[@]}"; do
+        if [[ -d "${ORDINALS_DATA_DIR}${dir}" ]]; then
+            has_wallets=false
+            files_to_move=()  # Array to store files that need to be moved
+
+            # We iterate over files to find .redb files that are not index.redb (these are wallet database files)
+            for file in "${ORDINALS_DATA_DIR}${dir}"/*.redb; do
+                if [[ "$(basename "${file}")" != "index.redb" ]]; then
+                    files_to_move+=("${file}")  # Add file to array
+                    has_wallets=true
+                fi
+            done
+
+            if [[ "${has_wallets}" == true ]]; then
+                # We only create the wallets subdirectory if there are wallets to move so that we mimic the behavior of ord 0.18.2 which only creates the wallets subdirectory once a wallet database is created
+                mkdir -p "${ORDINALS_DATA_DIR}${dir}/wallets"
+                # Move all collected wallet .redb files
+                for file in "${files_to_move[@]}"; do
+                    mv "${file}" "${ORDINALS_DATA_DIR}${dir}/wallets/"
+                done
+            fi
+        fi
+    done
+    touch "${APP_DATA_DIR}/AT_LEAST_0-18-2"  # Set the flag that the migration has been done
+fi
+
+
 
 
 

--- a/ordinals/umbrel-app.yml
+++ b/ordinals/umbrel-app.yml
@@ -16,10 +16,12 @@ description: >
 
   Disclaimer: The Ordinals app does not control, filter, or moderate the content hosted on the Bitcoin blockchain. Consequently, you may come across NSFW (Not Safe For Work), objectionable, or unlawful material while using the app.
 releaseNotes: >-
-  🚨 This update will automatically migrate existing wallet databases to the new ord 0.18.2 file structure. Simply update the app and you are done!
+  🚨 This update will automatically migrate existing wallet databases to the new ord 0.18.2 file structure. Simply update the app, and the rest is taken care of — no manual migration required!
 
 
-  Ord 0.18.2 Wallet databases are now stored in the /wallets subdirectory of the ord data directory. This update also includes other minor enhancements and bug fixes.
+  ⏳ If ord is currently indexing, it may take a few minutes to safely shut before updating. Please be patient during this process.
+
+
   Full release notes can be found at: https://github.com/ordinals/ord/releases
 developer: Casey Rodarmor
 website: https://ordinals.com/

--- a/ordinals/umbrel-app.yml
+++ b/ordinals/umbrel-app.yml
@@ -19,7 +19,7 @@ releaseNotes: >-
   🚨 This update will automatically migrate existing wallet databases to the new ord 0.18.2 file structure. Simply update the app, and the rest is taken care of — no manual migration required!
 
 
-  ⏳ If ord is currently indexing, it may take a few minutes to safely shut before updating. Please be patient during this process.
+  ⏳ If ord is currently indexing, it may take a few minutes to safely shut down before updating. Please be patient during this process.
 
 
   Full release notes can be found at: https://github.com/ordinals/ord/releases

--- a/ordinals/umbrel-app.yml
+++ b/ordinals/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ordinals
 category: bitcoin
 name: Ordinals
-version: "0.18.1"
+version: "0.18.2"
 tagline: Run your own index, block explorer, and command-line wallet for Ordinals
 description: >
   Run your own index, block explorer, and command-line wallet for Ordinals. The app automatically connects to your Bitcoin node on umbrelOS for trustless operation. Simply install the app and wait for Ordinals to index inscriptions and runes.
@@ -16,10 +16,11 @@ description: >
 
   Disclaimer: The Ordinals app does not control, filter, or moderate the content hosted on the Bitcoin blockchain. Consequently, you may come across NSFW (Not Safe For Work), objectionable, or unlawful material while using the app.
 releaseNotes: >-
-  🚨 This update will automatically perform a full re-index of the ord database to prepare for upcoming runes.
+  🚨 This update will automatically migrate existing wallet databases to the new ord 0.18.2 file structure. Simply update the app and you are done!
 
 
-  Ord 0.18.1 brings several crucial bug fixes and improvements related to runes. Full release notes can be found at: https://github.com/ordinals/ord/releases
+  Ord 0.18.2 Wallet databases are now stored in the /wallets subdirectory of the ord data directory. This update also includes other minor enhancements and bug fixes.
+  Full release notes can be found at: https://github.com/ordinals/ord/releases
 developer: Casey Rodarmor
 website: https://ordinals.com/
 dependencies:


### PR DESCRIPTION
This PR updates ord to 0.18.2, which requires the following migration:
https://github.com/ordinals/ord/releases/tag/0.18.2
> Wallet databases are now stored in the /wallets subdirectory of the data dir. To use old wallet databases with 0.18.2, move <WALLET_NAME>.redb files into the /wallets subdirectory of the data dir. Currently, the only information stored in wallet databases are pending etchings.

I have updated the pre-start script to migrate all wallet database files for all bitcoin networks (mainnet, testnet, signet, regtest). I have assumed that all .redb files in the ord data dir that **are not** index.db are instead wallet database files.

I have also removed the `ORD_FIRST_INSCRIPTION_HEIGHT` env var. Ord now handles this automatically for each Bitcoin network, so the app will work well on test networks because we haven't hard coded the first inscription height for mainnet.

Tested on arm64 and x86

@smolgrrr @mrv777 can I please get some eyes and additional tests on this 🙏