### PR TITLE
Updates cln-application to v0.0.5 and core lightning to v24.02.2

### DIFF
--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_CORE_LIGHTNING_PORT
 
   app:
-    image: ghcr.io/elementsproject/cln-application:0.0.4@sha256:5c4c930c0bd4b71de202b6166affd76c080a66bd7021877ffaa471207470bbfa
+    image: ghcr.io/elementsproject/cln-application:0.0.5@sha256:5125fc784564997d4d047cb99378284f57eb4900ebc39bdd9ab56811a4763312
     command: npm run start
     restart: on-failure
     volumes:
@@ -55,7 +55,7 @@ services:
         ipv4_address: ${APP_CORE_LIGHTNING_REST_IP}
 
   lightningd:
-    image: elementsproject/lightningd:v23.08@sha256:b00bbbbff77e1a3c8e1172777e0bc80c3af9f74c79683cf18a45636b04e29c7f
+    image: elementsproject/lightningd:v24.02.2@sha256:131e2ce65c3b051e240a294dccb61b565d3909efc5c23b15d8240e014a34f866
     restart: on-failure
     ports:
       - ${APP_CORE_LIGHTNING_DAEMON_PORT}:9735
@@ -68,11 +68,11 @@ services:
       - --lightning-dir=${CORE_LIGHTNING_PATH}
       - --proxy=${TOR_PROXY_IP}:${TOR_PROXY_PORT}
       - --bind-addr=${APP_CORE_LIGHTNING_DAEMON_IP}:9735
+      - --bind-addr=ws:${APP_CORE_LIGHTNING_DAEMON_IP}:${APP_CORE_LIGHTNING_WEBSOCKET_PORT}
       - --addr=statictor:${TOR_PROXY_IP}:29051
       - --tor-service-password=${TOR_PASSWORD}
       - --network=${APP_CORE_LIGHTNING_BITCOIN_NETWORK}
       - --database-upgrade=true
-      - --experimental-websocket-port=${APP_CORE_LIGHTNING_WEBSOCKET_PORT}
       - --experimental-offers
       - --grpc-port=${APP_CORE_LIGHTNING_DAEMON_GRPC_PORT}
     volumes:

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: core-lightning
 category: bitcoin
 name: Core Lightning
-version: "23.08-hotfix-1"
+version: "24.02.2"
 tagline: Run your personal Core Lightning node
 description: >-
   Get started with the Lightning network today with Core Lightning - a
@@ -32,17 +32,19 @@ defaultPassword: ""
 submitter: Blockstream
 submission: https://github.com/getumbrel/umbrel-apps/pull/475
 releaseNotes: >-
-  This hotfix update resolves an issue that was preventing the Core Lightning app from operating on test networks such as testnet. No additional changes are included in this release.
+  This updates cln-application to v0.0.5, and lightningd to v24.02.2.
 
+  cln-application:
 
-  The release notes from 23.08 are included here for completeness.
+  - bug fix for opening channel
 
+  - fixed message on the empty transactions channel card
 
-  cln-application v0.0.4 (user interface):
+  - bug fix for RC version compatibility check
 
-  - bug fix by filtering lnmessage's pubkey from peers list
+  - added gRPC options on connect wallet
 
-  - added support for more fiat currencies
+  - listpeers no longer returns channel, updated the endpoint to listpeerchannels
 
 
   Full cln-application release notes are available at https://github.com/ElementsProject/cln-application/releases/tag/v0.0.4
@@ -82,29 +84,31 @@ releaseNotes: >-
   Full c-lightning-REST release notes are available at https://github.com/Ride-The-Lightning/c-lightning-REST/releases
 
 
-  lightningd v23.08:
+  lightningd v24.02.2:
 
-  - NEW experimental feature: peer storage - back up your encrypted emergency channel backup with your peers
+  - pay route algorithm doesn't bias against our own "expensive" channels any more
 
-  - access a remote node with a cli flag: lightning-cli --commando=peerid:rune
+  - pay route algorithm fixed and refined to balance fees and capacity far better
 
-  - migrate all wrapped segwit UTXOs to native segwit with upgradewallet RPC.
+  - prevents repeating the preapproveinvoice check
 
-  - large nodes are more performant.
+  - gossip feature bit deprecation for LDK compatibility fix
 
-  - pay requiring a full description (not just a hash) has been pushed back, since it broke BTCPayServer and lnbits. It's still deprecated, and we will work with them to try to achieve this.
+  - renepay bugfix with situation htlcmax=htlcmin
 
-  - documentation now available for Offers invoicerequest, disableinvoicerequest and listinvoicerequest commands.
+  - recover plugin can now detect dataloss and guide you through the recovery process, making emergency recoveries less stressful
 
-  - NEW commando-blacklist and commando-listrunes RPCs for blacklisting and listing stored runes.
+  - logic of the anchor channels has been overhauled and channel fundings and closing should now be more flexible and reliable
 
-  - NEW feerates added 2 new options as "minimum" and NN"blocks". Use explicit block counts or slow/normal/urgent/minimum.
+  - dual-funding has been merged into the Lightning Specification! This is a major milestone for more efficient channel management
 
-  - listclosedchannels RPC to show old, dead channels.
+  - gossip_store file can now be shared with others, since it no longer contains local unpublished gossip
 
-  - reckless added support for node.js plugin installation and for networks beyond bitcoin and regtest.
+  - optimizations in the way we process blocks means that we can sync with the blockchain 50% faster than before
 
-  - spending unilateral close transactions now use dynamic fees based on deadlines (and RBF), instead of fixed fees.
+  - new --no-reconnect-private flag, which tells lightningd not to reconnect private peers. This is useful for service-providers and LSPs if the majority of peers is flaky
+
+  - newest version of the splicing proposal was implemented
 
 
   Full lightningd release notes are available at https://github.com/ElementsProject/lightning/releases

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -34,6 +34,7 @@ submission: https://github.com/getumbrel/umbrel-apps/pull/475
 releaseNotes: >-
   This updates cln-application to v0.0.5, and lightningd to v24.02.2.
 
+
   cln-application:
 
   - bug fix for opening channel


### PR DESCRIPTION
lightningd v24.02.2:
  - pay route algorithm doesn't bias against our own "expensive" channels any more
  - pay route algorithm fixed and refined to balance fees and capacity far better
  - prevents repeating the preapproveinvoice check
  - gossip feature bit deprecation for LDK compatibility fix
  - renepay bugfix with situation htlcmax=htlcmin
  - recover plugin can now detect dataloss and guide you through the recovery process, making emergency recoveries less stressful
  - logic of the anchor channels has been overhauled and channel fundings and closing should now be more flexible and reliable
  - dual-funding has been merged into the Lightning Specification! This is a major milestone for more efficient channel management
  - gossip_store file can now be shared with others, since it no longer contains local unpublished gossip
  - optimizations in the way we process blocks means that we can sync with the blockchain 50% faster than before
  - new --no-reconnect-private flag, which tells lightningd not to reconnect private peers. This is useful for service-providers and LSPs if the majority of peers is flaky
  - newest version of the splicing proposal was implemented

Full lightningd release notes are available at https://github.com/ElementsProject/lightning/releases

------------------------------------------------------------------------------------------------------------------------------------------------

cln-application 0.0.5:
  - bug fix for opening channel
  - fixed message on the empty transactions channel card
  - bug fix for RC version compatibility check
  - added gRPC options on connect wallet
  - listpeers no longer returns channel, updated the endpoint to listpeerchannels

Full cln-application release notes are available at https://github.com/ElementsProject/cln-application/releases/tag/v0.0.4
