### PR TITLE
Bugfix: Update invalid Zabbix Agent service name

### DIFF
--- a/zabbix/umbrel-app.yml
+++ b/zabbix/umbrel-app.yml
@@ -30,7 +30,7 @@ description: >-
   ⚙️ Configuration:
 
 
-  The Zabbix Agent listens on port 10050. To monitor the Zabbix server itslelf, navigate to Monitoring > Hosts within Zabbix, and modify the "Zabbix server" host by adding the DNS name "zabbix_zabbix-server_1" and toggling the "Connect to DNS" option.
+  The Zabbix Agent listens on port 10050. To monitor the Zabbix server itself, navigate to Monitoring > Hosts within Zabbix, and modify the "Zabbix server" host by adding the DNS name "zabbix_zabbix-agent_1" and toggling the "Connect to DNS" option.
 developer: Zabbix LLC
 website: https://www.zabbix.com/
 dependencies: []


### PR DESCRIPTION
Zabbix Agent has its own service, so we need to target the Agent's service instead of the Server

As you can see, Zabbix reports an error (in red) when targeting the invalid service name, but it resolves successfully when targeting the updated one.

<img width="677" alt="Screenshot 2024-09-18 at 09 38 13" src="https://github.com/user-attachments/assets/56a676f9-c495-471e-ab15-213934463fb1">

<img width="550" alt="Screenshot 2024-09-18 at 09 38 43" src="https://github.com/user-attachments/assets/491e56db-be32-4b37-a79d-0398122adb84">
