### PR TITLE
btcpay-server update to 1.13.5

### DIFF
--- a/btcpay-server/docker-compose.yml
+++ b/btcpay-server/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.5.2@sha256:a85a697d1cb35fd3736ed3bd4690076141beb32a965569b003b209e0b6fd4631
+    image: nicolasdorier/nbxplorer:2.5.5@sha256:bfeba69f30b023b56d376a2c8794434d918ababe608e0499b62fc7f9331df7a7
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/btcpay-server/docker-compose.yml
+++ b/btcpay-server/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       NBXPLORER_BTCHASTXINDEX: 1
 
   web:
-    image: btcpayserver/btcpayserver:1.13.1@sha256:ee432e652e129d82a76e4de8ff28e90eb5476d01fcb008e3678991c52f5084e9
+    image: btcpayserver/btcpayserver:1.13.5@sha256:c36e08c9162a268d3c4ba946c03b506738ebc1bd25a7a817c9b1fdf3daed50e8
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/btcpay-server/umbrel-app.yml
+++ b/btcpay-server/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: btcpay-server
 category: bitcoin
 name: BTCPay Server
-version: "1.13.1"
+version: "1.13.5"
 tagline: Accept Bitcoin payments with 0 fees & no 3rd party
 description: >-
   BTCPay Server is a payment processor that allows you to receive
@@ -34,20 +34,18 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  This update brings BTCPay Server to version 1.13.1, and includes various new features, bug fixes, and improvements.
+  This update brings BTCPay Server to version 1.13.5, and includes various new features, bug fixes, and improvements.
 
 
   Highlights:
 
-  - It is now possible to customize your instance name and add a contact URL in Server Settings
+  - Checkout now displays an item description if one is available
   
-  - There is a new Admin overview of the stores on the instance
+  - Crashed plugins are now automatically disabled on the dashboard
   
-  - Onboarding: Invite new users (#5714 #5719 #5874) @dennisreimann @dstrukt
+  - Refunds have now been added to reports
   
-  - A new option to add item list to keypad
-  
-  - Support for Better Bitcoin QRs (BBQr)
+  - General improvments to the POS, receipts, and invoices
 
 
   Full release notes can be found at https://github.com/btcpayserver/btcpayserver/releases.


### PR DESCRIPTION
Updated btcpay-server to 1.13.5. All other dependencies (postgress and nbxplorer) were verified up-to-date!