### PR TITLE
Update Plex to work when Home Assistant is already installed

### DIFF
--- a/plex/docker-compose.yml
+++ b/plex/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - PUID=1000
       - PGID=1000
       - VERSION=docker
+    # Currently running in host network mode to allow for UPnP discovery (Plex DLNA server) and so that Docker does not complain about port 1900/udp being in use (can be shared, for example with Home Assistant).
     # ports:
     #   - 32400:32400
     #   # Plex Companion

--- a/plex/docker-compose.yml
+++ b/plex/docker-compose.yml
@@ -5,24 +5,25 @@ services:
     image: linuxserver/plex:1.40.2@sha256:15eaab9b1447e413b3f28df1cad8e5c87e4a06ac2b0eaf09aca8c6ae11feed3c
     restart: on-failure
     hostname: "${DEVICE_HOSTNAME}"
+    network_mode: host
     environment:
       - PUID=1000
       - PGID=1000
       - VERSION=docker
-    ports:
-      - 32400:32400
-      # Plex Companion
-      - 3005:3005/tcp
-      # Roku via Plex Companion
-      - 8324:8324/tcp
-      # Plex DLNA Server
-      - 32469:32469/tcp 
-      - 1900:1900/udp
-      # Network discovery
-      - 32410:32410/udp
-      - 32412:32412/udp
-      - 32413:32413/udp
-      - 32414:32414/udp
+    # ports:
+    #   - 32400:32400
+    #   # Plex Companion
+    #   - 3005:3005/tcp
+    #   # Roku via Plex Companion
+    #   - 8324:8324/tcp
+    #   # Plex DLNA Server
+    #   - 32469:32469/tcp 
+    #   - 1900:1900/udp
+    #   # Network discovery
+    #   - 32410:32410/udp
+    #   - 32412:32412/udp
+    #   - 32413:32413/udp
+    #   - 32414:32414/udp
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
       - ${APP_DATA_DIR}/data/transcode:/transcode

--- a/plex/umbrel-app.yml
+++ b/plex/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: plex
 category: media
 name: Plex
-version: "1.40.2"
+version: "1.40.2-hotfix1"
 tagline: Stream Movies & TV Shows
 description: >-
   Stream movies and TV shows, plus 300+ channels of live TV, instantly, without a subscription. Watch live TV and movies anywhere, from any device, with Plex.
@@ -29,7 +29,10 @@ torOnly: false
 permissions:
   - STORAGE_DOWNLOADS
 releaseNotes: >-
-  ⚠️ Please be patient during this update to version 1.40.2. Large libraries may take a while to update.
+  This is a hotfix release that resolves an issue where users were unable to install both Plex and Home Assistant on the same device.
+
+
+  ⚠️ If you have not yet upgraded to Plex 1.40.2, then please be patient during this update as large libraries may take a while to update.
 
 
   Full release notes are available at https://www.videohelp.com/software/Plex


### PR DESCRIPTION
This PR switches the Plex container to use host networking instead of bridge networking. This fixes two issues:
1) It solves the port clash issue with Home Assistant. Previously, if a user tried to install Plex after installing Home Assistant (but not the other way around) the explicit mapping of port 1900 in the Plex compose file would cause Docker to error because port 1900 would be in use by Home Assistant for SSDP discovery and uPNP. Both apps now use the hosts network stack and don't explicitly bind ports, so Docker will not error and they can successfully share the udp port.
2) DLNA server access in Plex will actually work. DLNA server access doesn't work in bridge network mode by default, because udp multicast packets are not automatically forwarded from the host network stack to the bridge network stack.