### PR TITLE
Update Tailscale 1.68.1

### DIFF
--- a/tailscale/docker-compose.yml
+++ b/tailscale/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   web:
     network_mode: "host" # TODO: We can remove this later with some iptables magic
-    image: tailscale/tailscale:v1.66@sha256:cf8e97667e8be250caaed88694cec0befe11040bbd5a3de3b33086cc52ef4eb1
+    image: tailscale/tailscale:v1.68.1@sha256:a0d1a9ed2abfacf905c0e3423aea00181064162e548f875f422a03924b9cc5c4
     restart: on-failure
     stop_grace_period: 1m
     command: "sh -c 'tailscale web --listen 0.0.0.0:8240 & exec tailscaled --tun=userspace-networking'"

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: tailscale
 category: networking
 name: Tailscale
-version: "v1.66.0"
+version: "v1.68.1"
 tagline: Zero config VPN to access your Umbrel from anywhere
 description: >-
   Tailscale is zero config VPN that creates a secure network between
@@ -28,7 +28,7 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: |
-  This release updates Tailscale from v1.62.1 to v1.66.0.
+  This release updates Tailscale from v1.66.0 to v1.68.1.
   
   
   Full release notes and detailed information is available at https://github.com/tailscale/tailscale/releases


### PR DESCRIPTION
Bump Tailscale to 1.68.1
Tested on: Raspberry Pi 4, umbrelOS 1.1.2 ✔️ 