### PR TITLE
Update Bitcoin Knots to v27.1.knots20240801

### DIFF
--- a/bitcoin-knots/docker-compose.yml
+++ b/bitcoin-knots/docker-compose.yml
@@ -41,7 +41,7 @@ services:
         ipv4_address: $APP_BITCOIN_KNOTS_IP
 
   bitcoind:
-    image: retropexx/bitcoind:v27.1@sha256:4b405d9aca9d5b37a70cfa397f87df490a3f3452885d7bc80d1d1a6b110b06b5
+    image: retropexx/bitcoind:v27.2@sha256:d8519754120133324c54a9c638a5da63580a4581c9671190613db0de01e0da4b
     command: "${APP_BITCOIN_KNOTS_COMMAND}"
     restart: unless-stopped
     stop_grace_period: 15m30s

--- a/bitcoin-knots/umbrel-app.yml
+++ b/bitcoin-knots/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bitcoin-knots
 category: bitcoin
 name: Bitcoin Knots
-version: "27.1"
+version: "27.1.1"
 tagline: Run your personal node powered by Bitcoin Knots
 description: >-
   Take control of your digital sovereignty by running a Bitcoin node that aligns with your needs and preferences. 
@@ -30,6 +30,6 @@ releaseNotes: >-
   This release updates Bitcoin Knots to version 27.1
   
   
-  Full release notes for Bitcoin Knots can be found at https://github.com/bitcoinknots/bitcoin/releases/tag/v27.1.knots20240621
+  Full release notes can be found at https://github.com/bitcoinknots/bitcoin/releases/tag/v27.1.knots20240801
 submitter: Léo Haf
 submission: https://github.com/getumbrel/umbrel-apps/pull/953


### PR DESCRIPTION
Update Bitcoin Knots to [v27.1.knots20240801](https://github.com/bitcoinknots/bitcoin/releases/tag/v27.1.knots20240801).