### PR TITLE
Update all Servarr apps and download clients to auto-configure

### DIFF
--- a/lidarr/docker-compose.yml
+++ b/lidarr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/lidarr:2.1.7@sha256:a695aec5a08032c1a15e3d4b2c784952fe1f86071c377abf3ad19413657f4cbe
+    image: linuxserver/lidarr:2.3.3@sha256:32ddd032d57d7e996052b0fe68c651e88f87909eaab26935dc0160ea468a936e
     environment:
       - PUID=1000
       - PGID=1000
@@ -18,15 +18,24 @@ services:
     restart: on-failure
 
   mac:
-    image: getumbrel/media-app-configurator:v1.0.0@sha256:e3d8b18e0186f76dd3f3d4acacc9101b4abbf302d8f2afbb47cdd3879b1a1008
+    image: getumbrel/media-app-configurator:v1.3.0@sha256:67e75dd9f5a14402b7816119a8e20189bc2465484cea077909d164687e59742b
     user: "1000:1000"
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
       - ${UMBREL_ROOT}/data/storage/downloads:/downloads
     environment:
-      DOWNLOAD_CLIENT_API_URL: "http://lidarr_server_1:8686/api/v1/downloadclient"
-      ROOT_FOLDER_API_URL: "http://lidarr_server_1:8686/api/v1/rootfolder"
+      APP_ID: "lidarr"
+      APP_URL: "http://lidarr_server_1:8686"
       TRANSMISSION_HOST: "transmission_server_1"
       TRANSMISSION_PORT: 9091
       ROOT_FOLDER: "/downloads/music"
+      # optional qBittorrent download client
+      QBITTORRENT_INSTALLED: ${APP_LIDARR_QBITTORRENT_INSTALLED:-"false"}
+      QBITTORRENT_HOST: "qbittorrent_server_1"
+      QBITTORRENT_PORT: 8080
+      # optional SABnzbd download client
+      SABNZBD_INSTALLED: ${APP_LIDARR_SABNZBD_INSTALLED:-"false"}
+      SABNZBD_HOST: "sabnzbd_web_1"
+      SABNZBD_PORT: 8080
+      SABNZBD_API_KEY: ${APP_LIDARR_SABNZBD_API_KEY:-""}

--- a/lidarr/exports.sh
+++ b/lidarr/exports.sh
@@ -1,0 +1,13 @@
+# Check if qBittorrent and SABnzbd are installed
+installed_apps=$("${UMBREL_ROOT}/scripts/app" ls-installed)
+
+if echo "$installed_apps" | grep --quiet 'qbittorrent'; then
+  export APP_LIDARR_QBITTORRENT_INSTALLED="true"
+fi
+
+if echo "$installed_apps" | grep --quiet 'sabnzbd'; then
+  export APP_LIDARR_SABNZBD_INSTALLED="true"
+  # export SABNZBD_API_KEY, which has the format:
+  # api_key = 98e3444f7fab45e592958673bf656g3
+  export APP_LIDARR_SABNZBD_API_KEY=$(grep -Po 'api_key = \K.*' "${UMBREL_ROOT}/app-data/sabnzbd/data/config/sabnzbd.ini")
+fi

--- a/lidarr/umbrel-app.yml
+++ b/lidarr/umbrel-app.yml
@@ -2,16 +2,22 @@ manifestVersion: 1.1
 id: lidarr
 category: media
 name: Lidarr
-version: "2.1.7"
+version: "2.3.3"
 tagline: Looks and smells like Sonarr but made for music
 description: >-
   Lidarr is a music collection manager for Usenet and BitTorrent users.
-  
-  
   It can monitor multiple RSS feeds for new albums from your favorite artists and will interface with clients and indexers to grab, sort, and rename them.
-  
-  
   It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available.
+
+
+  🛠️ SETUP INSTRUCTIONS
+
+  Lidarr on umbrelOS will automatically connect to download clients installed from the Umbrel App Store. Choose from Transmission, qBittorerent, and SABnzbd. Simply install your preferred client(s).
+
+
+  All you need to do from there is add an indexer so Lidarr can search for music. You can add indexers directly within Lidarr, or install Prowlarr from the Umbrel App Store for easier management of indexers across multiple apps.
+  Add your indexers to Prowlarr and they will be automatically available in Lidarr.
+
 developer: Lidarr
 website: https://lidarr.audio/
 dependencies:
@@ -28,9 +34,15 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  This update takes Lidarr from 1.4.5 to 2.1.7.
+  Lidarr on umbrelOS now offers automatic configuration for qBittorrent and SABnzbd! If you currently have qBittorrent or SABnzbd installed, please update to the latest versions to take advantage of this feature.
 
-  For full Lidarr release notes: https://github.com/Lidarr/Lidarr/releases
+
+  - Simply install your preferred download client from the Umbrel App Store, and Lidarr will handle the rest. No manual configuration required!
+  
+  - Already configured? If you have previously set up Lidarr with qBittorrent or SABnzbd, this update will not affect your existing settings.
+
+
+  Full release notes for Lidarr are available at https://github.com/Lidarr/Lidarr/releases
 permissions:
   - STORAGE_DOWNLOADS
 submitter: Umbrel

--- a/prowlarr/docker-compose.yml
+++ b/prowlarr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/prowlarr:1.18.0@sha256:237e9a72c11c5350bf22e355759436ecd4fd660e820d5b556d9a9e436f25f6b9
+    image: linuxserver/prowlarr:1.20.1@sha256:c43dc0311d4381395b60b3a6068e82226eddb213278bfe886bebabe67eb0f762
     environment:
       - PUID=1000
       - PGID=1000
@@ -17,8 +17,12 @@ services:
       - ${UMBREL_ROOT}/data/storage/downloads:/downloads
     restart: on-failure
 
+  indexer_proxy:
+    image: flaresolverr/flaresolverr:v3.3.17@sha256:5f5661db1e69a6f80ac24d47d9fa5580f6f741ee5ec967818396ae0dacecd7ea
+    restart: on-failure
+
   mac:
-    image: getumbrel/media-app-configurator:v1.2.0@sha256:6aa568b53f6743dc4a7b3212f97b9d4ca78800ede5eadc0e4b80c7f3af50eda3
+    image: getumbrel/media-app-configurator:v1.3.0@sha256:67e75dd9f5a14402b7816119a8e20189bc2465484cea077909d164687e59742b
     user: "1000:1000"
     restart: on-failure
     volumes:
@@ -26,6 +30,7 @@ services:
     environment:
       APP_ID: "prowlarr"
       APP_URL: "http://prowlarr_server_1:9696"
+      FLARESOLVERR_URL: "http://prowlarr_indexer_proxy_1:8191"
       TRANSMISSION_HOST: "transmission_server_1"
       TRANSMISSION_PORT: 9091
       RADARR_URL: "http://radarr_server_1:7878"
@@ -36,3 +41,12 @@ services:
       SONARR_CONFIG_XML: "${APP_PROWLARR_SONARR_CONFIG_XML}"
       READARR_URL: "http://readarr_server_1:8787"
       READARR_CONFIG_XML: "${APP_PROWLARR_READARR_CONFIG_XML}"
+      # optional qBittorrent download client
+      QBITTORRENT_INSTALLED: ${APP_PROWLARR_QBITTORRENT_INSTALLED:-"false"}
+      QBITTORRENT_HOST: "qbittorrent_server_1"
+      QBITTORRENT_PORT: 8080
+      # optional SABnzbd download client
+      SABNZBD_INSTALLED: ${APP_PROWLARR_SABNZBD_INSTALLED:-"false"}
+      SABNZBD_HOST: "sabnzbd_web_1"
+      SABNZBD_PORT: 8080
+      SABNZBD_API_KEY: ${APP_PROWLARR_SABNZBD_API_KEY:-""}

--- a/prowlarr/exports.sh
+++ b/prowlarr/exports.sh
@@ -2,3 +2,17 @@ export APP_PROWLARR_RADARR_CONFIG_XML=$(cat "${UMBREL_ROOT}/app-data/radarr/data
 export APP_PROWLARR_LIDARR_CONFIG_XML=$(cat "${UMBREL_ROOT}/app-data/lidarr/data/config/config.xml" 2>/dev/null || echo "")
 export APP_PROWLARR_SONARR_CONFIG_XML=$(cat "${UMBREL_ROOT}/app-data/sonarr/data/config/config.xml" 2>/dev/null || echo "")
 export APP_PROWLARR_READARR_CONFIG_XML=$(cat "${UMBREL_ROOT}/app-data/readarr/data/config/config.xml" 2>/dev/null || echo "")
+
+# Check if qBittorrent and SABnzbd are installed
+installed_apps=$("${UMBREL_ROOT}/scripts/app" ls-installed)
+
+if echo "$installed_apps" | grep --quiet 'qbittorrent'; then
+  export APP_PROWLARR_QBITTORRENT_INSTALLED="true"
+fi
+
+if echo "$installed_apps" | grep --quiet 'sabnzbd'; then
+  export APP_PROWLARR_SABNZBD_INSTALLED="true"
+  # export SABNZBD_API_KEY, which has the format:
+  # api_key = 98e3444f7fab45e592958673bf656g3
+  export APP_PROWLARR_SABNZBD_API_KEY=$(grep -Po 'api_key = \K.*' "${UMBREL_ROOT}/app-data/sabnzbd/data/config/sabnzbd.ini")
+fi

--- a/prowlarr/umbrel-app.yml
+++ b/prowlarr/umbrel-app.yml
@@ -2,10 +2,26 @@ manifestVersion: 1
 id: prowlarr
 category: media
 name: Prowlarr
-version: "1.18.0"
+version: "1.20.1"
 tagline: Prowlarr is an indexer manager/proxy
 description: >-
-  Prowlarr is an indexer manager/proxy built on the popular *arr .net/reactjs base stack to integrate with your various PVR apps. Prowlarr supports management of both Torrent Trackers and Usenet Indexers. It integrates seamlessly with Lidarr, Mylar3, Radarr, Readarr, and Sonarr offering complete management of your indexers with no per app Indexer setup required (we do it all).
+  Prowlarr is an indexer manager/proxy built on the popular *arr .net/reactjs base stack to integrate with your various PVR apps.
+  Prowlarr supports management of both Torrent Trackers and Usenet Indexers. It integrates seamlessly with Lidarr, Mylar3, Radarr, Readarr, and Sonarr offering complete management of your indexers with no per app Indexer setup required (we do it all).
+
+
+  🛠️ SETUP INSTRUCTIONS
+
+
+  Prowlarr on umbrelOS will automatically:
+
+  1.	Connect to Other Servarr Apps and Download Clients:
+  
+  Prowlarr will seamlessly integrate with other Servarr apps (e.g., Radarr, Sonarr, etc.) and download clients (e.g., Transmission, qBittorrent, etc.) installed from the Umbrel App Store. Simply install your preferred apps, and Prowlarr will handle the connections for you.
+
+
+  2. Set up Flaresolverr:
+  
+  Prowlarr comes pre-configured with FlareSolverr. To use it, simply add the “flaresolverr” tag to any indexers that require it.
 developer: Prowlarr
 website: https://prowlarr.com/
 dependencies:
@@ -21,9 +37,14 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  This update takes Prowlarr from 1.12.2 to 1.18.0.
+  Prowlarr on umbrelOS now:
+  
+  - Automatically connects to more download clients (qBittorrent and SABnzbd) installed from the Umbrel App Store. Simply install your preferred download client from the Umbrel App Store, and Prowlarr will handle the rest. No manual configuration required! If you currently have qBittorrent or SABnzbd installed, please update to the latest versions to take advantage of this feature. If you have previously set up Prowlarr with qBittorrent or SABnzbd, this update will not affect your existing settings.
 
-  Full release notes here: https://github.com/Prowlarr/Prowlarr/releases
+  - Comes pre-configured with FlareSolverr. To use it, simply add the “flaresolverr” tag to any indexers that require it.
+
+
+  Full release notes for Prowlarr are available at https://github.com/Prowlarr/Prowlarr/releases
 torOnly: false
 permissions:
   - STORAGE_DOWNLOADS

--- a/qbittorrent/hooks/post-start
+++ b/qbittorrent/hooks/post-start
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# As of v4.6.1, qBittorrent no longer supports a default password and instead prints a temporary password to the logs, which is not ideal for users.
-# Users are meant to start qBittorrent, copy the temporary password from the container logs, log in with the temporary password, and then set a new password from the UI.
-# This script will set the default password to the legacy 'adminadmin' password if the password is not already set. If a user has already set a password, this script will not overwrite it.
-# The app description in the Umbrel app store encourages users to change the default password.
+echo "inside qbittorrent/hooks/post-start"
+
+# This script does 2 main things:
+# 1. Sets the default password to 'adminadmin' if it hasn't been set yet. This is done so that users can access qBittorrent after installation without needing to access the qBittorrent container logs to retrieve a temporary password which will reset on restart.
+# 2. Enables the AuthSubnetWhitelist option and sets the AuthSubnetWhitelist to the umbrel_main_network Docker network subnet. This is done so that we can autoconfigure other apps like Radarr/Sonarr/etc.
+
+# We use a file called HAS_BEEN_CONFIGURED to indicate that we've already configured qBittorrent. This way users can modify the qBittorrent.conf file without our script overwriting it.
 
 APP_DATA_DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")/..")"
 QBITTORRENT_CONF_FILE="${APP_DATA_DIR}/data/config/config/qBittorrent.conf"
+UMBREL_QBITTORRENT_CONFIG_FLAG="${APP_DATA_DIR}/HAS_BEEN_CONFIGURED_BY_UMBREL"
+
+if [[ -f "${UMBREL_QBITTORRENT_CONFIG_FLAG}" ]]; then
+  echo "qBittorrent has already been configured."
+  exit
+fi
 
 # Wait up to 30 seconds for the qBittorrent.conf file to exist
 echo "Waiting up to 30 seconds for qBittorrent.conf file to exist..."
@@ -24,26 +33,68 @@ if [[ ! -f "${QBITTORRENT_CONF_FILE}" ]]; then
   exit
 fi
 
+# wait 5 seconds to be extra sure the file is fully written by the qBittorrent service
+echo "Waiting 5 seconds for qBittorrent.conf file to be fully written..."
+sleep 5
+
+if "${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" stop server; then
+  echo "qBittorrent stopped successfully."
+else
+  echo "Failed to run stop command because we were sent here from the post-start hook. This is expected behavior. Continuing"
+fi
+
+# As of v4.6.1, qBittorrent no longer supports a default password and instead prints a temporary password to the logs, which is not ideal for users.
+# Users are meant to start qBittorrent, copy the temporary password from the container logs, log in with the temporary password, and then set a new password from the UI.
+# This script will set the default password to the legacy 'adminadmin' password if the password is not already set. If a user has already set a password, this script will not overwrite it.
+# The app description in the Umbrel app store encourages users to change the default password.
+
 # If a line with `WebUI\Password_PBKDF2` does not exist yet in the qBittorrent.conf, then a custom password hasn't been set yet and we write out `adminadmin` as the default password.
 # This line is expected to be under the [Preferences] section.
+# We check for this line first because a user may have a legacy install from before qBittorrent removed the default password.
 if ! grep --quiet '^WebUI\\Password_PBKDF2' "${QBITTORRENT_CONF_FILE}"; then
   echo "WebUI\\Password_PBKDF2 does not exist in qBittorrent.conf. Adding default password."
-
-  # wait 5 seconds to be extra sure the file is fully written by the qBittorrent service
-  echo "Waiting 5 seconds for qBittorrent.conf file to be fully written..."
-  sleep 5
-
-  # stop the qBittorrent service
-  echo "Stopping qBittorrent..."
-  "${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" stop server
 
   echo "Writing default password adminadmin to qBittorrent.conf"
   sed -i '/^\[Preferences\]/a WebUI\\Password_PBKDF2="@ByteArray(gTzqQHUv3A1X43tLaAhaJQ==:ZBCIBA4honNZ7H66xdEoHpqBC/Vvwj17ZCjQKARSK78ScJWDMdWSfxezHG536UekAL/zpRn571MXCfhtdqiArA==)"' "${QBITTORRENT_CONF_FILE}"
 
-  # start the qBittorrent service
-  echo "Starting qBittorrent..."
-  "${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" start server
-
 else
+  # This is a legacy install and the user has already set a password. We don't want to overwrite it. 
   echo "'WebUI\\Password_PBKDF2' already exists in qBittorrent.conf. No changes made."
 fi
+
+# Users can overwrite these settings in the qBittorrent.conf file if they want to change them and this script won't overwrite them.
+
+# Ensure WebUI\AuthSubnetWhitelist is set correctly
+echo "Setting AuthSubnetWhitelist=10.21.0.0/16 in qBittorrent.conf"
+if grep -q '^WebUI\\AuthSubnetWhitelist=' "${QBITTORRENT_CONF_FILE}"; then
+  sed -i 's/^WebUI\\AuthSubnetWhitelist=.*/WebUI\\AuthSubnetWhitelist=10.21.0.0\/16/' "${QBITTORRENT_CONF_FILE}"
+else
+  sed -i '/^\[Preferences\]/a WebUI\\AuthSubnetWhitelist=10.21.0.0/16' "${QBITTORRENT_CONF_FILE}"
+fi
+
+# Ensure WebUI\AuthSubnetWhitelistEnabled is set correctly
+echo "Setting WebUI\AuthSubnetWhitelistEnabled=true in qBittorrent.conf"
+if grep -q '^WebUI\\AuthSubnetWhitelistEnabled=' "${QBITTORRENT_CONF_FILE}"; then
+  sed -i 's/^WebUI\\AuthSubnetWhitelistEnabled=.*/WebUI\\AuthSubnetWhitelistEnabled=true/' "${QBITTORRENT_CONF_FILE}"
+else
+  sed -i '/^\[Preferences\]/a WebUI\\AuthSubnetWhitelistEnabled=true' "${QBITTORRENT_CONF_FILE}"
+fi
+
+# Create the UMBREL_QBITTORRENT_CONFIG_FLAG file to indicate that we've configured qBittorrent
+touch "${UMBREL_QBITTORRENT_CONFIG_FLAG}"
+
+# start the qBittorrent service
+echo "Starting qBittorrent..."
+"${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" start server
+
+# Restart *arr apps in order to trigger automatic configuration
+apps=("radarr" "sonarr" "lidarr" "readarr" "prowlarr")
+installed_apps=$("${UMBREL_ROOT}/scripts/app" ls-installed)
+
+for app in "${apps[@]}"; do
+  if echo "$installed_apps" | grep --quiet "$app"; then
+    # We don't block the script on restarting apps because we want to restart all apps in parallel
+    # AND we need qBittorrent to be listed as an installed app when the apps restart. 
+    "${UMBREL_ROOT}/scripts/app" restart "$app" &
+  fi
+done

--- a/qbittorrent/umbrel-app.yml
+++ b/qbittorrent/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: qbittorrent
 category: networking
 name: qBittorrent
-version: "4.6.5-hotfix"
+version: "4.6.5-autoconfigure"
 tagline: Free and reliable P2P Bittorrent client
 description: >-
   qBittorrent is an open-source software alternative to µTorrent. It's designed to meet the needs of most users while using as little CPU and memory as possible.
@@ -10,23 +10,29 @@ description: >-
   
   🛠️ SET-UP INSTRUCTIONS
 
-  - qBittorrent on umbrelOS is configured to work without any additional configuration. Please make sure that you do not change the default download path in the app settings. It should remain set to "/app/qBittorrent/downloads" to ensure that your downloads show up in your main Umbrel downloads folder.
 
-  - This app comes bundled with VueTorrent, a sleek user interface that provides an alternative to qBittorrent's default interface.
-  To enable VueTorrent, simply navigate to tools --> options --> Web UI and select "Use alternative Web UI".
+  qBittorrent on umbrelOS is set up to work without any additional configuration needed. It will automatically be connected to dependent apps like Radarr, Sonarr, Lidarr, Readarr, and Prowlarr. Simply install additional media apps from the Umbrel App Store, and everything will work seamlessly together.
+
+
+  Some additional tips:
+
+
+  - Please make sure that you do not change the default download path in the app settings. It should remain set to "/app/qBittorrent/downloads" to ensure that your downloads show up in your main Umbrel downloads folder.
 
   - It is recommended to change the default password for the app after installation.
+
+  - This app comes bundled with two alternative Web UI's: VueTorrent and Nightwalker. To enable them, navigate to tools --> options --> Web UI and select "Use alternative Web UI". In the "Files location" field, enter "/app/vuetorrent" for VueTorrent or "/app/nightwalker" for Nightwalker and then click "Save". 
   
 
   ⚠️ qBittorrent downloads torrents over the Clearnet, not Tor.
 releaseNotes: >-
-  This hotfix release addresses an issue where users who installed qBittorrent v4.6.5 on umbrelOS sometimes needed to restart the app to access the web interface.
+  qBittorrent on umbrelOS now offers automatic configuration for media apps like Radarr, Sonarr, Lidarr, Readarr, and Prowlarr. Simply install your preferred media apps from the Umbrel App Store, and the rest will be handled for you. No manual configuration required!
 
 
-  ⚠️ After updating, please ensure that your downloads path in the app is set to the default "/app/qBittorrent/downloads" path. This will make it so that your downloads show up in your main Umbrel downloads folder.
+  Please update your media apps to the latest versions to take advantage of this feature. If you have previously set up qBittorrent with media apps, this update will not affect your existing settings.
   
   
-  Read the full release notes at https://www.qbittorrent.org/news#sun-may-26th-2024---qbittorrent-v4.6.5-release
+  Full release notes for qBittorrent are available at https://www.qbittorrent.org/news#sun-may-26th-2024---qbittorrent-v4.6.5-release
 developer: qBittorrent
 website: https://qbittorrent.org/
 dependencies: []

--- a/radarr/docker-compose.yml
+++ b/radarr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/radarr:5.6.0@sha256:594fab7afdb1de2f61a82835f3f2377a6220d4940d4b49bfa95e82d8a6b13a95
+    image: linuxserver/radarr:5.7.0@sha256:bf5aaf1577edbc3ba33db069676e7f8324eda33761ca59721942bc8ef56c015c
     environment:
       - PUID=1000
       - PGID=1000
@@ -18,7 +18,7 @@ services:
     restart: on-failure
 
   mac:
-    image: getumbrel/media-app-configurator:v1.2.0@sha256:6aa568b53f6743dc4a7b3212f97b9d4ca78800ede5eadc0e4b80c7f3af50eda3
+    image: getumbrel/media-app-configurator:v1.3.0@sha256:67e75dd9f5a14402b7816119a8e20189bc2465484cea077909d164687e59742b
     user: "1000:1000"
     restart: on-failure
     volumes:
@@ -30,3 +30,13 @@ services:
       TRANSMISSION_HOST: "transmission_server_1"
       TRANSMISSION_PORT: 9091
       ROOT_FOLDER: "/downloads/movies"
+      # optional qBittorrent download client
+      QBITTORRENT_INSTALLED: ${APP_RADARR_QBITTORRENT_INSTALLED:-"false"}
+      QBITTORRENT_HOST: "qbittorrent_server_1"
+      QBITTORRENT_PORT: 8080
+      # optional SABnzbd download client
+      SABNZBD_INSTALLED: ${APP_RADARR_SABNZBD_INSTALLED:-"false"}
+      SABNZBD_HOST: "sabnzbd_web_1"
+      SABNZBD_PORT: 8080
+      SABNZBD_API_KEY: ${APP_RADARR_SABNZBD_API_KEY:-""}
+

--- a/radarr/exports.sh
+++ b/radarr/exports.sh
@@ -1,0 +1,13 @@
+# Check if qBittorrent and SABnzbd are installed
+installed_apps=$("${UMBREL_ROOT}/scripts/app" ls-installed)
+
+if echo "$installed_apps" | grep --quiet 'qbittorrent'; then
+  export APP_RADARR_QBITTORRENT_INSTALLED="true"
+fi
+
+if echo "$installed_apps" | grep --quiet 'sabnzbd'; then
+  export APP_RADARR_SABNZBD_INSTALLED="true"
+  # export SABNZBD_API_KEY, which has the format:
+  # api_key = 98e3444f7fab45e592958673bf656g3
+  export APP_RADARR_SABNZBD_API_KEY=$(grep -Po 'api_key = \K.*' "${UMBREL_ROOT}/app-data/sabnzbd/data/config/sabnzbd.ini")
+fi

--- a/radarr/umbrel-app.yml
+++ b/radarr/umbrel-app.yml
@@ -2,10 +2,19 @@ manifestVersion: 1.1
 id: radarr
 category: media
 name: Radarr
-version: "5.6.0"
+version: "5.7.0"
 tagline: Your movie collection manager
 description: >-
   Radarr is a movie collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new movies and will interface with clients and indexers to grab, sort, and rename them. It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available. Note that only one type of a given movie is supported. If you want both an 4k version and 1080p version of a given movie you will need multiple instances.
+
+
+  🛠️ SETUP INSTRUCTIONS
+
+  Radarr on umbrelOS will automatically connect to download clients installed from the Umbrel App Store. Choose from Transmission, qBittorerent, and SABnzbd. Simply install your preferred client(s).
+
+
+  All you need to do from there is add an indexer so Radarr can search for movies. You can add indexers directly within Radarr, or install Prowlarr from the Umbrel App Store for easier management of indexers across multiple apps.
+  Add your indexers to Prowlarr and they will be automatically available in Radarr.
 developer: Radarr
 website: https://radarr.video/
 dependencies:
@@ -19,10 +28,15 @@ gallery:
   - 3.jpg
 path: ""
 releaseNotes: >-
-  This release updates Radarr from 5.0.3 to 5.6.0.
+  Radarr on umbrelOS now offers automatic configuration for qBittorrent and SABnzbd!
 
 
-  Full release notes here https://github.com/Radarr/Radarr/releases
+  - Simply install your preferred download client from the Umbrel App Store, and Radarr will handle the rest. No manual configuration required! If you currently have qBittorrent or SABnzbd installed, please update to the latest versions to take advantage of this feature.
+  
+  - Already configured? If you have previously set up Radarr with qBittorrent or SABnzbd, this update will not affect your existing settings.
+
+
+  Full release notes for Radarr are available at https://github.com/Radarr/Radarr/releases
 defaultUsername: ""
 defaultPassword: ""
 torOnly: false

--- a/readarr/docker-compose.yml
+++ b/readarr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/readarr:0.3.16-nightly@sha256:e0393656789fd839d05a6719b079984740652c050e2fc19083e5111e7905850c
+    image: linuxserver/readarr:0.3.30-nightly@sha256:a7aebe9f2a371f9365a7b3706c0da837a4945b479199d37f2408d2b47b857209
     environment:
       - PUID=1000
       - PGID=1000
@@ -18,7 +18,7 @@ services:
     restart: on-failure
 
   mac:
-    image: getumbrel/media-app-configurator:v1.2.0@sha256:6aa568b53f6743dc4a7b3212f97b9d4ca78800ede5eadc0e4b80c7f3af50eda3
+    image: getumbrel/media-app-configurator:v1.3.0@sha256:67e75dd9f5a14402b7816119a8e20189bc2465484cea077909d164687e59742b
     user: "1000:1000"
     restart: on-failure
     volumes:
@@ -30,3 +30,12 @@ services:
       TRANSMISSION_HOST: "transmission_server_1"
       TRANSMISSION_PORT: 9091
       ROOT_FOLDER: "/downloads/books"
+      # optional qBittorrent download client
+      QBITTORRENT_INSTALLED: ${APP_READARR_QBITTORRENT_INSTALLED:-"false"}
+      QBITTORRENT_HOST: "qbittorrent_server_1"
+      QBITTORRENT_PORT: 8080
+      # optional SABnzbd download client
+      SABNZBD_INSTALLED: ${APP_READARR_SABNZBD_INSTALLED:-"false"}
+      SABNZBD_HOST: "sabnzbd_web_1"
+      SABNZBD_PORT: 8080
+      SABNZBD_API_KEY: ${APP_READARR_SABNZBD_API_KEY:-""}

--- a/readarr/exports.sh
+++ b/readarr/exports.sh
@@ -1,0 +1,13 @@
+# Check if qBittorrent and SABnzbd are installed
+installed_apps=$("${UMBREL_ROOT}/scripts/app" ls-installed)
+
+if echo "$installed_apps" | grep --quiet 'qbittorrent'; then
+  export APP_READARR_QBITTORRENT_INSTALLED="true"
+fi
+
+if echo "$installed_apps" | grep --quiet 'sabnzbd'; then
+  export APP_READARR_SABNZBD_INSTALLED="true"
+  # export SABNZBD_API_KEY, which has the format:
+  # api_key = 98e3444f7fab45e592958673bf656g3
+  export APP_READARR_SABNZBD_API_KEY=$(grep -Po 'api_key = \K.*' "${UMBREL_ROOT}/app-data/sabnzbd/data/config/sabnzbd.ini")
+fi

--- a/readarr/umbrel-app.yml
+++ b/readarr/umbrel-app.yml
@@ -2,10 +2,22 @@ manifestVersion: 1.1
 id: readarr
 category: media
 name: Readarr
-version: "0.3.16"
+version: "0.3.30"
 tagline: Your book collection manager
 description: >-
+  ⚠️ Readarr is currently in beta testing and is generally still in a work in progress. Features may be broken, incomplete, or cause spontaneous combustion.
+
+
   Readarr is an ebook and audiobook collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new books from your favorite authors and will grab, sort, and rename them. Note that only one type of a given book is supported. If you want both an audiobook and ebook of a given book you will need multiple instances.
+
+
+  🛠️ SETUP INSTRUCTIONS
+
+  Readarr on umbrelOS will automatically connect to download clients installed from the Umbrel App Store. Choose from Transmission, qBittorerent, and SABnzbd. Simply install your preferred client(s).
+
+
+  All you need to do from there is add an indexer so Readarr can search for books. You can add indexers directly within Readarr, or install Prowlarr from the Umbrel App Store for easier management of indexers across multiple apps.
+  Add your indexers to Prowlarr and they will be automatically available in Readarr.
 developer: Readarr
 website: https://readarr.com/
 dependencies:
@@ -25,4 +37,10 @@ permissions:
   - STORAGE_DOWNLOADS
 submitter: Choff3
 submission: https://github.com/getumbrel/umbrel-apps/pull/712
-releaseNotes: ""
+releaseNotes: >-
+  Readarr on umbrelOS now offers automatic configuration for qBittorrent and SABnzbd!
+
+
+  - Simply install your preferred download client from the Umbrel App Store, and Readarr will handle the rest. No manual configuration required! If you currently have qBittorrent or SABnzbd installed, please update to the latest versions to take advantage of this feature.
+  
+  - Already configured? If you have previously set up Readarr with qBittorrent or SABnzbd, this update will not affect your existing settings.

--- a/sabnzbd/docker-compose.yml
+++ b/sabnzbd/docker-compose.yml
@@ -8,15 +8,11 @@ services:
       PROXY_AUTH_WHITELIST: "/api*"
 
   web:
-    image: lscr.io/linuxserver/sabnzbd:4.1.0@sha256:84a54b2bd29198bc76e253c8592ac72996737d79f845c1db56ab053739cb61bc
+    image: lscr.io/linuxserver/sabnzbd:4.3.2@sha256:db76abdcd65ba2c06a630d17d7e71e75245f8c7ace734d4cadd6402e2776ad5c
     restart: unless-stopped
     stop_grace_period: 1m
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
-      # sabnzdb offers no way to change the default download directory via environment variables
-      # and the sabnzbd.ini is not generated until after going through the setup wizard, which automatically sets the download directory to /config/Downloads
-      # users then need to manually change the download directory to /downloads in Settings > Folders
-      # This must be done in order to integrate easily properly with other apps like Sonarr and Radarr
       - ${UMBREL_ROOT}/data/storage/downloads:/downloads
     environment:
       - PUID=1000

--- a/sabnzbd/hooks/post-install
+++ b/sabnzbd/hooks/post-install
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script does 3 main things:
+# 1. Sets the default download and complete directories to /downloads/incomplete and /downloads/complete respectively.
+# 2. Sets up the ini file so that *arr apps can automatically configure SABnzbd.
+# 3. Restarts any installed *arr apps so that autoconfiguration can take place.
+
+# Before the setup wizard runs we can add the default categories to the SABnzbd app's ini file without needing to worry about preserving user changes.
+
+# 1. Add the SABnzbd container name to host_whitelist in the SABnzbd app's ini file: 
+# host_whitelist = <whatever sab defaults to here>, sabnzbd_web_1
+
+# 2. Add the default categories to the SABnzbd app's ini file for each arr app.
+
+APP_DATA_DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")/..")"
+SABNZBD_CONF_FILE="${APP_DATA_DIR}/data/config/sabnzbd.ini"
+
+# Wait up to 30 seconds for the sabnzbd.conf file to exist
+echo "Waiting up to 30 seconds for sabnzbd.ini file to exist..."
+for attempt in $(seq 1 300); do
+	if [[ -f "${SABNZBD_CONF_FILE}" ]]; then
+		echo "sabnzbd.ini file exists"
+		break
+	fi
+	sleep 0.1
+done
+
+if [[ ! -f "${SABNZBD_CONF_FILE}" ]]; then
+  echo "sabnzbd.ini was never created. Something is likely wrong with the SABnzbd app."
+  exit
+fi
+
+# wait 5 seconds to be extra sure the file is fully written by the SABnzbd service
+echo "Waiting 5 seconds for sabnzbd.ini file to be fully written..."
+sleep 5
+
+# stop the SABnzbd service
+echo "Stopping SABnzbd..."
+"${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" stop web
+
+# Overwrite download directories
+echo "Overwriting download_dir and complete_dir in sabnzbd.ini"
+sed -i 's/download_dir = Downloads\/incomplete/download_dir = \/downloads\/incomplete/' "${SABNZBD_CONF_FILE}"
+sed -i 's/complete_dir = Downloads\/complete/complete_dir = \/downloads\/complete/' "${SABNZBD_CONF_FILE}"
+
+# Add the SABnzbd container name to host_whitelist in the SABnzbd app's ini file
+echo "Adding SABnzbd container name to host_whitelist in sabnzbd.ini"
+if grep -q '^host_whitelist =' "${SABNZBD_CONF_FILE}"; then
+  sed -i 's/^host_whitelist = \(.*\)/host_whitelist = \1 sabnzbd_web_1,/' "${SABNZBD_CONF_FILE}"
+else
+  sed -i '/^\[misc\]/a host_whitelist = sabnzbd_web_1,' "${SABNZBD_CONF_FILE}"
+fi
+
+# Add categories to the SABnzbd app's ini file
+# We do this because the *arr apps require exact category names to be present in the SABnzbd app's ini file in order to automatically configure SABnzbd.
+
+categories_content=$(cat << 'EOF'
+[categories]
+[[*]]
+name = *
+order = 0
+pp = 3
+script = None
+dir =
+newzbin =
+priority = 0
+[[movies]]
+name = movies
+order = 0
+pp =
+script = Default
+dir = /downloads/movies
+newzbin = movies
+priority = 0
+[[prowlarr-fallback]]
+name = prowlarr-fallback
+order = 0
+pp =
+script = Default
+dir = /downloads
+newzbin =
+priority = -100
+[[books]]
+name = books
+order = 0
+pp =
+script = Default
+dir = /downloads/books
+newzbin = books
+priority = -100
+[[shows]]
+name = shows
+order = 0
+pp =
+script = Default
+dir = /downloads/shows
+newzbin = shows
+priority = 0
+[[music]]
+name = music
+order = 0
+pp =
+script = Default
+dir = /downloads/music
+newzbin = music
+priority = 0
+EOF
+)
+
+# Append the categories to the ini file
+echo "$categories_content" >> "$SABNZBD_CONF_FILE"
+
+echo "Appended [categories] section with subheaders to $SABNZBD_CONF_FILE"
+
+# Start the SABnzbd service
+echo "Starting SABnzbd..."
+"${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" start web
+
+# Restart *arr apps in order to trigger automatic configuration
+apps=("radarr" "sonarr" "lidarr" "readarr" "prowlarr")
+
+installed_apps=$("${UMBREL_ROOT}/scripts/app" ls-installed)
+
+for app in "${apps[@]}"; do
+  if echo "$installed_apps" | grep --quiet "$app"; then
+    # We don't block the script on restarting apps because we want to restart all apps in parallel
+    # AND we need SABnzbd to be listed as an installed app when the apps restart. 
+    "${UMBREL_ROOT}/scripts/app" restart "$app" &
+  fi
+done

--- a/sabnzbd/umbrel-app.yml
+++ b/sabnzbd/umbrel-app.yml
@@ -1,8 +1,8 @@
-manifestVersion: 1
+manifestVersion: 1.1
 id: sabnzbd
 category: networking
 name: SABnzbd
-version: "4.1.0-hotfix1"
+version: "4.3.2"
 tagline: The automated Usenet download tool
 description: >-
   SABnzbd makes Usenet as simple and streamlined as possible by automating everything we can. All you have to do is add an .nzb.
@@ -13,16 +13,16 @@ description: >-
   If you want to know more you can head over to our website: https://sabnzbd.org.
 
 
-  🛠️ SET-UP INSTRUCTIONS 🛠️
+  🛠️ SET-UP INSTRUCTIONS
 
 
-  1. Set the Downloads Folder: During the quick-start wizard, you'll see default download directories ('/config/Downloads/complete' and '/config/Downloads/incomplete'). You will need to change these to 
-  `downloads/complete` and `downloads/incomplete` as shown in the second gallery image above. You can change these by navigating to Settings > Folders in the SABnzbd app.
-  These directories are pre-configured to map to the main 'downloads' folder on your Umbrel device and to also work seamlessly with other apps like Sonarr and Radarr.
+  SABnzbd on umbrelOS is set up to work without any additional configuration needed. It will automatically be connected to dependent apps like Radarr, Sonarr, Lidarr, Readarr, and Prowlarr. Simply install additional media apps from the Umbrel App Store, and everything will work seamlessly together.
 
 
-  2. Integrating with Other Applications: If you want to integrate SABnzbd with other applications such as Sonarr or Radarr, you'll need to use the IP address of your Umbrel device as the 'Host' and use 9876 as the 'Port'.
-  You can find the IP address of your Umbrel device by checking your router's admin dashboard or by using an IP scanning tool like Angry IP Scanner.
+  If you want to modify the default categories that are set up on install, you can do so by navigating to the Categories section in the SABnzbd settings tab.
+  If you do this, you will need to update the categories in your other apps like Sonarr and Radarr to match the ones you set up in SABnzbd in order for them to work together.
+  
+  You can also set up API keys for integration with other apps like Sonarr and Radarr by navigating to the General section in the SABnzbd app.
 developer: sabnzbd
 website: https://sabnzbd.org/
 dependencies: []
@@ -30,23 +30,14 @@ repo: https://github.com/sabnzbd/sabnzbd
 support: https://forums.sabnzbd.org/
 port: 9876
 releaseNotes: >-
-  This is a hotfix release for SABnzbd 4.1.0 on Umbrel. It makes it easier to configure SABnzbd with apps like Sonarr and Radarr.
-  
-
-  🚨 If you are already running SABnzbd 4.1.0 on Umbrel, please update your app and then follow these steps to re-configure your downloads folder path.
-  You may see errors in the UI when first opening SABnzbd after updating. No data has been lost. This is expected and will be fixed after following these steps.
+  SABnzbd on umbrelOS now offers automatic configuration for media apps like Radarr, Sonarr, Lidarr, Readarr, and Prowlarr. Simply install your preferred media apps from the Umbrel App Store, and the rest will be handled for you. No manual configuration required!
 
 
-  1. In the SABnzbd app, navigate to Settings > Folders.
+  Please update your media apps to the latest versions to take advantage of this feature. If you have previously set up qBittorrent with media apps, this update will not affect your existing settings.
+  If you have not previously set up SABnzbd with media apps it is recommended that you uninstall and reinstall SABnzbd to take advantage of this feature.
 
 
-  2. Change the 'Temporary Download Folder' to `downloads/incomplete` and the 'Completed Download Folder' to `downloads/complete`.
-
-
-  3. Click 'Save Changes'.
-
-
-  You are now set!
+  Full release notes for SABnzbd are available at https://github.com/sabnzbd/sabnzbd/releases
 permissions:
   - STORAGE_DOWNLOADS
 gallery:

--- a/sabnzbd/umbrel-app.yml
+++ b/sabnzbd/umbrel-app.yml
@@ -33,8 +33,8 @@ releaseNotes: >-
   SABnzbd on umbrelOS now offers automatic configuration for media apps like Radarr, Sonarr, Lidarr, Readarr, and Prowlarr. Simply install your preferred media apps from the Umbrel App Store, and the rest will be handled for you. No manual configuration required!
 
 
-  Please update your media apps to the latest versions to take advantage of this feature. If you have previously set up qBittorrent with media apps, this update will not affect your existing settings.
-  If you have not previously set up SABnzbd with media apps it is recommended that you uninstall and reinstall SABnzbd to take advantage of this feature.
+  Please update your media apps to the latest versions to take advantage of this feature. If you have previously set up SABnzbd as a download client within media apps, this update will not affect your existing settings.
+  If you have not previously set up SABnzbd with media apps, it is recommended that you uninstall and reinstall SABnzbd to avoid any potential category conflicts.
 
 
   Full release notes for SABnzbd are available at https://github.com/sabnzbd/sabnzbd/releases

--- a/sonarr/docker-compose.yml
+++ b/sonarr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/sonarr:4.0.5@sha256:30432d9faf9e8fbb7c6336806ee061ed426204e1f9718d9659a2642a6e3a7c59
+    image: linuxserver/sonarr:4.0.6@sha256:8414846e440ca34c1cbed96daf7d5b3bcde20aab79761aaaaef496f24cec8d20
     environment:
       - PUID=1000
       - PGID=1000
@@ -18,7 +18,7 @@ services:
     restart: on-failure
 
   mac:
-    image: getumbrel/media-app-configurator:v1.2.0@sha256:6aa568b53f6743dc4a7b3212f97b9d4ca78800ede5eadc0e4b80c7f3af50eda3
+    image: getumbrel/media-app-configurator:v1.3.0@sha256:67e75dd9f5a14402b7816119a8e20189bc2465484cea077909d164687e59742b
     user: "1000:1000"
     restart: on-failure
     volumes:
@@ -30,3 +30,12 @@ services:
       TRANSMISSION_HOST: "transmission_server_1"
       TRANSMISSION_PORT: 9091
       ROOT_FOLDER: "/downloads/shows"
+      # optional qBittorrent download client
+      QBITTORRENT_INSTALLED: ${APP_SONARR_QBITTORRENT_INSTALLED:-"false"}
+      QBITTORRENT_HOST: "qbittorrent_server_1"
+      QBITTORRENT_PORT: 8080
+      # optional SABnzbd download client
+      SABNZBD_INSTALLED: ${APP_SONARR_SABNZBD_INSTALLED:-"false"}
+      SABNZBD_HOST: "sabnzbd_web_1"
+      SABNZBD_PORT: 8080
+      SABNZBD_API_KEY: ${APP_SONARR_SABNZBD_API_KEY:-""}

--- a/sonarr/exports.sh
+++ b/sonarr/exports.sh
@@ -1,0 +1,13 @@
+# Check if qBittorrent and SABnzbd are installed
+installed_apps=$("${UMBREL_ROOT}/scripts/app" ls-installed)
+
+if echo "$installed_apps" | grep --quiet 'qbittorrent'; then
+  export APP_SONARR_QBITTORRENT_INSTALLED="true"
+fi
+
+if echo "$installed_apps" | grep --quiet 'sabnzbd'; then
+  export APP_SONARR_SABNZBD_INSTALLED="true"
+  # export SABNZBD_API_KEY, which has the format:
+  # api_key = 98e3444f7fab45e592958673bf656g3
+  export APP_SONARR_SABNZBD_API_KEY=$(grep -Po 'api_key = \K.*' "${UMBREL_ROOT}/app-data/sabnzbd/data/config/sabnzbd.ini")
+fi

--- a/sonarr/umbrel-app.yml
+++ b/sonarr/umbrel-app.yml
@@ -2,10 +2,19 @@ manifestVersion: 1.1
 id: sonarr
 category: media
 name: Sonarr
-version: "4.0.5"
+version: "4.0.6"
 tagline: Smart PVR for newsgroup and bittorrent users
 description: >-
   Sonarr is a PVR for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.
+
+
+  🛠️ SETUP INSTRUCTIONS
+
+  Sonarr on umbrelOS will automatically connect to download clients installed from the Umbrel App Store. Choose from Transmission, qBittorerent, and SABnzbd. Simply install your preferred client(s).
+
+
+  All you need to do from there is add an indexer so Sonarr can search for shows. You can add indexers directly within Sonarr, or install Prowlarr from the Umbrel App Store for easier management of indexers across multiple apps.
+  Add your indexers to Prowlarr and they will be automatically available in Sonarr.
 developer: Sonarr
 website: https://sonarr.tv/
 dependencies:
@@ -19,13 +28,15 @@ gallery:
   - 3.jpg
 path: ""
 releaseNotes: >-
-  This release updates Sonarr from 3.0.10 to 4.0.5. The official Sonarr v4 announcement can be found at https://forums.sonarr.tv/t/sonarr-v4-released/33089.
+  Sonarr on umbrelOS now offers automatic configuration for qBittorrent and SABnzbd!
 
 
-  🚨 You will be required to set-up a login for Sonarr with this update.
+  - Simply install your preferred download client from the Umbrel App Store, and Sonarr will handle the rest. No manual configuration required! If you currently have qBittorrent or SABnzbd installed, please update to the latest versions to take advantage of this feature.
+  
+  - Already configured? If you have previously set up Sonarr with qBittorrent or SABnzbd, this update will not affect your existing settings.
 
 
-  Full release notes can be found at https://github.com/Sonarr/Sonarr/releases
+  Full release notes for Sonarr can be found at https://github.com/Sonarr/Sonarr/releases
 defaultUsername: ""
 defaultPassword: ""
 torOnly: false


### PR DESCRIPTION
This PR updates Radarr, Sonarr, Lidarr, Readarr, Prowlarr, qBittorrent, and SABnzbd.

In addition to bumping the versions of these apps, this PR also makes it so that the Servarr and download client ecosystem auto-configures upon installation (this was already the case for Servarr apps and Transmission). Auto-configuration of Overseerr, Jellyseerr, and Autobrrr will be added in the future.

### Radarr, Sonarr, Lidarr, Readarr:
- The media-app-configurator will now connect these apps to qBittorrent and SABnzbd if they are installed. These download clients are optional and configuration will only be attempted if they are installed on a user's umbrel.
- This will not change a user's existing configuration if they have already connected the download client.
- User's can make changes to the configurations after install (e.g., name of client, priority, tags, etc) and we won't overwrite their changes.

### Prowlarr:
- The media-app-configurator will now connect qBittorrent and SABnzbd if they are installed. These download clients are optional and configuration will only be attempted if they are installed on a user's umbrel.
- This will not change a user's existing configuration if they have already connected the download client.
- User's can make changes to the configurations after install (e.g., name of client, priority, tags, etc) and we won't overwrite their changes.
- The Flaresolverr container is now included (Thanks to @Julienpeps https://github.com/getumbrel/umbrel-apps/pull/1042). Flaresolverr is automatically configured to be available. To use it, simply add the “flaresolverr” tag to any indexers that require it.

### qBittorrent
- qBittorrent restarts any Servarr apps (e.g., Radarr) after qBittorrent is installed so that the Servarr app runs the auto-configuration. 
- In order to allow connections coming in from Servarr apps, we set `WebUI\AuthSubnetWhitelistEnabled` to `true` and add the umbrel Docker network subnet to `WebUI\AuthSubnetWhitelist`.
- User's can make changes to the configurations after install and we won't overwrite their changes.

### SABnzbd 
- SABnzbd restarts any Servarr apps (e.g., Radarr) after SABnzbd is installed so that the Servarr app runs the auto-configuration. 
- The download directories are now set correctly at install without needing to modify them through the setup wizard, and the sabnzbd container name has been added to `host_whitelist` to allow connections coming in from Servarr apps (Thanks to @fabricionaweb for initiating this https://github.com/getumbrel/umbrel-apps/pull/1153)
- Categories are set up for Prowlarr (`prowlarr-fallback`), Radarr (`movies`), Sonarr (`shows`), Readarr (`books`), and Lidarr (`music`) so that the media-app-configurator can connect Servarr apps using these categories (Connecting to SABnzbd requires that a category set in a Servarr app is an exact match to a category set in SABnzbd).
- User's can make changes to the configurations after install and we won't overwrite their changes.
- Users who already have SABnzbd **AND** have not previously set up SABnzbd with media apps, should uninstall and reinstall SABnzbd to avoid any potential category conflicts.

Tested app updates and fresh installs.