### PR TITLE
Update Uptime Kuma - whitelist api route in app proxy

### DIFF
--- a/uptime-kuma/docker-compose.yml
+++ b/uptime-kuma/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
       APP_HOST: uptime-kuma_server_1
       APP_PORT: 3001
+      PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
     image: louislam/uptime-kuma:1.23.13@sha256:96510915e6be539b76bcba2e6873591c67aca8a6075ff09f5b4723ae47f333fc

--- a/uptime-kuma/umbrel-app.yml
+++ b/uptime-kuma/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: uptime-kuma
 category: networking
 name: Uptime Kuma
-version: "1.23.13"
+version: "1.23.13-push"
 tagline: Self-hosted uptime monitoring tool
 description: >
   Uptime Kuma is a self-hosted monitoring tool like Uptime Robot.
@@ -39,13 +39,9 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >
-  This release updates Uptime Kuma from version 1.23.12 to 1.23.13 and includes the following bug fixes:
-
-  - Fixed language setting issues: Localisation-matching algorithm missing some edgecase
-
-  - Fixed TLS issues: Getting TLS certificate through proxy & prometheus update
+  This release brings Push monitor functionality to Uptime Kuma on umbrelOS. Push monitors allow you to ping your Uptime Kuma instance from external services/servers to act as a check-in.
   
 
-  Full release notes can be found at https://github.com/louislam/uptime-kuma/releases
+  Full release notes for Uptime Kuma versions can be found at https://github.com/louislam/uptime-kuma/releases
 submitter: Philipp Haussleiter
 submission: https://github.com/getumbrel/umbrel/pull/1148


### PR DESCRIPTION
This PR whitelists the Uptime Kuma `/api` route from the auth proxy so that push monitors work (require pinging `http://<hostname>:8385/api/push/...`)