### PR TITLE
Fixed booleans for umbrelOS 0.5

### DIFF
--- a/mealie/docker-compose.yml
+++ b/mealie/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     restart: on-failure
     environment:
       # Allow additional user sign-up without token
-      ALLOW_SIGNUP: true
+      ALLOW_SIGNUP: "true"
       PUID: 1000
       PGID: 1000
       MAX_WORKERS: 1

--- a/ntfy/docker-compose.yml
+++ b/ntfy/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       APP_HOST: ntfy_app_1
       APP_PORT: 80
-      PROXY_AUTH_ADD: false
+      PROXY_AUTH_ADD: "false"
 
   app:
     image: binwiederhier/ntfy:v2.11.0@sha256:4a7d0f0adc6d5d9fc36e64ab55ef676e76e124a2bdd50ce115b6d9c1c7430294
@@ -22,7 +22,7 @@ services:
       NTFY_BASE_URL: http://${DEVICE_DOMAIN_NAME}:${APP_PROXY_PORT}
       NTFY_UPSTREAM_BASE_URL: https://ntfy.sh
       NTFY_CACHE_FILE: /var/cache/ntfy/cache.db
-      NTFY_ENABLE_LOGIN: true
+      NTFY_ENABLE_LOGIN: "true"
       NTFY_AUTH_FILE: /var/lib/ntfy/user.db
       NTFY_AUTH_DEFAULT_ACCESS: deny-all
       NTFY_PASSWORD: ${APP_PASSWORD}

--- a/stirling-pdf/docker-compose.yml
+++ b/stirling-pdf/docker-compose.yml
@@ -20,6 +20,6 @@ services:
       - ${APP_DATA_DIR}/data/logs:/logs
     environment:
       # Not needed as Umbrel authenticates the user
-      DOCKER_ENABLE_SECURITY: false
-      INSTALL_BOOK_AND_ADVANCED_HTML_OPS: true
+      DOCKER_ENABLE_SECURITY: "false"
+      INSTALL_BOOK_AND_ADVANCED_HTML_OPS: "true"
       LANGS: ALL


### PR DESCRIPTION
Hello,

Docker Compose V1 does not allow booleans inside the `environment`, `labels` or the `extra_hosts` key.

This PR fixes that issue to get those apps running on umbrelOS 0.5 .

Kind reagards

Sharknoon