### PR TITLE
Update Lightning Node to v0.17.5-beta

### DIFF
--- a/lightning/docker-compose.yml
+++ b/lightning/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
   lnd:
     hostname: "${DEVICE_DOMAIN_NAME}" # Needed so LND can generate a valid cert
-    image: lightninglabs/lnd:v0.17.4-beta@sha256:72402c389943e83ccf65f978ed651eb7c655aaa5ff9ecbd7a373a2f2ff34d82e
+    image: lightninglabs/lnd:v0.17.5-beta@sha256:88526ea488a08ac55dd87202874cdba6919fbd82bfbb1fc4947b09d144c8d343
     command: "${APP_LIGHTNING_COMMAND}"
     user: 1000:1000
     restart: unless-stopped

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: lightning
 category: bitcoin
 name: Lightning Node
-version: "v0.17.4-beta-w"
+version: "v0.17.5-beta"
 tagline: Run your personal Lightning Network node
 description: >-
   Run your personal Lightning Network node, and join the future of Bitcoin today.
@@ -22,22 +22,10 @@ description: >-
 
   An official app from Umbrel.
 releaseNotes: >-
-  🎉 Widgets are here for umbrelOS 1.0.
+  This release updates LND to v0.17.5-beta. This is a minor hot fix release that bumps a dependency to ensure that lnd is compatible with Bitcoin Core 27.0.
 
 
-  This update brings three new widgets for the Lightning Node app, allowing you to keep an eye on your node's stats, Bitcoin balance, and Lightning balance right from your Umbrel's home screen:
-
-
-  - Node Stats: A widget that displays the number of peer connections, number of active channels, max send, and max receive for your node.
-
-
-  - Bitcoin Wallet: A widget that shows the balance of your Bitcoin wallet and has shortcuts to send and receive Bitcoin in the Lightning Node app.
-
-
-  - Lightning Wallet: A widget that shows the balance of your Lightning wallet and has shortcuts to send and receive Lightning payments in the Lightning Node app.
-
-
-  After updating to umbrelOS 1.0, you can add widgets by right-clicking on the home screen and selecting "Edit widgets", or by clicking on Widgets in the Dock.
+  Full LND v0.17.5-beta can be found at https://github.com/lightningnetwork/lnd/releases
 developer: Umbrel
 website: https://umbrel.com
 dependencies:

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -22,7 +22,7 @@ description: >-
 
   An official app from Umbrel.
 releaseNotes: >-
-  This release updates LND to v0.17.5-beta. This is a minor hot fix release that bumps a dependency to ensure that lnd is compatible with Bitcoin Core 27.0.
+  This release updates LND to v0.17.5-beta. This is a minor hot fix release that bumps a dependency to ensure that LND is compatible with Bitcoin Core 27.0.
 
 
   Full LND v0.17.5-beta can be found at https://github.com/lightningnetwork/lnd/releases


### PR DESCRIPTION
https://github.com/lightningnetwork/lnd/releases/tag/v0.17.5-beta

> This is a minor hot fix release that resolves an issue that arises (sendrawtransaction calls rejected) when lnd is run with bitcoind 27. This hot fix release bumps a dependency to ensure that lnd is compatible with the latest version of bitcoind.

Tested on arm64 and x86