### PR TITLE
Update RoboSats to v0.7.0-alpha

### DIFF
--- a/robosats/docker-compose.yml
+++ b/robosats/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 12596
 
   web:
-    image: recksato/robosats-client:v0.7.0-alpha@sha256:fcb8045d5da4a87865e2aca78fb90a37af110d5e069107051aafa33d95301331
+    image: recksato/robosats-client:1ba8183@sha256:6a776a00364449f10eebdf7781a4f75d068d697767fc77c3e578cb854291eb68
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/robosats/docker-compose.yml
+++ b/robosats/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 12596
 
   web:
-    image: recksato/robosats-client:v0.7.0-alpha@sha256:28ae9e1de541a563cfd7555b9b182c32918eff9860c0475b37910f925e8e1302
+    image: recksato/robosats-client:v0.7.0-alpha@sha256:fcb8045d5da4a87865e2aca78fb90a37af110d5e069107051aafa33d95301331
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/robosats/docker-compose.yml
+++ b/robosats/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 12596
 
   web:
-    image: recksato/robosats-client:v0.6.0-alpha@sha256:ae5b806bef9bb6dc23899b0d1e667fcc4321f7f85c1623954a3861186000eee0
+    image: recksato/robosats-client:v0.7.0-alpha@sha256:28ae9e1de541a563cfd7555b9b182c32918eff9860c0475b37910f925e8e1302
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: robosats
 category: bitcoin
 name: RoboSats
-version: "v0.6.0-alpha"
+version: "v0.7.0-alpha"
 tagline: Simple and Private Bitcoin P2P Exchange
 description: >-
   RoboSats is a simple and private app to exchange bitcoin for national currencies. 
@@ -34,17 +34,14 @@ description: >-
   You can join other cool Robots and get community support at https://t.me/robosats telegram group.
   
 releaseNotes: >-
-  This is the biggest ever RoboSats update. RoboSats has decentralized! The whole app architecture is new, yet, it should feel as familiar as always.
-  Learn more about why these changes are important on the RoboSats blog https://learn.robosats.com/robosats/update/pre-release-robosats-decentralized/
+  This is a minor release to help the clients to be up to date with the major changes in coordinators:
 
-
-  - Your RoboSats app connects to multiple trade coordinators simultaneously. This greatly improves robustness and censorship resistance.
-
-
-  - Robot identities are now generated locally. This improves speed by an order of magnitude as well as identity sovereignty.
+   - Manually add new coordinators
+   - New currency DZD
+   - UI Bug fixes and regression fixes caused with LND v18 upgrade
   
   
-  Full changelog can be found here: https://github.com/Reckless-Satoshi/robosats/compare/v0.5.3-alpha...v0.6.0-alpha
+  Full changelog can be found here: https://github.com/Reckless-Satoshi/robosats/compare/v0.6.0-alpha...v0.7.0-alpha
 
 developer: RoboSats
 website: https://learn.robosats.com

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -41,8 +41,7 @@ releaseNotes: >-
    - UI Bug fixes and regression fixes caused with LND v18 upgrade
   
   
-  Full changelog can be found here: https://github.com/Reckless-Satoshi/robosats/compare/v0.6.0-alpha...v0.7.0-alpha
-
+  Full release notes are available at https://github.com/RoboSats/robosats/releases
 developer: RoboSats
 website: https://learn.robosats.com
 dependencies: []


### PR DESCRIPTION
Update RoboSats to latest v0.7.0-alpha

Untested. Exactly replicated the steps to update to v0.6.0-alpha https://github.com/getumbrel/umbrel-apps/pull/1022