### PR TITLE
Update Jam to v0.2.0-patch-20240521

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   web:
-    image: ghcr.io/joinmarket-webui/jam-standalone:v0.2.0-clientserver-v0.9.11@sha256:fd6e763e48f079fa1d302cf9c44c8368d9cef39ed85d2790d52664cee1e75b4c
+    image: ghcr.io/joinmarket-webui/jam-dev-standalone:v0.2.0-clientserver-v0.9.11-patch-20240521@sha256:6716161d0a5d4514d6744bf8351c7490f3446a7ba52eb736e10ec62ffb0dc491
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: jam
 category: bitcoin
 name: Jam
-version: "0.2.0"
+version: "0.2.0-patch-20240521"
 tagline: Your sats. Your privacy. Your profit.
 description: >-
   Jam is a user-interface for JoinMarket with focus on
@@ -13,13 +13,7 @@ description: >-
 
   The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 releaseNotes: >-
-  - Feature: You can now renew an expired fidelity bond in a straightforward manner
-
-  - Fees: Sending funds now allows for customizable fee settings for both direct and collaborative sends
-
-  - Version: It's now readily apparent what version of Jam you're running, along with what version of JoinMarket
-
-  - UI: Various UI improvements and bugfixes
+  This is a patch release that makes Jam v0.2.0 compatible with the Raspberry Pi 5 on umbrelOS.
 developer: JoinMarket WebUI Org.
 website: https://jamapp.org
 dependencies:


### PR DESCRIPTION
This patch update of Jam fixes an issue where Jam could not be run on a Raspberry Pi 5:
https://github.com/joinmarket-webui/jam-docker/issues/123
https://github.com/joinmarket-webui/jam-docker/pull/124#issuecomment-2124505130