### PR TITLE
Modify qBittorrent post-start hook for default credentials

### DIFF
--- a/qbittorrent/hooks/post-start
+++ b/qbittorrent/hooks/post-start
@@ -6,12 +6,11 @@ set -euo pipefail
 # This script will set the default password to the legacy 'adminadmin' password if the password is not already set. If a user has already set a password, this script will not overwrite it.
 # The app description in the Umbrel app store encourages users to change the default password.
 
-APP_DATA_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)"
+APP_DATA_DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")/..")"
 QBITTORRENT_CONF_FILE="${APP_DATA_DIR}/data/config/config/qBittorrent.conf"
 
-echo "Waiting for file (${QBITTORRENT_CONF_FILE}) to exist..."
-
-# Wait up to 30 seconds...
+# Wait up to 30 seconds for the qBittorrent.conf file to exist
+echo "Waiting up to 30 seconds for qBittorrent.conf file to exist..."
 for attempt in $(seq 1 300); do
 	if [[ -f "${QBITTORRENT_CONF_FILE}" ]]; then
 		echo "qBittorrent.conf file exists"
@@ -21,27 +20,30 @@ for attempt in $(seq 1 300); do
 done
 
 if [[ ! -f "${QBITTORRENT_CONF_FILE}" ]]; then
-	echo "qBittorrent.conf was never created. Something is likely wrong with the qBittorrent app."
-	exit
+  echo "qBittorrent.conf was never created. Something is likely wrong with the qBittorrent app."
+  exit
 fi
 
-# If a line with `WebUI\Password_PBKDF2` does not exist yet in the qBittorrent.conf then a custom password hasn't been set yet and we write out `adminadmin` as the default password.
+# If a line with `WebUI\Password_PBKDF2` does not exist yet in the qBittorrent.conf, then a custom password hasn't been set yet and we write out `adminadmin` as the default password.
 # This line is expected to be under the [Preferences] section.
-
 if ! grep --quiet '^WebUI\\Password_PBKDF2' "${QBITTORRENT_CONF_FILE}"; then
+  echo "WebUI\\Password_PBKDF2 does not exist in qBittorrent.conf. Adding default password."
+
+  # wait 5 seconds to be extra sure the file is fully written by the qBittorrent service
+  echo "Waiting 5 seconds for qBittorrent.conf file to be fully written..."
+  sleep 5
+
+  # stop the qBittorrent service
+  echo "Stopping qBittorrent..."
+  "${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" stop server
+
   echo "Writing default password adminadmin to qBittorrent.conf"
+  sed -i '/^\[Preferences\]/a WebUI\\Password_PBKDF2="@ByteArray(gTzqQHUv3A1X43tLaAhaJQ==:ZBCIBA4honNZ7H66xdEoHpqBC/Vvwj17ZCjQKARSK78ScJWDMdWSfxezHG536UekAL/zpRn571MXCfhtdqiArA==)"' "${QBITTORRENT_CONF_FILE}"
 
-  # Add the WebUI\Password_PBKDF2 line directly to the qBittorrent.conf file
-  # This salted hash is for the password 'adminadmin'
-  awk '/^\[Preferences\]/ { print; print "WebUI\\Password_PBKDF2=\"@ByteArray(gTzqQHUv3A1X43tLaAhaJQ==:ZBCIBA4honNZ7H66xdEoHpqBC/Vvwj17ZCjQKARSK78ScJWDMdWSfxezHG536UekAL/zpRn571MXCfhtdqiArA==)\""; next }1' "${QBITTORRENT_CONF_FILE}" > "${QBITTORRENT_CONF_FILE}.tmp"
+  # start the qBittorrent service
+  echo "Starting qBittorrent..."
+  "${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" start server
 
-  # Backup the original configuration file
-  cp "${QBITTORRENT_CONF_FILE}" "${QBITTORRENT_CONF_FILE}.bak"
-
-  # Replace the original configuration file with the updated one
-  mv "${QBITTORRENT_CONF_FILE}.tmp" "${QBITTORRENT_CONF_FILE}"
-
-  echo "Password has been set to 'adminadmin'."
 else
   echo "'WebUI\\Password_PBKDF2' already exists in qBittorrent.conf. No changes made."
 fi

--- a/qbittorrent/umbrel-app.yml
+++ b/qbittorrent/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: qbittorrent
 category: networking
 name: qBittorrent
-version: "4.6.5"
+version: "4.6.5-hotfix"
 tagline: Free and reliable P2P Bittorrent client
 description: >-
   qBittorrent is an open-source software alternative to µTorrent. It's designed to meet the needs of most users while using as little CPU and memory as possible.
@@ -20,7 +20,7 @@ description: >-
 
   ⚠️ qBittorrent downloads torrents over the Clearnet, not Tor.
 releaseNotes: >-
-  This release updates qBittorrent from version 4.6.0 to 4.6.5. 
+  This hotfix release addresses an issue where users who installed qBittorrent v4.6.5 on umbrelOS sometimes needed to restart the app to access the web interface.
 
 
   ⚠️ After updating, please ensure that your downloads path in the app is set to the default "/app/qBittorrent/downloads" path. This will make it so that your downloads show up in your main Umbrel downloads folder.


### PR DESCRIPTION
This fixes an issue where qBittorrent sometimes required a restart after installation/update to v4.6.5 in order for default credentials to work.