### PR TITLE
Remove periods from taglines

### DIFF
--- a/alby-nostr-wallet-connect/umbrel-app.yml
+++ b/alby-nostr-wallet-connect/umbrel-app.yml
@@ -1,7 +1,7 @@
 manifestVersion: 1
 id: alby-nostr-wallet-connect
 name: Nostr Wallet Connect
-tagline: The power of the zaps at the tip of your fingers.
+tagline: The power of the zaps at the tip of your fingers
 category: finance
 version: "0.4.2"
 port: 58000

--- a/frigate/umbrel-app.yml
+++ b/frigate/umbrel-app.yml
@@ -3,7 +3,7 @@ id: frigate
 category: automation
 name: Frigate
 version: "0.13.2"
-tagline: A complete and local NVR.
+tagline: A complete and local NVR
 description: >-
   A complete and local NVR designed for Home Assistant with AI object detection. 
   Uses OpenCV and Tensorflow to perform realtime object detection locally for IP cameras.

--- a/nutstash-wallet/umbrel-app.yml
+++ b/nutstash-wallet/umbrel-app.yml
@@ -3,7 +3,7 @@ id: nutstash-wallet
 category: bitcoin
 name: Nutstash Wallet
 version: "0.1.10"
-tagline: Nutstash is a Cashu wallet for your browser.
+tagline: Nutstash is a Cashu wallet for your browser
 description: >- 
   What is Cashu?
 

--- a/tallycoin-connect/umbrel-app.yml
+++ b/tallycoin-connect/umbrel-app.yml
@@ -3,7 +3,7 @@ id: tallycoin-connect
 category: bitcoin
 name: Tallycoin Connect
 version: "1.8.0-1"
-tagline: Crowdfund donations directly to your Umbrel node with Tallycoin.
+tagline: Crowdfund donations directly to your Umbrel node with Tallycoin
 description: Tallycoin is a crowdfunding platform with bitcoin and lightning donations. Together with the Tallycoin Connect app, you can receive donations directly to your Umbrel node. Zero fees!
 developer: djbooth007
 website: https://tallycoin.app/connect/

--- a/tdex/umbrel-app.yml
+++ b/tdex/umbrel-app.yml
@@ -3,7 +3,7 @@ id: tdex
 category: bitcoin
 name: TDEX Provider
 version: "0.9.1"
-tagline: Provide liquidity on the TDEX Network, an open protocol to trade Liquid Network assets.
+tagline: Provide liquidity on the TDEX Network, an open protocol to trade Liquid Network assets
 description: >-
   A liquidity provider holds Liquid reserves of both a BASE_ASSET-QUOTE_ASSET in his non-custodial Liquid hot-wallet,
   running automated market-making strategies, either with or without an oracle. Providers are incentivized to


### PR DESCRIPTION
Hello,

to be consistent with other apps, I have removed the periods at the end of the taglines.

Exceptions were made for taglines like this: `Read. Listen. Pay back.` by `usocial`.

Kind regards

Sharknoon