### PR TITLE
Upgrade Affine to version 0.16.3

### DIFF
--- a/affine/docker-compose.yml
+++ b/affine/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_PORT: 3010
 
   web:
-    image: ghcr.io/toeverything/affine-graphql:stable-a579cc7@sha256:b15070c36e1416f2ddbfae8aa47af97b32705ba166f128cedfeabd0ed28d7a89
+    image: ghcr.io/toeverything/affine-graphql:stable-eb0466e@sha256:3dc307907cbaed5d87ad30afb5e7f1ada7cdb6372736a920b0765401d4bce5e7
     restart: on-failure
     init: true
     command:
@@ -17,8 +17,6 @@ services:
       - REDIS_SERVER_HOST=affine_redis_1
       - DATABASE_URL=postgres://affine:affine@db:5432/affine
       - NODE_ENV=production
-      - AFFINE_ADMIN_EMAIL=admin@umbrel.local
-      - AFFINE_ADMIN_PASSWORD=$APP_PASSWORD
     volumes:
       - ${APP_DATA_DIR}/data/config:/root/.affine/config
       - ${APP_DATA_DIR}/data/storage/blob:/root/.affine/storage

--- a/affine/umbrel-app.yml
+++ b/affine/umbrel-app.yml
@@ -8,11 +8,6 @@ port: 3013
 description: >-
   A privacy-focused, local-first, open-source, and ready-to-use alternative for Notion & Miro.
   One hyper-fused platform for wildly creative minds.
-
-
-  🛠️ SET-UP INSTRUCTIONS
-
-  Open app and follow the steps to create your admin account for your workspace. You are now ready to use Affine with your self-hosted instance!
 developer: toeverything
 website: https://affine.pro
 submitter: Jasper

--- a/affine/umbrel-app.yml
+++ b/affine/umbrel-app.yml
@@ -8,6 +8,9 @@ port: 3013
 description: >-
   A privacy-focused, local-first, open-source, and ready-to-use alternative for Notion & Miro.
   One hyper-fused platform for wildly creative minds.
+
+
+  To Shape, not to adapt. Tools can impact your lifestyle. AFFiNE is built for individual & teams who care their data, who refuse vendor lock-in, and who want to have control over their essential tools. 
 developer: toeverything
 website: https://affine.pro
 submitter: Jasper

--- a/affine/umbrel-app.yml
+++ b/affine/umbrel-app.yml
@@ -3,7 +3,7 @@ id: affine
 name: Affine
 tagline: Open source alternative to Notion, Miro, and Airtable
 category: files
-version: "0.16.1"
+version: "0.16.3"
 port: 3013
 description: >-
   A privacy-focused, local-first, open-source, and ready-to-use alternative for Notion & Miro.
@@ -12,17 +12,7 @@ description: >-
 
   🛠️ SET-UP INSTRUCTIONS
 
-  In order to save your data, you need to sign in to your self-hosted Affine instance:
-
-
-  1. In the Affine app select the "Sign up/ Sign in" to sync with your self-hosted instance.
-
-
-  2. Enter the email and password credentials that are provided when you installed the app. To find these again, right-click on the Affine app icon
-  on the umbrelOS homescreen and select "Show default credentials".
-
-
-  3. Follow the steps to create your self-hosted cloud workspace. You are now ready to use Affine with your self-hosted instance!
+  Open app and follow the steps to create your admin account for your workspace. You are now ready to use Affine with your self-hosted instance!
 developer: toeverything
 website: https://affine.pro
 submitter: Jasper
@@ -36,14 +26,13 @@ gallery:
 releaseNotes: >-
   This release includes various improvements and bug fixes:
 
-    - Improved internationalization support
-    - Fixed issues with deleting items from folders
-    - Enhanced search functionality for better results
-    - Resolved UI issues in the sidebar and AI subscribe button
-    - Improved handling of collections in the electron app
+    - Add self-host setup and user management page
+    - Add config page to admin
+    - Add server runtime config settings
+    - Add prompt management page
+    - Center peek support open in new tab
 
   For full release notes, visit https://github.com/toeverything/AFFiNE/releases
 dependencies: []
 path: ""
-defaultUsername: "admin@umbrel.local"
-deterministicPassword: true
+defaultUsername: ""

--- a/affine/umbrel-app.yml
+++ b/affine/umbrel-app.yml
@@ -24,13 +24,17 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  This release includes various improvements and bug fixes:
+  🚨 New installs of Affine will now walk you through setting up an admin account.
+  For existing Affine users who are updating from a previous version and have already set up their workspace,
+  you can still access your admin workspace using your existing account details.
+  
 
-    - Add self-host setup and user management page
-    - Add config page to admin
-    - Add server runtime config settings
-    - Add prompt management page
-    - Center peek support open in new tab
+  This release includes various improvements and bug fixes, as well as the following new features:
+
+    - Added self-host setup and user management page
+    - Added config page to admin
+    - Added server runtime config settings
+    - Added prompt management page
 
   For full release notes, visit https://github.com/toeverything/AFFiNE/releases
 dependencies: []


### PR DESCRIPTION
Upgrade Affine to version 0.16.3.

The main difference is that the local version control panel has been added. The standard username and password are no longer needed, an administrator account is created in the setup wizard.