### PR TITLE
Update Penpot 2.0.1

### DIFF
--- a/penpot/docker-compose.yml
+++ b/penpot/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.7"
 
 services:
   app_proxy:

--- a/penpot/docker-compose.yml
+++ b/penpot/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.8"
 
 services:
   app_proxy:
@@ -9,7 +9,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   penpot-frontend:
-    image: penpotapp/frontend:1.18.3@sha256:9cea5dfeceed55533a3aacf3acf65a833bc7da3fd30c7c2e9c1acddcc7d4b7a1
+    image: penpotapp/frontend:2.0.1@sha256:d5e154a986527e66a69ae1a0e81399e13198c0a764c8249319a8ecf0357ca34e
     volumes:
       - ${APP_DATA_DIR}/data/assets:/opt/data/assets
     environment:
@@ -20,7 +20,7 @@ services:
     restart: on-failure
 
   penpot-backend:
-    image: penpotapp/backend:1.18.3@sha256:a744cc44f8305fb9be2a878ce2e29c7d370d370f0ec39a3e623c70014b7387c9
+    image: penpotapp/backend:2.0.1@sha256:73e234c2bba2a18c9dcaa6c525b4eb7fe5c3df27d3654e937dd50eaabf23e511
     # user 1000:1000 to avoid permission issues when importing libraries and templates
     user: "1000:1000"
     volumes:
@@ -40,7 +40,7 @@ services:
     restart: on-failure
 
   penpot-exporter:
-    image: penpotapp/exporter:1.18.3@sha256:c5daee8f7b966f91aaee0a286956ea1859b6d3a77a62da9359ed454ed4dc196b
+    image: penpotapp/exporter:2.0.1@sha256:ce67d475c0f178db8a3e6a0d866f270edddc4940797bd735d2b161ef3de46930
     user: "1000:1000"
     environment:
       - PENPOT_PUBLIC_URI=http://penpot-frontend

--- a/penpot/docker-compose.yml
+++ b/penpot/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       - PENPOT_ASSETS_STORAGE_BACKEND=assets-fs
       - PENPOT_STORAGE_ASSETS_FS_DIRECTORY=/opt/data/assets
       - PENPOT_TELEMETRY_ENABLED=false
+      # PENPOT_PUBLIC_URI needs to be set to in order to render thumbnails in the frontend
+      - PENPOT_PUBLIC_URI=http://${DEVICE_DOMAIN_NAME}:${APP_PENPOT_UI_PORT}
     depends_on:
       - penpot-postgres
       - penpot-redis

--- a/penpot/export.sh
+++ b/penpot/export.sh
@@ -1,0 +1,1 @@
+export APP_PENPOT_UI_PORT="9001"

--- a/penpot/umbrel-app.yml
+++ b/penpot/umbrel-app.yml
@@ -2,14 +2,26 @@ manifestVersion: 1
 id: penpot
 category: developer
 name: Penpot
-version: "1.18.3"
+version: "2.0.1"
 tagline: Design and prototyping platform
 description: >-
   Penpot is a pioneering open-source platform for design and prototyping, tailored specifically for product teams.
   Unconstrained by operating systems, Penpot utilizes the flexibility of web-based platforms and the interoperability
   of open standards, specifically SVG. Penpot invites designers all over the world to fall in love with open source
   while getting developers excited about the design process in return.
-releaseNotes: ""
+releaseNotes: >-
+  🚀 Epics and highlights
+  - Grid CSS layout Taiga #4915
+  - UI redesign Taiga #4958
+  - New components System Taiga #2662
+  - Swap components Taiga #1331
+  - Images as fill Taiga #2983
+  - HTML code generation Taiga #5277
+  - Light and dark themes Taiga #2287
+  💥 Breaking changes & Deprecations
+  - New strokes default to inside border Taiga
+
+  Read the full release notes for additional information and detailed changes at https://github.com/penpot/penpot/releases/tag/2.0.0
 developer: Penpot
 website: https://penpot.app/
 dependencies: []

--- a/penpot/umbrel-app.yml
+++ b/penpot/umbrel-app.yml
@@ -10,16 +10,17 @@ description: >-
   of open standards, specifically SVG. Penpot invites designers all over the world to fall in love with open source
   while getting developers excited about the design process in return.
 releaseNotes: >-
-  🚀 Epics and highlights
-  - Grid CSS layout Taiga #4915
-  - UI redesign Taiga #4958
-  - New components System Taiga #2662
-  - Swap components Taiga #1331
-  - Images as fill Taiga #2983
-  - HTML code generation Taiga #5277
-  - Light and dark themes Taiga #2287
-  💥 Breaking changes & Deprecations
-  - New strokes default to inside border Taiga
+  🚀 Epics and highlights  
+    - Grid CSS layout  
+    - UI redesign  
+    - New components System  
+    - Swap components  
+    - Images as fill  
+    - HTML code generation  
+    - Light and dark themes
+  
+  💥 Breaking changes & Deprecations  
+    - New strokes default to inside border  
 
   Read the full release notes for additional information and detailed changes at https://github.com/penpot/penpot/releases/tag/2.0.0
 developer: Penpot

--- a/penpot/umbrel-app.yml
+++ b/penpot/umbrel-app.yml
@@ -10,6 +10,9 @@ description: >-
   of open standards, specifically SVG. Penpot invites designers all over the world to fall in love with open source
   while getting developers excited about the design process in return.
 releaseNotes: >-
+  ⚠️ This is a major update of Penpot. The app may take a few minutes to start after updating. Please be patient.
+
+
   🚀 Epics and highlights  
     - Grid CSS layout  
     - UI redesign  


### PR DESCRIPTION
Penpot has released v2 which has quite a lot of changes. https://github.com/penpot/penpot/releases/tag/2.0.0

I've updated the images in `docker-compose.yml` and I've updated the release notes + version in `umbrel-app.yml`. 

I tested the new container but I've been getting 502 errors which I can't resolve. The 502 error persists when reverting versions so I'm thinking I did something wrong when trying to test. The 502 occurs when a request to `http://umbrel.local:9001/api/rpc/command/get-profile` is made.