### PR TITLE
Update Navidrome to v0.52.5-hotfix

### DIFF
--- a/navidrome/hooks/pre-start
+++ b/navidrome/hooks/pre-start
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+UMBREL_STORAGE_DOWNLOADS_MUSIC_DIR="${UMBREL_ROOT}/data/storage/downloads/music"
+DESIRED_OWNER="1000:1000"
+
+if [[ ! -d "${UMBREL_STORAGE_DOWNLOADS_MUSIC_DIR}" ]]; then
+	mkdir -p "${UMBREL_STORAGE_DOWNLOADS_MUSIC_DIR}"
+fi
+
+navidrome_correct_permission() {
+	local -r path="${1}"
+
+	if [[ -d "${path}" ]]; then
+		owner=$(stat -c "%u:%g" "${path}")
+
+		if [[ "${owner}" != "${DESIRED_OWNER}" ]]; then
+			chown "${DESIRED_OWNER}" "${path}"
+		fi
+	fi
+}
+
+navidrome_correct_permission "${UMBREL_STORAGE_DOWNLOADS_MUSIC_DIR}"

--- a/navidrome/umbrel-app.yml
+++ b/navidrome/umbrel-app.yml
@@ -1,8 +1,8 @@
-manifestVersion: 1
+manifestVersion: 1.1
 id: navidrome
 category: media
 name: Navidrome
-version: "0.52.5"
+version: "0.52.5-hotfix"
 tagline: Your personal streaming service
 description: >-
   Navidrome is an open source web-based music collection server and streamer.
@@ -50,6 +50,8 @@ gallery:
 path: ""
 permissions:
   - STORAGE_DOWNLOADS
-releaseNotes: ""
+releaseNotes: >-
+  This is a hotfix release to ensure that the main music folder has the correct permissions set to allow proper access to the music files.
+  There are no new features or bug fixes in this release.
 submitter: owmsoton
 submission: https://github.com/getumbrel/umbrel-apps/pull/1232


### PR DESCRIPTION
Adds a pre-start script to set proper permissions for music folder.
Tested on both fresh install and update.