### PR TITLE
Moved just-download to codeberg

### DIFF
--- a/just-download/docker-compose.yml
+++ b/just-download/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 5000
   
   web:
-    image: ghcr.io/highghlow/just-download:v1.0.8@sha256:8d86964f203bc91438ce5fbe32d2799c2942fa37224c578bd0264e789486864e
+    image: codeberg.org/highghlow/just-download:v1.0.9@sha256:96d8ed20104418ca41ccc8fc7001889f827bc60235b71b8e9aa19d1f5a6e4db7
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/just-download/umbrel-app.yml
+++ b/just-download/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: just-download
 category: media
 name: Just. Download.
-version: "1.0.8"
+version: "1.0.9"
 tagline: Download torrents. Just. Download.
 description: >-
   Just Download allows you to easily download movies, books, games, etc. from your favourite indexers. It acts as a bridge between a Torznab feed (Jackett is recommended for making these) and transmission.

--- a/just-download/umbrel-app.yml
+++ b/just-download/umbrel-app.yml
@@ -9,7 +9,8 @@ description: >-
 
 
   You just search, press download and you're done!
-releaseNotes: ""
+releaseNotes: >-
+  Full release notes can be found at https://codeberg.org/highghlow/just-download/releases
 developer: highghlow
 website: https://codeberg.org/highghlow/just-download
 dependencies:

--- a/just-download/umbrel-app.yml
+++ b/just-download/umbrel-app.yml
@@ -11,11 +11,11 @@ description: >-
   You just search, press download and you're done!
 releaseNotes: ""
 developer: highghlow
-website: https://github.com/highghlow/just-download
+website: https://codeberg.org/highghlow/just-download
 dependencies:
   - transmission
-repo: https://github.com/highghlow/just-download/
-support: https://github.com/highghlow/just-download/discussions
+repo: https://codeberg.org/highghlow/just-download/
+support: https://codeberg.org/highghlow/just-download/issues
 port: 3684
 gallery:
   - 1.jpg


### PR DESCRIPTION
I have moved just-download to codeberg: https://codeberg.org/highghlow/just-download

That's the only change