### PR TITLE
Update ghostfolio to 2.83.0

### DIFF
--- a/ghostfolio/docker-compose.yml
+++ b/ghostfolio/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3334
 
   server:
-    image: ghostfolio/ghostfolio:2.61.0@sha256:f37a4d6e411ec4308c3f2e4936222239d1e60c4a479fdde8a2b74f8ed445547f
+    image: ghostfolio/ghostfolio:2.83.0@sha256:e25d644dbc4189822d54f3559b6a02826a4b4612b612c63dfa6af0ece528d269
     restart: on-failure
     environment:
       NODE_ENV: production

--- a/ghostfolio/docker-compose.yml
+++ b/ghostfolio/docker-compose.yml
@@ -8,6 +8,7 @@ services:
 
   server:
     image: ghostfolio/ghostfolio:2.83.0@sha256:e25d644dbc4189822d54f3559b6a02826a4b4612b612c63dfa6af0ece528d269
+    init: true
     restart: on-failure
     environment:
       NODE_ENV: production

--- a/ghostfolio/umbrel-app.yml
+++ b/ghostfolio/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ghostfolio
 category: finance
 name: Ghostfolio
-version: "2.61.0"
+version: "2.83.0"
 tagline: Manage your wealth like a boss
 description: >-
   Ghostfolio is a privacy-first, open source dashboard for your personal finances.
@@ -31,29 +31,39 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: >
-  This release upgrades Ghostfolio from v2.51.0 to v2.61.0, and includes numerous bug fixes, performance improvements, and new features. Here's what's new in the latest version:
+  This release upgrades Ghostfolio from 2.61.0 to v2.83.0, and includes numerous bug fixes, performance improvements, and new features. Here's what's new in the latest version:
   
 
   Added:
 
-    - Added an index for isExcluded to the account database table
+    - Added an indicator for active filters (experimental)
 
-    - Extended the content of the Self-Hosting section on the Frequently Asked Questions (FAQ) page
+    - Added the absolute change column to the holdings table on the home page
 
 
   Changed:
 
+    - Improved the usability of the create or update activity dialog by preselecting the (only) account
+    
+    - Improved the usability of the date range selector in the assistant
+    
+    - Refactored the holding detail dialog to a standalone component
+    
+    - Refreshed the cryptocurrencies list
+    
+    - Refactored various pages to standalone components
+    
+    - Improved the delete all activities functionality on the portfolio activities page to work with the filters of the assistant
 
-    - Optimized the calculation of the portfolio summary
-
-    - Improved the activities import by isin in the Yahoo Finance service
-
-    - Improved the handling of activities without account
+    - Improved the language localization for German (de)
+    
+    - Improved the language localization for Türkçe (tr)
   
 
   Fixed:
 
-    - Fixed the the activities import
+    - Upgraded yahoo-finance2 from version 2.11.1 to 2.11.2 (causing pricing errors)
+    - Fixed the position detail dialog close functionality
     
 
   For full release notes and additional changes from previous versions, please visit: https://github.com/ghostfolio/ghostfolio/releases


### PR DESCRIPTION
Release notes: https://github.com/ghostfolio/ghostfolio/releases

Could not test it, but I don't see any breaking changes. 

Follows a repeated request for an update on the forum, as the current version is in some cases unusable. See here: 

https://community.umbrel.com/t/ghostfolio-needs-to-be-updated-due-to-yahoo-api-issue/16667