### PR TITLE
lightning-terminal: update to v0.13.4-alpha

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.13.2-alpha@sha256:0862c4f0cfa6829a9ef6cf3d6990f41b68825805a4510110a2a2dc0485bcfbb6
+    image: lightninglabs/lightning-terminal:v0.13.4-alpha@sha256:aefe880a54040ad5829beba967d919e3987b377ee32d3550a84642777a8999fc
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.13.3-alpha"
+version: "0.13.4-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -56,8 +56,8 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  This release of Lightning Terminal (LiT) includes updates to the integrated 
-  Taproot Assets and Loop daemons. 
+  This release of Lightning Terminal (LiT) includes updates to the integrated
+  LND and Loop daemons.
 
 
   IMPORTANT NOTE: To avoid loss of funds, it's imperative that you read the
@@ -95,7 +95,7 @@ releaseNotes: >-
   feedback from the community.
 
 
-  This release packages LND v0.18.2-beta, Taproot Assets Daemon v0.4.1-alpha,
-  Loop v0.28.6-beta, Pool v0.6.4-beta and Faraday v0.2.13-alpha.
+  This release packages LND v0.18.3-beta, Taproot Assets Daemon v0.4.1-alpha,
+  Loop v0.28.7-beta, Pool v0.6.4-beta and Faraday v0.2.13-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
In this PR we bump Litd to `v0.13.4-alpha`.

See the release notes here: https://github.com/lightninglabs/lightning-terminal/blob/master/docs/release-notes/release-notes-0.13.4.md

Happy to address any feedback if needed :)!