### PR TITLE
Update Bitcoin Knots to v26.1.knots20240513

### DIFF
--- a/bitcoin-knots/docker-compose.yml
+++ b/bitcoin-knots/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3005
   
   server:
-    image: retropexx/umbrel-bitcoin-knots:v0.5.0@sha256:b19da8308ec9b6c66511d327f5fd2b64aa430a3da8ed3854e8e170274b11b624
+    image: retropexx/umbrel-bitcoin-knots:v0.5.2@sha256:b1916b7a5961081ac6fbfbe3ff90a9b1fb05b792dcd97318278a1941c3d21527
     depends_on: [bitcoind]
     restart: on-failure
     volumes:
@@ -41,7 +41,7 @@ services:
         ipv4_address: $APP_BITCOIN_KNOTS_IP
 
   bitcoind:
-    image: retropexx/bitcoind:v26.1@sha256:14d3acf5f5d3030631161e37d8f8115f489acf94340cd6bc45328584442603e4
+    image: retropexx/bitcoind:v26.2@sha256:43a9b8b205d7c0c068e9e13ea8da8d439c4807f6d61f2f22e48ad7b7fac71b72
     command: "${APP_BITCOIN_KNOTS_COMMAND}"
     restart: unless-stopped
     stop_grace_period: 15m30s

--- a/bitcoin-knots/umbrel-app.yml
+++ b/bitcoin-knots/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bitcoin-knots
 category: bitcoin
 name: Bitcoin Knots
-version: "26.1"
+version: "26.1.1"
 tagline: Run your personal node powered by Bitcoin Knots
 description: >-
   Take control of your digital sovereignty by running a Bitcoin node that aligns with your needs and preferences. 
@@ -27,9 +27,9 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This release updates Bitcoin Knots to version 26.1.
+  This release updates Bitcoin Knots to version 26.1.knots20240513
   
   
-  Full release notes can be found at https://github.com/bitcoinknots/bitcoin/blob/v26.1.knots20240325/doc/release-notes.md
+  Full release notes can be found at https://github.com/bitcoinknots/bitcoin/blob/v26.1.knots20240513/doc/release-notes.md
 submitter: Léo Haf
 submission: https://github.com/getumbrel/umbrel-apps/pull/953


### PR DESCRIPTION
Update Bitcoin Knots to [v26.1.knots20240513](https://github.com/bitcoinknots/bitcoin/releases/tag/v26.1.knots20240513)

tested on Umbrel v0.5.4 (aarch64 and amd64)