### PR TITLE
Update Immich to v1.106.4

### DIFF
--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -33,18 +33,6 @@ services:
       - postgres
     restart: on-failure
 
-  microservices:
-    image: ghcr.io/immich-app/immich-server:v1.105.1@sha256:658b40420d7a39d6eb34c797cec8d36ff315f5adb168301aaf27dc4eafc8e228
-    command: [ "start.sh", "microservices" ]
-    volumes:
-      - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
-    environment:
-      <<: *env
-    depends_on:
-      - redis
-      - postgres
-    restart: on-failure
-
   machine-learning:
     image: ghcr.io/immich-app/immich-machine-learning:v1.105.1@sha256:2e2736ba2f2270485c0b6fa33eee66ea0b2279b70b92ea838a015c4d5289c9f0
     volumes:

--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -23,7 +23,6 @@ services:
 
   server:
     image: ghcr.io/immich-app/immich-server:v1.105.1@sha256:658b40420d7a39d6eb34c797cec8d36ff315f5adb168301aaf27dc4eafc8e228
-    command: [ "start.sh", "immich" ]
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
     environment:

--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -50,11 +50,13 @@ services:
   postgres:
     image: tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0
     user: "1000:1000"
+    command: ["postgres", "-c" ,"shared_preload_libraries=vectors.so", "-c", 'search_path="$$user", public, vectors', "-c", "logging_collector=on", "-c", "max_wal_size=2GB", "-c", "shared_buffers=512MB", "-c", "wal_compression=on"]
     environment:
       <<: *env
       POSTGRES_PASSWORD: *db_password
       POSTGRES_USER: *db_username
       POSTGRES_DB: *db_database_name
+      POSTGRES_INITDB_ARGS: '--data-checksums'
     volumes:
       - ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
     restart: on-failure

--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*,/search/*"
 
   server:
-    image: ghcr.io/immich-app/immich-server:v1.105.1@sha256:658b40420d7a39d6eb34c797cec8d36ff315f5adb168301aaf27dc4eafc8e228
+    image: ghcr.io/immich-app/immich-server:v1.106.4@sha256:d39cb7ecbcc9924f2c51a3e0deb8a469075996c6ba9e1384eb2ddb550984848e
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
     environment:
@@ -33,7 +33,7 @@ services:
     restart: on-failure
 
   machine-learning:
-    image: ghcr.io/immich-app/immich-machine-learning:v1.105.1@sha256:2e2736ba2f2270485c0b6fa33eee66ea0b2279b70b92ea838a015c4d5289c9f0
+    image: ghcr.io/immich-app/immich-machine-learning:v1.106.4@sha256:9db20e5c2033bef01fa2be50fa0a2c3d62e43f069aedde4d49a65e65a436d40b
     volumes:
       - ${APP_DATA_DIR}/data/model-cache:/cache
     environment:

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -48,7 +48,7 @@ releaseNotes: >-
   ⚠️ As usual, please check that your mobile app is compatible with this release of Immich. 
 
 
-  Welcome to release v1.106.0 of Immich. Woooh, this release is packed with many new features, improvements, and bug fixes. Let's go over some of the highlights of the release below:
+  This release is packed with many new features, improvements, and bug fixes. Highlights include:
 
   - Removal of the immich-microservices container
 
@@ -67,8 +67,7 @@ releaseNotes: >-
   - Public roadmap: https://immich.app/roadmap/
 
   - Translation on the web
-Notable fix: Fixed an edge case bug on mobile synchronization when there is a bad file with date time information.
-  
+
 
   Full release notes are found at https://github.com/immich-app/immich/releases
 developer: Alex Tran

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: immich
 category: files
 name: Immich
-version: "v1.105.1"
+version: "v1.106.4"
 tagline: High-performance photo and video backup solution
 description: >-
   An open-source and high-performance self-hosted backup solution for the videos and photos on your mobile device
@@ -46,6 +46,28 @@ description: >-
   - User-defined storage structure
 releaseNotes: >-
   ⚠️ As usual, please check that your mobile app is compatible with this release of Immich. 
+
+
+  Welcome to release v1.106.0 of Immich. Woooh, this release is packed with many new features, improvements, and bug fixes. Let's go over some of the highlights of the release below:
+
+  - Removal of the immich-microservices container
+
+  - Similar image detection and management
+
+  - End-to-end acceleration for NVENC and QSV transcoding
+
+  - Better video thumbnails
+
+  - Email notifications for album events
+
+  - Per user email notifications settings
+
+  - Send a test email when configuring the SMTP email server
+
+  - Public roadmap: https://immich.app/roadmap/
+
+  - Translation on the web
+Notable fix: Fixed an edge case bug on mobile synchronization when there is a bad file with date time information.
   
 
   Full release notes are found at https://github.com/immich-app/immich/releases


### PR DESCRIPTION
Closes https://github.com/getumbrel/umbrel-apps/issues/1158

This update required structural changes to the compose file: https://github.com/immich-app/immich/releases/tag/v1.106.4
- removes the microservices container
- adds data checksums for data corruption detection in the In PostgreSQL container. 

Tested on arm64 and x86. Migration is successful. Server version 1.106.4 works with latest mobile version 1.106.3.