### PR TITLE
Fix bad gateway error in Seafile-app

### DIFF
--- a/seafile/docker-compose.yml
+++ b/seafile/docker-compose.yml
@@ -5,28 +5,29 @@ services:
     environment:
       APP_HOST: seafile
       APP_PORT: 80
+      PROXY_AUTH_ADD: "false"
 
   db:
     image: mariadb:10.11.6@sha256:20a8bd91d972c97cffded88f2ba0ab533c8988b2dc08090c57d50caf7114ed20
     container_name: seafile-mysql
     environment:
-      - MYSQL_ROOT_PASSWORD=db_dev 
+      - MYSQL_ROOT_PASSWORD=db_dev
       - MYSQL_LOG_CONSOLE=true
     volumes:
-       - ${APP_DATA_DIR}/data/db:/var/lib/mysql
+      - ${APP_DATA_DIR}/data/db:/var/lib/mysql
 
   memcached:
     image: memcached:1.6.18@sha256:4ab520657d9919221f752771bb013d632c9b39cea9dfae9162244b2e39885bcd
     container_name: seafile-memcached
     entrypoint: memcached -m 256
-          
+
   seafile:
-    image: seafileltd/seafile-mc:11.0.3@sha256:e712a7b15c63855e2977eda07a8fdd0024d0c1b5a413d2497e8c63c7c82c6d87
+    image: seafileltd/seafile-mc:11.0.8@sha256:1be82fe59680b6fae0df4a6fee6735c21d9915955e3e1aa6775a970ece333e52
     container_name: seafile
     volumes:
       - ${APP_DATA_DIR}/data/seafile-data:/shared
     environment:
-      - DB_HOST=db
+      - DB_HOST=seafile-mysql
       - DB_ROOT_PASSWD=db_dev
       - SEAFILE_ADMIN_EMAIL=umbrel
       - SEAFILE_ADMIN_PASSWORD=${APP_PASSWORD}

--- a/seafile/umbrel-app.yml
+++ b/seafile/umbrel-app.yml
@@ -23,7 +23,8 @@ description: >
 
   Seafile is configured to work out-of-the-box when installed on Umbrel. However, if you want to be able to upload files from a domain name that is not umbrel.local,
   open the Seafile app, go to System Admin > Settings and change "FILE_SERVER_ROOT" to /seafhttp.
-releaseNotes: ""
+releaseNotes: >-
+  This release updates Seafile from version 11.0.3 to 11.0.8. Full release notes can be found at https://manual.seafile.com/changelog/server-changelog/#1108-2024-04-22
 developer: Seafile
 website: https://www.seafile.com/
 dependencies: []

--- a/seafile/umbrel-app.yml
+++ b/seafile/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: seafile
 category: files
 name: Seafile
-version: "11.0.3"
+version: "11.0.8"
 tagline: Reliable and Performant File Sync and Share Solution
 description: >
   Seafile is an open source file sync&share solution designed for high reliability, performance and productivity.


### PR DESCRIPTION
This fixes 2 issues:
- bad gateway error after starting the app: The seafile container has to use the container-name seafile-mysql to access the database
-  When connecting through one of the desktop seafile apps, there was an internal server error: This was caused by the additional proxy auth, that the apps could not handle so I deactivated it. Seafile already provides an authentification, so this seems redundant anyway.

I have also updated seafile to the latest patch version and tested it on umbrel home 1.1.
