### PR TITLE
Update BTC RPC Explorer with RPC Terminal Functionality

### DIFF
--- a/btc-rpc-explorer/docker-compose.yml
+++ b/btc-rpc-explorer/docker-compose.yml
@@ -32,4 +32,4 @@ services:
       BTCEXP_NO_RATES: "true"
       # Disable RPC
       BTCEXP_RPC_ALLOWALL: "false"
-      BTCEXP_BASIC_AUTH_PASSWORD: ""
+      BTCEXP_BASIC_AUTH_PASSWORD: ${APP_PASSWORD}

--- a/btc-rpc-explorer/umbrel-app.yml
+++ b/btc-rpc-explorer/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: btc-rpc-explorer
 category: bitcoin
 name: BTC RPC Explorer
-version: "3.4.0"
+version: "3.4.0-rpc"
 tagline: Simple, database-free blockchain explorer
 description: >-
   BTC RPC Explorer is a full-featured, self-hosted explorer for the
@@ -16,20 +16,13 @@ description: >-
 
   It's time to appreciate the "fullness" of your node.
 releaseNotes: >-
-  This update brings several changes to BTC RPC Explorer, including:
-
-  - Several new API actions/changes (some breaking)
-
-  - Homepage additions such as a "Next Halving" widget.
-
-  - New curated list of Bitcoin "Holidays"
-
-  - Refreshed "Dark" theme with blues toned down (legacy dark theme still available)
-
-  - and more!
+  This update brings RPC Browser and RPC Terminal features to BTC RPC Explorer on umbrelOS.
+  
+  
+  ⚠️ A username and password is now required to access the explorer due to the new RPC Browser and RPC Terminal features. You can find your unique credentials by right-clicking on the BTC RPC Explorer app icon on the umbrelOS homescreen and selecting "Show default credentials".
 
 
-  Full release notes are available at https://github.com/janoside/btc-rpc-explorer/releases/tag/v3.4.0
+  Full release notes for BTC RPC Explorer versions are available at https://github.com/janoside/btc-rpc-explorer/releases
 developer: Dan Janosik
 website: https://bitcoinexplorer.org/
 dependencies:
@@ -43,7 +36,7 @@ gallery:
   - 2.jpg
   - 3.jpg
 path: ""
-defaultUsername: ""
-defaultPassword: ""
+defaultUsername: "umbrel"
+deterministicPassword: true
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/334


### PR DESCRIPTION
This PR adds RPC Terminal and RPC Browser functionality to BTC RPC Explorer. This is done by enabling password protection with a non-empty `BTCEXP_BASIC_AUTH_PASSWORD` environment variable.

Closes https://github.com/getumbrel/umbrel-apps/issues/569

The app only requires a password and no username, per https://github.com/janoside/btc-rpc-explorer/blob/adb80713ffea2a39fb600a3e61348dbd207bba52/.env-sample#L116-L118

...but the browser popup auth asks for both a username and password, so to avoid unnecessary confusion and instructions in the app-description to leave the username blank, I have just included a default username.

<img width="429" alt="image" src="https://github.com/user-attachments/assets/fb68c4c8-5ae1-458f-993a-37a99fb5b673">

