### PR TITLE
lightning-terminal: update to `v0.13.2-alpha`

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.13.1-alpha@sha256:bcad5fc37cec9c8c00be56fa717814ae024cca56207dbbd43709016cf750f907
+    image: lightninglabs/lightning-terminal:v0.13.2-alpha@sha256:8f871aef89c5610d2e7730f6928d91a86c9fec12102d2b4633b42bbd1c282857
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.13.1-alpha"
+version: "0.13.2-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -86,7 +86,7 @@ releaseNotes: >-
   feedback from the community.
 
 
-  This release packages LND v0.18.1-beta, Taproot Assets Daemon v0.3.3-alpha,
+  This release packages LND v0.18.2-beta, Taproot Assets Daemon v0.3.3-alpha,
   Loop v0.28.5-beta, Pool v0.6.4-beta and Faraday v0.2.13-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
In this PR we bump Litd to `v0.13.2-alpha`.

See the release notes here: https://github.com/lightninglabs/lightning-terminal/blob/master/docs/release-notes/release-notes-0.13.2.md

Happy to address any feedback if needed :)!