### PR TITLE
Update Helipad to v0.2.0

### DIFF
--- a/helipad/docker-compose.yml
+++ b/helipad/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 2112
 
   web:
-    image: podcastindexorg/podcasting20-helipad:0.1.11@sha256:b1292d46b4e126ad5c6c20c5630f28d9220ef4c8d90566d17be2232e238b9d4f
+    image: podcastindexorg/podcasting20-helipad:0.2.0@sha256:1e298d6986840ae5304c53ccdd3770cde867e6cab6837997e1c45f89538a0568
     init: true
     restart: on-failure
     stop_grace_period: 1m

--- a/helipad/umbrel-app.yml
+++ b/helipad/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: helipad
 category: bitcoin
 name: Helipad
-version: "0.1.11"
+version: "0.2.0"
 tagline: View boosts & boostagrams from Podcasting 2.0 apps
 description: Helipad shows boosts and boostagram messages coming in to your
   Lightning node from your listeners who are using Podcasting 2.0 apps.
@@ -24,14 +24,12 @@ submission: https://github.com/getumbrel/umbrel/pull/1174
 releaseNotes: >-
   This update includes the following improvements:
 
-  - Added missing User-Agent header when calling the Podcast Index API
+  - New settings page which includes settings for boosts, sounds, custom numerology and webhooks
 
-  - Added reply boosts, sent tab, and password protection
+  - Improve strange TLV handling
 
-  - Show automated boosts in the Boosts tab
+  - Added axum framework
 
-  - Added browser-based reply boosts (e.g. WebLN, Alby)
+  - Added new TrueFans logo
 
-  - Added icons for LN Beats, Podcast Guru, and TrueFans
-
-  - Added boosts, streams, and sent lists to CSV export and fixed positional params
+  - Added The Split Kit to the apps list


### PR DESCRIPTION
Updates Helipad from `v0.1.11` to `v0.2.0`