### PR TITLE
Update Torq to v2.0.4

### DIFF
--- a/torq/docker-compose.yml
+++ b/torq/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 7028
 
   web:
-    image: lncapital/torq:1.5.1@sha256:f705b5a1b1da79668264dd9197b7c2b0020cfe6d9f0fdb946672d2e763ba176b
+    image: lncapital/torq:2.0.4@sha256:e3debd8d4681fd7b9841b24a004261cc4ac5d8643d5f516117e9451444fac214
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/torq/umbrel-app.yml
+++ b/torq/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: torq
 category: bitcoin
 name: Torq
-version: "v1.5.1"
+version: "v2.0.4"
 tagline: Scalable Node Management Software
 description: >-
   Operating a Lightning node requires a lot of work. You need to monitor your channels, rebalance them, keep track of your fees and much more.
@@ -52,39 +52,52 @@ gallery:
   - 5.jpg
 releaseNotes: >-
   
-  Torq v.1.5.1:
-
-  Release notes:
-
-  - CLN v23.11+ is required (pagination)
-
-  - Integration with Kraken
-
-  - New workflow triggers: Invoice, Forward, Payment, Transaction (on-chain)
-
-  - New workflow filters: Mempool, Exchange (Kraken) balance
-
-  - New workflow action: Payment Attempt (experimental: tries to find a route to pay an exchange invoice)
-
-  - New variables in workflow actions: API client, notification
-
-  - Replace intercom with chatwoot
-
-  - Small changes to rebalancer + new metrics and logs
-
-  - Timelock Delta in seconds on list screens
-
-  - Update of packages
+  Torq v.2.0.4:
   
+  A lot of improvements have been made in this release. It's hard to cover it all but here are som highlights.
   
-  Notes:
+  List of changes:
+
+    - Add advanced outputs table (UTXO management), with the ability to lock/unlock individual outputs.
   
-  - This release contains a large set of database updates. So the migration might take some time depending on the 
-    hardware and stored data. Please create a backup before updating, there is no automatic rollback process other 
-    then a database restore from before the migration.
+    - LND v0.18 support (+ inbound fees)
   
-  - This release (re)imports CLN data so it might take some time to get all data fetched from your CLN node. 
-    (No impact to LND nodes)
+    - CLN v24.05 support
+  
+    - Tighter CLN integration via Torq plugin
+  
+    - Fix opening a channel with CLN (missing close-to address)
+  
+    - Fix CLN+LND on-chain transaction import (this will reimport on-chain transactions)
+  
+    - Torq will import transactions + transaction inputs and outputs
+  
+    - We advise to configure bitcoind connection details for extra annotation
+  
+    - Ability to integrate Electrum (for unconfirmed on-chain notification support)
+  
+    - System/workflow variables/templates in workflows
+  
+    - example 1: proportionate fee template: 2000 - ({{Channels.peerGauge}} * 2000)
+  
+    - example 2: dynamic max HTLC amount: {{Channels.localBalance}} / 2
+  
+    - Channel open interceptor workflow (LND and CLN)
+  
+    - Email is now a notification type in workflows (using SMTP)
+  
+    - Ability to trigger a workflow via gRPC (and specify workflow/system variables)
+  
+    - Manual and automatic emergency recovery file / SCB (for CLN and LND)
+  
+    - Automatic includes: email, Github, dropbox, gdrive
+  
+    - Beta feature: (Unauthenticated) Implementation agnostic Torq gRPC
+  
+    - With methods: GetActiveNodes, GetNodeInformation, ConnectPeer, DisconnectPeer, OpenChannel, CloseChannel, SendPayment, CreateInvoice, CreateAddress, TagPeer, TriggerWorkflow, GetOnChainTransactionsByAddress, GetOnChainFeeEstimates, WaitInvoiceSettledByPaymentHash, SubscribeInvoiceStatuses, WaitOnChainTransactionsByAddress, SubscribeOnChainTransactions
+  
+    - Package upgrades
+  
   
 
 path: ""


### PR DESCRIPTION
Torq v.2.0.4:
  
  A lot of improvements have been made in this release. It's hard to cover it all, but here are some highlights.
  
  List of changes:

    - Add advanced outputs table (UTXO management), with the ability to lock/unlock individual outputs.
  
    - LND v0.18 support (+ inbound fees)
  
    - CLN v24.05 support
  
    - Tighter CLN integration via Torq plugin
  
    - Fix opening a channel with CLN (missing close-to address)
  
    - Fix CLN+LND on-chain transaction import (this will reimport on-chain transactions)
  
    - Torq will import transactions + transaction inputs and outputs
  
    - Ability to integrate Electrum (for unconfirmed on-chain notification support)
  
    - System/workflow variables/templates in workflows
  
    - example 1: proportionate fee template: 2000 - ({{Channels.peerGauge}} * 2000)
  
    - example 2: dynamic max HTLC amount: {{Channels.localBalance}} / 2
  
    - Channel open interceptor workflow (LND and CLN)
  
    - Email is now a notification type in workflows (using SMTP)
  
    - Ability to trigger a workflow via gRPC (and specify workflow/system variables)
  
    - Manual and automatic emergency recovery file / SCB (for CLN and LND)
  
    - Automatic includes: email, Github, dropbox, gdrive
  
    - Beta feature: (Unauthenticated) Implementation agnostic Torq gRPC
  
    - With methods: GetActiveNodes, GetNodeInformation, ConnectPeer, DisconnectPeer, OpenChannel, CloseChannel, SendPayment, CreateInvoice, CreateAddress, TagPeer, TriggerWorkflow, GetOnChainTransactionsByAddress, GetOnChainFeeEstimates, WaitInvoiceSettledByPaymentHash, SubscribeInvoiceStatuses, WaitOnChainTransactionsByAddress, SubscribeOnChainTransactions
  
    - Package upgrades