### PR TITLE
Update synapse v1.55.0

### DIFF
--- a/synapse/docker-compose.yml
+++ b/synapse/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: matrixdotorg/synapse:v1.42.0@sha256:10a1dd576504af002a1107d6d1edddc5bb891ccfc404218fbd99a15531cef742
+    image: matrixdotorg/synapse:v1.55.0@sha256:4b750f7a4d0ddb9d1b20838e4005b885017e2a317aa3654821de5251b37ef485
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -24,3 +24,4 @@ services:
       SYNAPSE_REPORT_STATS: "yes"
       SYNAPSE_ENABLE_REGISTRATION: "yes"
       SYNAPSE_NO_TLS: "yes"
+

--- a/synapse/docker-compose.yml
+++ b/synapse/docker-compose.yml
@@ -9,7 +9,6 @@ services:
 
   server:
     image: matrixdotorg/synapse:v1.55.0@sha256:4b750f7a4d0ddb9d1b20838e4005b885017e2a317aa3654821de5251b37ef485
-    user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
     entrypoint: "bash"

--- a/synapse/umbrel-app.yml
+++ b/synapse/umbrel-app.yml
@@ -41,4 +41,5 @@ defaultPassword: ""
 torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/c9f0975e766e79d4bd6adf4255cd081f54d654cb
-releaseNotes: ""
+releaseNotes: >-
+  This release updates Synapse to version 1.55.0 to ensure compatibility with the latest Element app. An upcoming update for Synapse on umbrelOS will further upgrade Synapse to the latest available version.

--- a/synapse/umbrel-app.yml
+++ b/synapse/umbrel-app.yml
@@ -3,7 +3,7 @@ id: synapse
 category: social
 name: Synapse
 version: "1.55.0"
-tagline: Matrix reference homeserver
+tagline: Matrix homeserver
 description: >-
   Synapse is an open source Matrix homeserver implementation, written and maintained by Element. Matrix is the open standard for secure and interoperable real time communications.
 

--- a/synapse/umbrel-app.yml
+++ b/synapse/umbrel-app.yml
@@ -25,11 +25,11 @@ description: >-
 
   
   For seamless connection even when your client isn't connected to the same network as your Umbrel, simply install the "Tailscale" app on your Umbrel and your client device, and use http://umbrel:8008 as the address of your server.
-developer: Matrix
-website: https://matrix.org
+developer: Element
+website: https://element-hq.github.io/synapse/latest/
 dependencies: []
-repo: https://github.com/matrix-org/synapse
-support: https://matrix.to/#/#synapse:matrix.org
+repo: https://github.com/element-hq/synapse
+support: https://github.com/element-hq/synapse/issues
 port: 8008
 gallery:
   - 1.jpg

--- a/synapse/umbrel-app.yml
+++ b/synapse/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: synapse
 category: social
 name: Synapse
-version: "1.42.0"
+version: "1.55.0"
 tagline: Matrix reference homeserver
 description: >-
   Synapse is a reference "homeserver" implementation of Matrix from

--- a/synapse/umbrel-app.yml
+++ b/synapse/umbrel-app.yml
@@ -5,20 +5,26 @@ name: Synapse
 version: "1.55.0"
 tagline: Matrix reference homeserver
 description: >-
-  Synapse is a reference "homeserver" implementation of Matrix from
-  the core development team at matrix.org, written in Python/Twisted. It is
-  intended to showcase the concept of Matrix and let folks see the spec in the
-  context of a codebase and let you run your own homeserver and generally help
-  bootstrap the ecosystem.
+  Synapse is an open source Matrix homeserver implementation, written and maintained by Element. Matrix is the open standard for secure and interoperable real time communications.
 
 
-  The easiest way to try out your new Synapse installation is by connecting to it from a web client.
+  💡 How It Works
+  
+  
+  To chat using Matrix, you'll need a client. You can find a list of popular clients here: https://matrix.org/ecosystem/clients/
+  
+  
+  In Matrix, each user operates one or more Matrix clients, which connect to a Matrix homeserver. The homeserver stores all personal chat history and user account information, similar to how a mail client connects to an IMAP/SMTP server.
+  Like email, you can either run your own Matrix homeserver to control and own your communications and history, or use a hosted server (e.g., matrix.org). Matrix has no single point of control or mandatory service provider, unlike WhatsApp, Facebook, Hangouts, etc.
 
 
-  An easy way to get started is to install the "Element" app on your Umbrel and change its Homeserver URL from matrix.org server to your Synapse's Homeserver URL of http://umbrel.local:8008 (or http://<synapse-tor-hidden-service-url> if you are accessing remotely).
+  🛠️ Connecting a Client
 
 
-  In Matrix, every user runs one or more Matrix clients, which connect through to a Matrix homeserver. The homeserver stores all their personal chat history and user account information - much as a mail client connects through to an IMAP/SMTP server. Just like email, you can either run your own Matrix homeserver and control and own your own communications and history or use one hosted by someone else (e.g. matrix.org) - there is no single point of control or mandatory service provider in Matrix, unlike WhatsApp, Facebook, Hangouts, etc.
+  To get started, install the "Element" app on your Umbrel, or install any other Matrix client on a device of your choice. When you register or login through the client, you will need to change the address of the homeserver you are logging into from the default matrix.org to http://umbrel.local:8008 for local access. 
+
+  
+  For seamless connection even when your client isn't connected to the same network as your Umbrel, simply install the "Tailscale" app on your Umbrel and your client device, and use http://umbrel:8008 as the address of your server.
 developer: Matrix
 website: https://matrix.org
 dependencies: []


### PR DESCRIPTION
The compose configuration and initial installation setup for Synapse will need to change in order to update past version 1.55.0 (details to follow - will edit this comment).
https://github.com/matrix-org/synapse/blob/develop/docs/upgrade.md#upgrading-to-v1560

In the interim, I have updated Synapse to 1.55.0 to maintain compatibility with the latest Element app.