### PR TITLE
Gitlab App - How to change the `root` password

### DIFF
--- a/gitlab/umbrel-app.yml
+++ b/gitlab/umbrel-app.yml
@@ -9,6 +9,9 @@ description: >-
   ⚠️ This app is RAM-intensive (+6GB recommended) and can take 15-20 minutes to start after installation on low-powered devices.
 
 
+  🔐 After installing the App, you can create a new user account via web interface, or you can connect via SSH/Terminal and change the `root` password by running the `gitlab-rake "gitlab:password:reset[root]"` command
+
+
   GitLab is a comprehensive, web-based DevOps lifecycle tool that provides a robust platform for managing projects and repositories. It offers a wide range of features that cater to the entire software development lifecycle, including version control, CI/CD, code review, issue tracking, and more. All operations are performed in a secure, collaborative environment, ensuring your code and data are safe and accessible.
 
   


### PR DESCRIPTION
This is updating the description of the app so we all know how to change the password for the `root` user when installing the app for the very first time.

I have tested it with my local install (umbrel home) and I got it from this page: https://stackoverflow.com/questions/55747402/docker-gitlab-change-forgotten-root-password