### PR TITLE
Update sabnzbd to 4.3.2

### DIFF
--- a/sabnzbd/docker-compose.yml
+++ b/sabnzbd/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 
 services:
   app_proxy:
@@ -8,15 +8,11 @@ services:
       PROXY_AUTH_WHITELIST: "/api*"
 
   web:
-    image: lscr.io/linuxserver/sabnzbd:4.1.0@sha256:84a54b2bd29198bc76e253c8592ac72996737d79f845c1db56ab053739cb61bc
+    image: linuxserver/sabnzbd:4.3.2@sha256:6c25ce4614035d6e25736a2fc30a7087b95f4dbae64933eb113a8e2f081bea4a
     restart: unless-stopped
     stop_grace_period: 1m
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
-      # sabnzdb offers no way to change the default download directory via environment variables
-      # and the sabnzbd.ini is not generated until after going through the setup wizard, which automatically sets the download directory to /config/Downloads
-      # users then need to manually change the download directory to /downloads in Settings > Folders
-      # This must be done in order to integrate easily properly with other apps like Sonarr and Radarr
       - ${UMBREL_ROOT}/data/storage/downloads:/downloads
     environment:
       - PUID=1000

--- a/sabnzbd/hooks/post-install
+++ b/sabnzbd/hooks/post-install
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Create a config file with minimal values, it will later be merged by the app
+
+CONFIG_FILE="${APP_DATA_DIR}/data/config/sabnzbd.ini"
+DEVICE_DOMAIN_NAME="${DEVICE_DOMAIN_NAME:-"umbrel.local"}"
+APP_HOST="${APP_HOST:-"sabnzbd_web_1"}"
+
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  echo "App: SABnzbd - Creating config file"
+  echo "App: SABnzbd - APP_HOST: ${APP_HOST}"
+  echo "App: SABnzbd - DEVICE_DOMAIN_NAME: ${DEVICE_DOMAIN_NAME}"
+
+  cat <<EOF >"${CONFIG_FILE}"
+[misc]
+download_dir = /downloads/incomplete
+complete_dir = /downloads/complete
+host_whitelist = ${DEVICE_DOMAIN_NAME}, ${APP_HOST}
+EOF
+fi

--- a/sabnzbd/umbrel-app.yml
+++ b/sabnzbd/umbrel-app.yml
@@ -2,11 +2,11 @@ manifestVersion: 1
 id: sabnzbd
 category: networking
 name: SABnzbd
-version: "4.1.0-hotfix1"
+version: "4.3.2"
 tagline: The automated Usenet download tool
 description: >-
   SABnzbd makes Usenet as simple and streamlined as possible by automating everything we can. All you have to do is add an .nzb.
-  SABnzbd takes over from there, where it will be automatically downloaded, verified, repaired, extracted and filed away with zero human interaction. 
+  SABnzbd takes over from there, where it will be automatically downloaded, verified, repaired, extracted and filed away with zero human interaction.
   SABnzbd offers an easy setup wizard and has self-analysis tools to verify your setup.
 
 
@@ -16,13 +16,7 @@ description: >-
   🛠️ SET-UP INSTRUCTIONS 🛠️
 
 
-  1. Set the Downloads Folder: During the quick-start wizard, you'll see default download directories ('/config/Downloads/complete' and '/config/Downloads/incomplete'). You will need to change these to 
-  `downloads/complete` and `downloads/incomplete` as shown in the second gallery image above. You can change these by navigating to Settings > Folders in the SABnzbd app.
-  These directories are pre-configured to map to the main 'downloads' folder on your Umbrel device and to also work seamlessly with other apps like Sonarr and Radarr.
-
-
-  2. Integrating with Other Applications: If you want to integrate SABnzbd with other applications such as Sonarr or Radarr, you'll need to use the IP address of your Umbrel device as the 'Host' and use 9876 as the 'Port'.
-  You can find the IP address of your Umbrel device by checking your router's admin dashboard or by using an IP scanning tool like Angry IP Scanner.
+  1. Integrating with Other Applications: To integrate SABnzbd with other applications such as Sonarr or Radarr, use "sabnzbd_web_1:8080" or "umbrel.local:9876".
 developer: sabnzbd
 website: https://sabnzbd.org/
 dependencies: []
@@ -30,23 +24,10 @@ repo: https://github.com/sabnzbd/sabnzbd
 support: https://forums.sabnzbd.org/
 port: 9876
 releaseNotes: >-
-  This is a hotfix release for SABnzbd 4.1.0 on Umbrel. It makes it easier to configure SABnzbd with apps like Sonarr and Radarr.
-  
-
-  🚨 If you are already running SABnzbd 4.1.0 on Umbrel, please update your app and then follow these steps to re-configure your downloads folder path.
-  You may see errors in the UI when first opening SABnzbd after updating. No data has been lost. This is expected and will be fixed after following these steps.
+  This release updates SABnzbd from 4.1.0-hotfix1 to 4.3.2
 
 
-  1. In the SABnzbd app, navigate to Settings > Folders.
-
-
-  2. Change the 'Temporary Download Folder' to `downloads/incomplete` and the 'Completed Download Folder' to `downloads/complete`.
-
-
-  3. Click 'Save Changes'.
-
-
-  You are now set!
+  Full release notes here: https://github.com/sabnzbd/sabnzbd/releases
 permissions:
   - STORAGE_DOWNLOADS
 gallery:


### PR DESCRIPTION
If a config file exists on first run, a merged will occour and values there will be used. We can use this to change download location and also add hosts whitelist.

I tested on 1.1.2 amd64 and it worked.

It would be cool to have the `mac` to add it to sonarr/radarr/prowlarr etc, maybe we can think on that later.

We could just use static value and create the config/sabnzbd.ini, but I thought the envs can change, so Im not sure. Feedback is appreciated.