### PR TITLE
Update Bitcoin Node to v27.1

### DIFF
--- a/bitcoin/docker-compose.yml
+++ b/bitcoin/docker-compose.yml
@@ -40,7 +40,7 @@ services:
         ipv4_address: $APP_BITCOIN_IP
 
   bitcoind:
-    image: lncm/bitcoind:v27.0@sha256:324fec72192e8a1c7b79e7ab91003e47678b808d46da2c1943e72ec212ab348f
+    image: getumbrel/bitcoind:v27.1@sha256:c5c7a98af15bedf73401d9623b192ad8e920e94b8cd23474553bf9bd30a31407
     user: "1000:1000"
     command: "${APP_BITCOIN_COMMAND}"
     restart: unless-stopped

--- a/bitcoin/docker-compose.yml
+++ b/bitcoin/docker-compose.yml
@@ -41,6 +41,7 @@ services:
 
   bitcoind:
     image: lncm/bitcoind:v27.0@sha256:324fec72192e8a1c7b79e7ab91003e47678b808d46da2c1943e72ec212ab348f
+    user: "1000:1000"
     command: "${APP_BITCOIN_COMMAND}"
     restart: unless-stopped
     stop_grace_period: 15m30s

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -42,23 +42,10 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This release of the Bitcoin Node app includes the following updates:
+  This release updates Bitcoin Core to v27.1, which includes various bug fixes and performance improvements.
 
 
-  - Bitcoin Core: Upgrades Bitcoin Core to version 27.0. Full release notes for Bitcoin Core 27.0 can be found at https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-27.0.md.
-
-
-  - New Advanced Settings Options: Adds 3 new options to the Advanced Settings menu:
-    - datacarrier: Choose whether or not to relay transactions with OP_RETURN outputs.
-    - datacarriersize: Set the maximum size of the data in OP_RETURN outputs (in bytes) that your node will relay.
-    - permitbaremultisig: Choose wether or not to relay non-P2SH multisig transactions.
-
-
-  - JoinMarket Compatibility: The deprecated RPC 'deprecatedrpc=create_bdb' is enabled to allow integration with JoinMarket and the Jam app by default.
-  This fixes an issue where Jam app users who upgraded to Bitcoin Core v26.0 would have to manually add 'deprecatedrpc=create_bdb' to their bitcoin.conf file in order for the app to work.
-  
-  
-  ⚠️ For existing Jam users, if you receive a connection error in Jam after updating to Bitcoin Core v27.0, please restart the Jam app from your homescreen by right-clicking on the app and selecting 'restart'.
+  Full Bitcoin Core release notes for this release are found at https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-27.1.md
 widgets:
   - id: "stats"
     type: "four-stats"

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bitcoin
 category: bitcoin
 name: Bitcoin Node
-version: "27.0"
+version: "27.1"
 tagline: Run your personal node powered by Bitcoin Core
 description: >-
   Run your Bitcoin node and independently store and validate


### PR DESCRIPTION
Awaiting `getumbrel/bitcoind:v27.1` image build. New bitcoind image must be added to the compose file and the app tested.

This PR updates the Bitcoin Node app to use the latest Bitcoin Core version 27.1. The previous [lncm/bitcoind](https://github.com/lncm/docker-bitcoind) image has been replaced with [getumbrel/bitcoind](https://github.com/getumbrel/docker-bitcoind).

