### PR TITLE
Update Cloudflare Tunnel to 2024.6.1 (web 1.0.2)

### DIFF
--- a/cloudflared/docker-compose.yml
+++ b/cloudflared/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/radiokot/umbrel-cloudflared:1.0.1-cf.2023.10.0@sha256:77a0fe80bd9c8c1fa83290bbffbb1d478a047c4103ecd2aa5826bd9f19f84f18
+    image: ghcr.io/radiokot/umbrel-cloudflared:1.0.2@sha256:9660fb4e90317036d2b418f1c9437cc2cdb7f7bdd8d820084237a0c37bb94f5b
     hostname: cloudflared-web
     restart: on-failure
     stop_grace_period: 1s
@@ -21,7 +21,7 @@ services:
       CLOUDFLARED_TOKEN_FILE: "/app/data/token"
 
   connector:
-    image: ghcr.io/radiokot/umbrel-cloudflared-connector:1.0.0-cf.2023.10.0@sha256:4e8daf3826c1717cce0b37dda927f0a255ca87d6bb75e4d97e5412643a531abe
+    image: ghcr.io/radiokot/umbrel-cloudflared-connector:1.0.0-cf.2024.6.1@sha256:6f008e93af8c1230ad3d13df853aa182344eca5577725bf0ce80376de029a809
     hostname: cloudflared-connector
     restart: on-failure
     stop_grace_period: 5s

--- a/cloudflared/umbrel-app.yml
+++ b/cloudflared/umbrel-app.yml
@@ -3,7 +3,7 @@ id: cloudflared
 name: Cloudflare Tunnel
 tagline: Access your Umbrel apps from the Internet using Cloudflare network
 category: networking
-version: "2023.10.0 (web 1.0.1)"
+version: "2024.6.1 (web 1.0.2)"
 port: 4499
 description: >-
   Start a secure tunnel to access your Umbrel apps from the Internet using the Cloudflare network. 
@@ -33,7 +33,8 @@ gallery:
   - 1.jpg
   - 2.jpg
   - 3.jpg
-releaseNotes: ""
+releaseNotes: >-
+  The tunneling daemon (cloudflared) has been updated to 2024.6.1
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
Changes:
- The tunneling daemon (cloudflared) has been updated to 2024.6.1
- In the web app, updated dependency versions as per vulnerability audit results. This is not a user-facing change

Related: 
- #1169 
- https://github.com/Radiokot/umbrel-cloudflared/issues/8 