### PR TITLE
Update Mealie to v1.8.0

### DIFF
--- a/mealie/docker-compose.yml
+++ b/mealie/docker-compose.yml
@@ -3,23 +3,19 @@ version: "3.7"
 services:
   app_proxy:
     environment:
-      APP_HOST: mealie_mealie-frontend_1
-      APP_PORT: 3000
+      APP_HOST: mealie_web_1
+      APP_PORT: 9000
       PROXY_AUTH_WHITELIST: "/api/*"
 
-  mealie-frontend:
-    image: hkotel/mealie:frontend-v1.0.0beta-5@sha256:d8ff0ecd5cfe460fb593a99fa78d9ca17401925d287c723a319abd764f80b9f7
+  web:
+    image: ghcr.io/mealie-recipes/mealie:v1.8.0@sha256:1622cfc765645792a739443369a11b5c0909c8083b6fcfff194dd44e95bdcad4
+    restart: on-failure
     environment:
-      - API_URL=http://mealie-api:9000
+      # Allow additional user sign-up without token
+      ALLOW_SIGNUP: true
+      PUID: 1000
+      PGID: 1000
+      MAX_WORKERS: 1
+      WEB_CONCURRENCY: 1
     volumes:
       - ${APP_DATA_DIR}/data:/app/data
-    restart: on-failure
-
-  mealie-api:
-    image: hkotel/mealie:api-v1.0.0beta-5@sha256:5031ad226b8ec4c895afdc54dab654e07980dd33391a3e8106aadb3f09b73104
-    environment:
-      - PUID=1000
-      - PGID=1000
-    volumes:
-      - ${APP_DATA_DIR}/data:/app/data
-    restart: on-failure

--- a/mealie/umbrel-app.yml
+++ b/mealie/umbrel-app.yml
@@ -24,4 +24,8 @@ defaultPassword: ""
 torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/608
-releaseNotes: ""
+releaseNotes: >-
+  This release upgrades Mealie from version 1.0.0beta-5 to 1.8.0.
+
+
+  Full release notes can be found at https://github.com/mealie-recipes/mealie/releases.

--- a/mealie/umbrel-app.yml
+++ b/mealie/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: mealie
 category: files
 name: Mealie
-version: "1.0.0beta-5"
+version: "1.8.0"
 tagline: A Place for All Your Recipes
 description: >-
   Mealie is a self hosted recipe manager and meal planner. Easily add recipes by providing


### PR DESCRIPTION
This updates Mealie from 1.0.0beta-5 to 1.8.0. This required a rewrite of the compose file because Mealie has changed from a two-container to a single container deployment.

Database migration is only needed for Mealie installations that are v0.5.6 and earlier. This does not impact any umbrelOS users because the initial release on the Umbrel app store was 1.0.0beta-5 (https://github.com/getumbrel/umbrel-apps/pull/608); no database migration is needed.

Tested on arm64 and x86.