### PR TITLE
General fixes

### DIFF
--- a/calibre-web/umbrel-app.yml
+++ b/calibre-web/umbrel-app.yml
@@ -18,7 +18,7 @@ description: >-
   
   It's recommended to read through the official documentation, which is available at https://github.com/janeczku/calibre-web/wiki
 developer: Janeczku
-website: ""
+website: https://github.com/janeczku/calibre-web
 dependencies: []
 repo: https://github.com/janeczku/calibre-web
 support: https://github.com/linuxserver/docker-calibre-web/issues

--- a/ln-visualizer/umbrel-app.yml
+++ b/ln-visualizer/umbrel-app.yml
@@ -28,7 +28,7 @@ website: https://lnvisualizer.com
 dependencies:
   - lightning
 repo: https://github.com/MaxKotlan/LN-Visualizer
-support: lnvisualizer@gmail.com
+support: mailto:lnvisualizer@gmail.com
 port: 5646
 gallery:
   - 1.jpg

--- a/prowlarr/umbrel-app.yml
+++ b/prowlarr/umbrel-app.yml
@@ -30,5 +30,6 @@ releaseNotes: >-
   Full release notes here: https://github.com/Prowlarr/Prowlarr/releases
 torOnly: false
 permissions:
-  - STORAGE_DOWNLOADSsubmitter: Umbrel
+  - STORAGE_DOWNLOADS
+submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/commit/60878f278d544b204d8e7c96240c797f43a9b319


### PR DESCRIPTION
Hello Umbrel Team,

I have found some issues in some apps:

- Calibre Web: According to the [schema](https://github.com/getumbrel/umbrel/blob/master/packages/umbreld/source/modules/apps/schema.ts), the website entry is mandatory. Other apps without a website used the GitHub repo as the website. So I have aligned that
- LN Visualizer: The type of the support entry seems to be a link. All the other apps are using it as a link, therefore I have added a `mailto:` to the email to be a valid link and be clickable
- Prowlarr: A missing newline

Thank you so much for your awesome work on UmbrelOS, I am really loving it.
I am exited for future features like https, domain names and backups 😍

Kind regards from Germany

Sharknoon