### PR TITLE
Update Bitcoin Node to v27.0

### DIFF
--- a/bitcoin/docker-compose.yml
+++ b/bitcoin/docker-compose.yml
@@ -40,7 +40,7 @@ services:
         ipv4_address: $APP_BITCOIN_IP
 
   bitcoind:
-    image: lncm/bitcoind:v26.0@sha256:2a335ea0e77106fc8768cade374808485a43825a6b4a17e85dd36d4acd931b22
+    image: lncm/bitcoind:v27.0@sha256:324fec72192e8a1c7b79e7ab91003e47678b808d46da2c1943e72ec212ab348f
     command: "${APP_BITCOIN_COMMAND}"
     restart: unless-stopped
     stop_grace_period: 15m30s

--- a/bitcoin/docker-compose.yml
+++ b/bitcoin/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3005
   
   server:
-    image: getumbrel/umbrel-bitcoin:v0.5.0@sha256:1f9dea33de72ce3304ced3a820a5b657e1faa5c9a9ea695fd53d1486c4618d36
+    image: getumbrel/umbrel-bitcoin:v0.7.0@sha256:f2bb98c962fbad13991ceeda1308bbfaca13cc7cd5cb7d6b2e0d1d06e6123072
     depends_on: [bitcoind]
     restart: on-failure
     volumes:

--- a/bitcoin/exports.sh
+++ b/bitcoin/exports.sh
@@ -110,6 +110,8 @@ BIN_ARGS+=( "-zmqpubsequence=tcp://0.0.0.0:${APP_BITCOIN_ZMQ_SEQUENCE_PORT}" )
 # BIN_ARGS+=( "-peerbloomfilters=1" )
 # BIN_ARGS+=( "-peerblockfilters=1" )
 # BIN_ARGS+=( "-rpcworkqueue=128" )
+# We can remove depratedrpc=create_bdb in a future update once Jam (JoinMarket) implements descriptor wallet support
+BIN_ARGS+=( "-deprecatedrpc=create_bdb" )
 
 export APP_BITCOIN_COMMAND=$(IFS=" "; echo "${BIN_ARGS[@]}")
 

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -47,10 +47,12 @@ releaseNotes: >-
 
   - Bitcoin Core: Upgrades Bitcoin Core to version 27.0. Full release notes for Bitcoin Core 27.0 can be found at https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-27.0.md.
 
+
   - New Advanced Settings Options: Adds 3 new options to the Advanced Settings menu:
     - datacarrier: Choose whether or not to relay transactions with OP_RETURN outputs.
     - datacarriersize: Set the maximum size of the data in OP_RETURN outputs (in bytes) that your node will relay.
     - permitbaremultisig: Choose wether or not to relay non-P2SH multisig transactions.
+
 
   - JoinMarket Compatibility: The deprecated RPC 'deprecatedrpc=create_bdb' is enabled to allow integration with JoinMarket and the Jam app by default.
   This fixes an issue where Jam app users who upgraded to Bitcoin Core v26.0 would have to manually add 'deprecatedrpc=create_bdb' to their bitcoin.conf file in order for the app to work.

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -56,6 +56,7 @@ releaseNotes: >-
 
   - JoinMarket Compatibility: The deprecated RPC 'deprecatedrpc=create_bdb' is enabled to allow integration with JoinMarket and the Jam app by default.
   This fixes an issue where Jam app users who upgraded to Bitcoin Core v26.0 would have to manually add 'deprecatedrpc=create_bdb' to their bitcoin.conf file in order for the app to work.
+  For existing Jam users, if you receive a connection error in Jam after updating to Bitcoin Core v27.0, please restart the Jam app from your homescreen by right-clicking on the app and selecting 'restart'.
 widgets:
   - id: "stats"
     type: "four-stats"

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -56,7 +56,9 @@ releaseNotes: >-
 
   - JoinMarket Compatibility: The deprecated RPC 'deprecatedrpc=create_bdb' is enabled to allow integration with JoinMarket and the Jam app by default.
   This fixes an issue where Jam app users who upgraded to Bitcoin Core v26.0 would have to manually add 'deprecatedrpc=create_bdb' to their bitcoin.conf file in order for the app to work.
-  For existing Jam users, if you receive a connection error in Jam after updating to Bitcoin Core v27.0, please restart the Jam app from your homescreen by right-clicking on the app and selecting 'restart'.
+  
+  
+  ⚠️ For existing Jam users, if you receive a connection error in Jam after updating to Bitcoin Core v27.0, please restart the Jam app from your homescreen by right-clicking on the app and selecting 'restart'.
 widgets:
   - id: "stats"
     type: "four-stats"

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bitcoin
 category: bitcoin
 name: Bitcoin Node
-version: "26.0-w"
+version: "27.0"
 tagline: Run your personal node powered by Bitcoin Core
 description: >-
   Run your Bitcoin node and independently store and validate
@@ -42,19 +42,18 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  🎉 Widgets are here for umbrelOS 1.0.
+  This release of the Bitcoin Node app includes the following updates:
 
 
-  This update brings two new widgets for the Bitcoin Node app, allowing you to keep an eye on your node's stats and its sync progress right from your Umbrel's home screen:
+  - Bitcoin Core: Upgrades Bitcoin Core to version 27.0. Full release notes for Bitcoin Core 27.0 can be found at https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-27.0.md.
 
+  - New Advanced Settings Options: Adds 3 new options to the Advanced Settings menu:
+    - datacarrier: Choose whether or not to relay transactions with OP_RETURN outputs.
+    - datacarriersize: Set the maximum size of the data in OP_RETURN outputs (in bytes) that your node will relay.
+    - permitbaremultisig: Choose wether or not to relay non-P2SH multisig transactions.
 
-  - Node Stats: A widget that displays the number of peer connections, mempool size, hashrate, and blockchain size of your node.
-
-
-  - Sync Progress: A widget that shows your node's synchronization progress.
-
-
-  After updating to umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
+  - JoinMarket Compatibility: The deprecated RPC 'deprecatedrpc=create_bdb' is enabled to allow integration with JoinMarket and the Jam app by default.
+  This fixes an issue where Jam app users who upgraded to Bitcoin Core v26.0 would have to manually add 'deprecatedrpc=create_bdb' to their bitcoin.conf file in order for the app to work.
 widgets:
   - id: "stats"
     type: "four-stats"


### PR DESCRIPTION
Bitcoin Core: Upgrades Bitcoin Core to version 27.0. Full release notes for Bitcoin Core 27.0 can be found at https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-27.0.md.

New Advanced Settings Options: Adds 3 new options to the Advanced Settings menu:
- datacarrier: Choose whether or not to relay transactions with OP_RETURN outputs.
- datacarriersize: Set the maximum size of the data in OP_RETURN outputs (in bytes) that your node will relay.
- permitbaremultisig: Choose wether or not to relay non-P2SH multisig transactions.

JoinMarket Compatibility: The deprecated RPC 'deprecatedrpc=create_bdb' is enabled to allow integration with JoinMarket and the Jam app by default. This fixes an issue where Jam app users who upgraded to Bitcoin Core v26.0 would have to manually add 'deprecatedrpc=create_bdb' to their bitcoin.conf file in order for the app to work.

Relevant JoinMarket issue: https://github.com/getumbrel/umbrel-bitcoin/issues/19