### PR TITLE
Add missing `releaseNotes` keys and logo fix

### DIFF
--- a/agora/umbrel-app.yml
+++ b/agora/umbrel-app.yml
@@ -27,3 +27,4 @@ defaultUsername: umbrel
 torOnly: false
 submitter: Jonathan Zernik
 submission: https://github.com/getumbrel/umbrel/pull/1282
+releaseNotes: ""

--- a/bitfeed/umbrel-app.yml
+++ b/bitfeed/umbrel-app.yml
@@ -29,3 +29,4 @@ defaultUsername: ""
 defaultPassword: ""
 submitter: Mononaut
 submission: https://github.com/getumbrel/umbrel/pull/1202
+releaseNotes: ""

--- a/bleskomat-server/umbrel-app.yml
+++ b/bleskomat-server/umbrel-app.yml
@@ -25,3 +25,4 @@ deterministicPassword: true
 torOnly: false
 submitter: Charles Hill
 submission: https://github.com/getumbrel/umbrel/pull/1175
+releaseNotes: ""

--- a/blockstream-blind-oracle/umbrel-app.yml
+++ b/blockstream-blind-oracle/umbrel-app.yml
@@ -32,3 +32,4 @@ path: ''
 deterministicPassword: false
 submitter: Blockstream
 submission: https://github.com/getumbrel/umbrel-apps/pull/950
+releaseNotes: ""

--- a/bluewallet/umbrel-app.yml
+++ b/bluewallet/umbrel-app.yml
@@ -27,3 +27,4 @@ defaultUsername: ""
 defaultPassword: ""
 submitter: Aaron Dewes
 submission: https://github.com/getumbrel/umbrel/pull/566
+releaseNotes: ""

--- a/element/umbrel-app.yml
+++ b/element/umbrel-app.yml
@@ -39,3 +39,4 @@ defaultPassword: ""
 torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/bb10e17a6256db19767af7eaeb93e665ac275b24
+releaseNotes: ""

--- a/ipfs-podcasting/umbrel-app.yml
+++ b/ipfs-podcasting/umbrel-app.yml
@@ -20,7 +20,8 @@ gallery:
 - 1.jpg
 - 2.jpg
 - 3.jpg
-path: ''
-defaultPassword: ''
+path: ""
+defaultPassword: ""
 submitter: IPFSPodcasting.net
 submission: https://github.com/getumbrel/umbrel/pull/1356
+releaseNotes: ""

--- a/libreddit/umbrel-app.yml
+++ b/libreddit/umbrel-app.yml
@@ -33,3 +33,4 @@ defaultUsername: ""
 defaultPassword: ""
 submitter: Jasper
 submission: https://github.com/getumbrel/umbrel-apps/pull/126
+releaseNotes: ""

--- a/libreoffice/umbrel-app.yml
+++ b/libreoffice/umbrel-app.yml
@@ -43,3 +43,4 @@ defaultPassword: ""
 torOnly: false
 submitter: Pranshu Agrawal
 submission: https://github.com/getumbrel/umbrel-apps/pull/216
+releaseNotes: ""

--- a/libretranslate/umbrel-app.yml
+++ b/libretranslate/umbrel-app.yml
@@ -27,3 +27,4 @@ defaultUsername: ""
 defaultPassword: ""
 submitter: highghlow
 submission: https://github.com/getumbrel/umbrel/pull/1040
+releaseNotes: ""

--- a/lightning-shell/umbrel-app.yml
+++ b/lightning-shell/umbrel-app.yml
@@ -38,4 +38,5 @@ defaultUsername: umbrel
 deterministicPassword: true
 submitter: Ioan Bizău
 submission: https://github.com/getumbrel/umbrel/pull/1146
+releaseNotes: ""
 disabled: true

--- a/mealie/umbrel-app.yml
+++ b/mealie/umbrel-app.yml
@@ -24,3 +24,4 @@ defaultPassword: ""
 torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/608
+releaseNotes: ""

--- a/minio/umbrel-app.yml
+++ b/minio/umbrel-app.yml
@@ -44,3 +44,4 @@ gallery:
 path: ""
 deterministicPassword: true
 defaultUsername: umbrel
+releaseNotes: ""

--- a/passky-client/umbrel-app.yml
+++ b/passky-client/umbrel-app.yml
@@ -32,3 +32,4 @@ defaultUsername: ""
 defaultPassword: ""
 submitter: Rabbit Company LLC
 submission: https://github.com/getumbrel/umbrel-apps/pull/385
+releaseNotes: ""

--- a/peerswap/umbrel-app.yml
+++ b/peerswap/umbrel-app.yml
@@ -20,3 +20,4 @@ gallery:
 path: ""
 submitter: Vlad Goryachev
 submission: https://github.com/getumbrel/umbrel-apps/pull/932
+releaseNotes: ""

--- a/readarr/umbrel-app.yml
+++ b/readarr/umbrel-app.yml
@@ -25,3 +25,4 @@ permissions:
   - STORAGE_DOWNLOADS
 submitter: Choff3
 submission: https://github.com/getumbrel/umbrel-apps/pull/712
+releaseNotes: ""

--- a/remmina/umbrel-app.yml
+++ b/remmina/umbrel-app.yml
@@ -40,3 +40,4 @@ defaultUsername: ""
 defaultPassword: ""
 submitter: Pranshu Agrawal
 submission: https://github.com/getumbrel/umbrel-apps/pull/291
+releaseNotes: ""

--- a/satsale/umbrel-app.yml
+++ b/satsale/umbrel-app.yml
@@ -35,3 +35,4 @@ path: /admin
 deterministicPassword: true
 submitter: Nick Farrow
 submission: https://github.com/getumbrel/umbrel/pull/1102
+releaseNotes: ""

--- a/snapdrop/umbrel-app.yml
+++ b/snapdrop/umbrel-app.yml
@@ -33,3 +33,4 @@ defaultUsername: ""
 defaultPassword: ""
 submitter: Pranshu Agrawal
 submission: https://github.com/getumbrel/umbrel-apps/pull/290
+releaseNotes: ""

--- a/sparkkiosk/umbrel-app.yml
+++ b/sparkkiosk/umbrel-app.yml
@@ -27,3 +27,4 @@ deterministicPassword: true
 torOnly: false
 submitter: Jens Gertsen
 submission: https://github.com/getumbrel/umbrel/pull/1312
+releaseNotes: ""

--- a/squeaknode/umbrel-app.yml
+++ b/squeaknode/umbrel-app.yml
@@ -28,3 +28,4 @@ defaultUsername: umbrel
 deterministicPassword: true
 submitter: Jonathan Zernik
 submission: https://github.com/getumbrel/umbrel/pull/385
+releaseNotes: ""

--- a/synapse/umbrel-app.yml
+++ b/synapse/umbrel-app.yml
@@ -35,3 +35,4 @@ defaultPassword: ""
 torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/c9f0975e766e79d4bd6adf4255cd081f54d654cb
+releaseNotes: ""

--- a/tdex/umbrel-app.yml
+++ b/tdex/umbrel-app.yml
@@ -32,3 +32,4 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: ""

--- a/urbit-bitcoin-connector/umbrel-app.yml
+++ b/urbit-bitcoin-connector/umbrel-app.yml
@@ -36,3 +36,4 @@ deterministicPassword: false
 torOnly: false
 submitter: ~sitful-hatred
 submission: https://github.com/getumbrel/umbrel/pull/1243
+releaseNotes: ""

--- a/usocial/umbrel-app.yml
+++ b/usocial/umbrel-app.yml
@@ -36,3 +36,4 @@ deterministicPassword: true
 torOnly: false
 submitter: Ioan Bizău
 submission: https://github.com/getumbrel/umbrel/pull/1247
+releaseNotes: ""


### PR DESCRIPTION
Hello,

I have found some small issues:

- Some apps are missing the key for the release notes in the `umbrel-app.yml`. 
- Adguard Home has the wrong [logo](https://github.com/getumbrel/umbrel-apps-gallery/blob/master/adguard-home/icon.svg). According to their [repo](https://github.com/AdguardTeam/AdGuardHome), the app should have this logo:
![adguard](https://github.com/getumbrel/umbrel-apps/assets/16149608/d4d927c5-8018-4d2a-81dd-0698b38bc7ad)
(This is a 256x256 optimized svg, ready to be used as app icon)

Kind regards

Sharknoon