### PR TITLE
Add missing digest for postgres image

### DIFF
--- a/paperless/docker-compose.yml
+++ b/paperless/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ${APP_DATA_DIR}/data/redisdata:/data
 
   db:
-    image: docker.io/library/postgres:16
+    image: docker.io/library/postgres:16@sha256:46aa2ee5d664b275f05d1a963b30fff60fb422b4b594d509765c42db46d48881
     restart: unless-stopped
     volumes:
       - ${APP_DATA_DIR}/data/pgdata:/var/lib/postgresql/data


### PR DESCRIPTION
Hello,

the app `paperless` has a Postgres database, which lacks the digest in the image.

This PR fixes this issue.

Kind regards

Sharknoon