### PR TITLE
Update Bitcoin Knots to v27.1

### DIFF
--- a/bitcoin-knots/docker-compose.yml
+++ b/bitcoin-knots/docker-compose.yml
@@ -41,7 +41,7 @@ services:
         ipv4_address: $APP_BITCOIN_KNOTS_IP
 
   bitcoind:
-    image: retropexx/bitcoind:v26.2@sha256:43a9b8b205d7c0c068e9e13ea8da8d439c4807f6d61f2f22e48ad7b7fac71b72
+    image: retropexx/bitcoind:v27.1@sha256:4b405d9aca9d5b37a70cfa397f87df490a3f3452885d7bc80d1d1a6b110b06b5
     command: "${APP_BITCOIN_KNOTS_COMMAND}"
     restart: unless-stopped
     stop_grace_period: 15m30s

--- a/bitcoin-knots/umbrel-app.yml
+++ b/bitcoin-knots/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bitcoin-knots
 category: bitcoin
 name: Bitcoin Knots
-version: "26.1.2"
+version: "27.1"
 tagline: Run your personal node powered by Bitcoin Knots
 description: >-
   Take control of your digital sovereignty by running a Bitcoin node that aligns with your needs and preferences. 
@@ -27,9 +27,9 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This update includes minor changes to the descriptions of Advanced Settings parameters that were introduced in the previous release (26.1.1).
+  This release updates Bitcoin Knots to version 27.1
   
   
-  Full release notes for Bitcoin Knots can be found at https://github.com/bitcoinknots/bitcoin/blob/v26.1.knots20240513/doc/release-notes.md
+  Full release notes for Bitcoin Knots can be found at https://github.com/bitcoinknots/bitcoin/releases/tag/v27.1.knots20240621
 submitter: Léo Haf
 submission: https://github.com/getumbrel/umbrel-apps/pull/953


### PR DESCRIPTION
Update Bitcoin Knots to [v27.1](https://github.com/bitcoinknots/bitcoin/releases/tag/v27.1.knots20240621)