### PR TITLE
[URGENT] Updated tailscale to v1.66.0

### DIFF
--- a/tailscale/docker-compose.yml
+++ b/tailscale/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   web:
     network_mode: "host" # TODO: We can remove this later with some iptables magic
-    image: tailscale/tailscale:v1.62.1@sha256:3b310f980cd9ff0e334e48c53eb95b21d77b72a596854c4369fd028f83b41b10
+    image: tailscale/tailscale:v1.66@sha256:cf8e97667e8be250caaed88694cec0befe11040bbd5a3de3b33086cc52ef4eb1
     restart: on-failure
     stop_grace_period: 1m
     command: "sh -c 'tailscale web --listen 0.0.0.0:8240 & exec tailscaled --tun=userspace-networking'"

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: tailscale
 category: networking
 name: Tailscale
-version: "v1.62.1"
+version: "v1.66.0"
 tagline: Zero config VPN to access your Umbrel from anywhere
 description: >-
   Tailscale is zero config VPN that creates a secure network between
@@ -28,13 +28,11 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: |
-  This release updates Tailscale from v1.56.1 to v1.62.1, and includes: 
+  This release updates Tailscale from v1.62.1 to v1.66.0, and includes: 
 
-  - Enhanced Access Control: Enhanced security with Access Control Lists (ACLs) for managing permissions on tagged devices.
+  - Security Update: This release includes a fix for TS-2024-005. All users are advised to update.
 
-  - Expanded DNS Options: Added Mullvad's family-friendly server to the list of well known DNS over HTTPS (DoH) servers.
-
-  - Improved Request Handling: DNS over HTTP requests now come with a set timeout.
+  - ACL Syntax Updates: As part of a security fix to address an issue related to exit nodes and subnet routing (TS-2024-005), changes are made to ACLs.
 
   - and more!
 

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -28,7 +28,7 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: |
-  This release updates Tailscale from v1.62.1 to v1.66.0, and includes.
+  This release updates Tailscale from v1.62.1 to v1.66.0.
   
   
   Full release notes and detailed information is available at https://github.com/tailscale/tailscale/releases

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -28,14 +28,9 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: |
-  This release updates Tailscale from v1.62.1 to v1.66.0, and includes: 
-
-  - Security Update: This release includes a fix for TS-2024-005. All users are advised to update.
-
-  - ACL Syntax Updates: As part of a security fix to address an issue related to exit nodes and subnet routing (TS-2024-005), changes are made to ACLs.
-
-  - and more!
-
+  This release updates Tailscale from v1.62.1 to v1.66.0, and includes.
+  
+  
   Full release notes and detailed information is available at https://github.com/tailscale/tailscale/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/1248


### PR DESCRIPTION
This updated fixes a security issue: TS-2024-005
Fixed: getumbrel/umbrel#1831

I'll try to figure out a way to automate updates.