### PR TITLE
Update Overseer from 1.32.5 to 1.33.2

### DIFF
--- a/overseerr/docker-compose.yml
+++ b/overseerr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/overseerr:1.32.5@sha256:376c23e5dd1304c3b4f54710eb5bb8e33ef9555fe17636098b9a0c7ec9731b26
+    image: linuxserver/overseerr:1.33.2@sha256:711c465b65d36a01580f995043a240eedaac0aa31321a8d95fa8f29f0ff8299d
     environment:
       - PUID=1000
       - PGID=1000

--- a/overseerr/umbrel-app.yml
+++ b/overseerr/umbrel-app.yml
@@ -35,7 +35,6 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
-releaseNotes: ""
 torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/607

--- a/overseerr/umbrel-app.yml
+++ b/overseerr/umbrel-app.yml
@@ -16,6 +16,12 @@ description: >-
 
   During initial set-up, you will need to input your Umbrel device's IP address to connect to Plex (and optional services such as Radarr and Sonarr).
   You can find your device's IP address by visiting your router's admin dashboard or by using an IP scanning tool like Angry IP Scanner.
+releaseNotes: >-
+  Overseerr will now synchronize the media availability state with your Plex and Radarr/Sonnar instances.
+  This means if you delete items from your Plex and Radarr/Sonarr, Overseerr will now update the media status to reflect the change so it can be requested again.
+
+
+  Full release notes can be found at https://github.com/sct/overseerr/releases
 developer: Ryan Cohen
 website: https://overseerr.dev/
 dependencies: []

--- a/overseerr/umbrel-app.yml
+++ b/overseerr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: overseerr
 category: media
 name: Overseerr
-version: "1.32.5"
+version: "1.33.2"
 tagline: Beautiful media discovery
 description: >-
   Overseerr is a request management and media discovery tool built to work with your existing Plex ecosystem.


### PR DESCRIPTION
Updates Overseer from `1.32.5` to `1.33.2`.

Tested on rpi5 with Umbrel OS 1.1
