### PR TITLE
Update Thunderhub to v0.13.31

### DIFF
--- a/thunderhub/docker-compose.yml
+++ b/thunderhub/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: apotdevin/thunderhub:v0.13.30@sha256:486cf816bf6dd92780037842ff42036ee6254c787353225416be30c4e17a5630
+    image: apotdevin/thunderhub:v0.13.31@sha256:8c2e54dbc09cb7924def149c4be3ae0bd7fc7080b7d6db6daed9c17f829f8dcc
     # We now have to run as root to avoid schema.gql permission errors
     # user: "1000:1000"
     restart: on-failure

--- a/thunderhub/umbrel-app.yml
+++ b/thunderhub/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: thunderhub
 category: bitcoin
 name: ThunderHub
-version: "0.13.30"
+version: "0.13.31"
 tagline: Take full control of your Lightning node
 description: >-
   ThunderHub allows you to take full control of your Lightning node
@@ -28,12 +28,16 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  - Chore: Extra error log
+  - feat: Taproot swaps
   
-  - Fix: Boltz swap claim transaction fees
+  - chore: show ghost error to user
   
-  - Fix: Adding safety on object lookups
+  - chore: update package lock
+
+  - chore: remove swap backup
+
+  - fix: bump dep, don't work with Node.js ^21.0.0 fix
   
-  Full release notes can be found at https://github.com/apotdevin/thunderhub/releases/tag/v0.13.30
+  Full release notes can be found at https://github.com/apotdevin/thunderhub/releases/tag/v0.13.31
 submitter: Anthony Potdevin
 submission: https://github.com/getumbrel/umbrel/pull/343

--- a/thunderhub/umbrel-app.yml
+++ b/thunderhub/umbrel-app.yml
@@ -28,15 +28,8 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  - feat: Taproot swaps
-  
-  - chore: show ghost error to user
-  
-  - chore: update package lock
+  This release upgrades Boltz Swaps to Taproot for cheaper and more private swaps. The upgrade is backwards compatible, so existing swaps that are pending before the upgrade will complete without issue.
 
-  - chore: remove swap backup
-
-  - fix: bump dep, don't work with Node.js ^21.0.0 fix
   
   Full release notes can be found at https://github.com/apotdevin/thunderhub/releases/tag/v0.13.31
 submitter: Anthony Potdevin


### PR DESCRIPTION
Includes an important upgrade for Boltz Swaps, see [release notes](https://github.com/apotdevin/thunderhub/releases/tag/v0.13.31)