### PR TITLE
updated to latest databag container

### DIFF
--- a/databag/docker-compose.yml
+++ b/databag/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 7000
       
   web:
-    image: balzack/databag:0.1.14@sha256:60615abeadfcbd52a03e2d9e777bf5ead14aac2dc3707965423924fd67e7aab0
+    image: balzack/databag:0.1.15@sha256:bf8c2689fb91947a269ade9a1c1b90a259504a2c517487273228125a3ca5c5b5
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/databag/umbrel-app.yml
+++ b/databag/umbrel-app.yml
@@ -45,7 +45,9 @@ description: >-
   Detailed instructions for configuring the tunnel can be found here: https://github.com/Radiokot/umbrel-cloudflared/wiki/How-to-set-up-Cloudflare-Tunnel-on-your-Umbrel
 releaseNotes: >-
   This update of Databag brings the following changes:
+
   - Added support for the Cloudflare turn service for audio and video calls as an alternative to self-hosting coturn.
+  
   - Added support for browser push notifications; existing session also require log (out/in) to enable.
 dependencies: []
 developer: Pierre Balzack

--- a/databag/umbrel-app.yml
+++ b/databag/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: databag
 category: social
 name: Databag
-version: "0.1.14"
+version: "0.1.15"
 tagline: A tiny self-hosted federated messenger for the decentralized web
 description: >-
   Databag is a self-hosted messaging service. Notable features include:
@@ -44,7 +44,9 @@ description: >-
   🌐 HTTPS Configuration: The browser version of the app can operate over http, but the mobile app requires https. You can set up https using the Cloudflare Tunnel app available in the app store.
   Detailed instructions for configuring the tunnel can be found here: https://github.com/Radiokot/umbrel-cloudflared/wiki/How-to-set-up-Cloudflare-Tunnel-on-your-Umbrel
 releaseNotes: >-
-  This update adds support for multi-factor authentication via TOTP.
+  This update of Databag brings the following changes:
+  - Added support for the Cloudflare turn service for audio and video calls as an alternative to self-hosting coturn.
+  - Added support for browser push notifications; existing session also require log (out/in) to enable.
 dependencies: []
 developer: Pierre Balzack
 website: https://github.com/balzack/databag


### PR DESCRIPTION
- added support for cloudflare turn service for audio and video calls as an alternative to self-hosting coturn
- added support for browser push notifications. existing session require log (out/in) to enable