### PR TITLE
Fixes permission issues

### DIFF
--- a/.github/workflows/lint-apps.yml
+++ b/.github/workflows/lint-apps.yml
@@ -10,5 +10,8 @@ jobs:
   lint-apps:
     name: Lint apps
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: sharknoon/umbrel-app-linter-action@v1.1.8


### PR DESCRIPTION
This change fixes permission issues with PRs from external repositories (forks).

By adding the permission `pull-requests: write` and `issues: write` we allow comments to be posted to the PR by this bot.

A PR is internally an special issue, that is why we also need the `issue` permission, see [here](https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment).