### PR TITLE
Update PeerSwap to v1.6.6

### DIFF
--- a/peerswap/docker-compose.yml
+++ b/peerswap/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 1984
 
   web:
-    image: ghcr.io/impa10r/peerswap-web:v1.6.3@sha256:0efd0a1616ab6178abeb59256ef25b803b76aaa6a1b8bc6e0548c35f73c1d898
+    image: ghcr.io/impa10r/peerswap-web:v1.6.6@sha256:97a9f1691f8f327902567b787ba6ce5d30dbb1c54581918c41fbdef1deb03a03
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/peerswap/docker-compose.yml
+++ b/peerswap/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 1984
 
   web:
-    image: ghcr.io/impa10r/peerswap-web:v1.6.6@sha256:97a9f1691f8f327902567b787ba6ce5d30dbb1c54581918c41fbdef1deb03a03
+    image: ghcr.io/impa10r/peerswap-web:v1.6.6@sha256:e9bef044b5df47e8f1d3df2dc84e3eb565220f0bf626433a79bd73cb2d11125c
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/peerswap/umbrel-app.yml
+++ b/peerswap/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: peerswap
 category: bitcoin
 name: PeerSwap
-version: "1.6.3"
+version: "1.6.6"
 tagline: Balance your lightning channels with Liquid BTC
 description: PeerSwap enables Lightning Network nodes to balance their channels by facilitating atomic swaps with direct peers. PeerSwap enhances decentralization of the Lightning Network by enabling all nodes to be their own swap provider. No centralized coordinator, no 3rd party rent collector, and lowest cost channel balancing means small nodes can better compete with large nodes. Includes channel AutoFees, Liquid Peg-in and BTC send with coin select + fee bump functionality.
 developer: PeerSwap Project
@@ -21,4 +21,4 @@ path: ""
 submitter: Impa10r
 submission: https://github.com/getumbrel/umbrel-apps/pull/932
 releaseNotes: >-
-  Simplifies New Swap interface, adds BTC send with coin select, bug fixes. See full changelog here: https://github.com/Impa10r/peerswap-web/blob/main/CHANGELOG.md
+  Adds option to advertise BTC and L-BTC balance to direct PeerSwap Web UI peers, bug fixes. See full changelog here: https://github.com/Impa10r/peerswap-web/blob/main/CHANGELOG.md


### PR DESCRIPTION
Adds option to advertise BTC and L-BTC balance to direct PeerSwap Web UI peers.