### PR TITLE
BTCPay Server: Remove deprecated NBXplorer options

### DIFF
--- a/btcpay-server/docker-compose.yml
+++ b/btcpay-server/docker-compose.yml
@@ -26,8 +26,6 @@ services:
       NBXPLORER_BTCRPCUSER: $APP_BITCOIN_RPC_USER
       NBXPLORER_BTCRPCPASSWORD: $APP_BITCOIN_RPC_PASS
       NBXPLORER_POSTGRES: User ID=postgres;Host=btcpay-server_postgres_1;Port=5432;Application Name=nbxplorer;MaxPoolSize=20;Database=nbxplorer$APP_BITCOIN_NETWORK
-      NBXPLORER_AUTOMIGRATE: 1
-      NBXPLORER_NOMIGRATEEVTS: 1
       NBXPLORER_BTCHASTXINDEX: 1
 
   web:

--- a/btcpay-server/umbrel-app.yml
+++ b/btcpay-server/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: btcpay-server
 category: bitcoin
 name: BTCPay Server
-version: "1.13.5"
+version: "1.13.5-hotfix1"
 tagline: Accept Bitcoin payments with 0 fees & no 3rd party
 description: >-
   BTCPay Server is a payment processor that allows you to receive
@@ -34,19 +34,15 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  This update brings BTCPay Server to version 1.13.5, and includes various new features, bug fixes, and improvements.
+  This hotfix for the umbrelOS app store removes depecrated database migration options from NBXplorer, which were preventing BTCPay Server from starting properly.
 
 
-  Highlights:
+  Highlights from previous release notes:
 
-  - Checkout now displays an item description if one is available
-  
-  - Crashed plugins are now automatically disabled on the dashboard
-  
-  - Refunds have now been added to reports
-  
-  - General improvments to the POS, receipts, and invoices
-
+    - Checkout now displays an item description if one is available
+    - Crashed plugins are now automatically disabled on the dashboard
+    - Refunds have now been added to reports
+    - General improvments to the POS, receipts, and invoices
 
   Full release notes can be found at https://github.com/btcpayserver/btcpayserver/releases.
 submitter: Umbrel


### PR DESCRIPTION
Fixes getumbrel/umbrel-apps#1292 and btcpayserver/btcpayserver#6128.