### PR TITLE
Update firefox to 130.0.1-hotfix

### DIFF
--- a/firefox/docker-compose.yml
+++ b/firefox/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   server:
-    image: linuxserver/firefox:130.0.1@sha256:e1e5ab3a6c54cff79b66798d322dbd8ca734eb7bfd0b0e266a98a2f557e2208a
+    image: linuxserver/firefox:130.0.1@sha256:2208519e32670e886783f74a976b5ca927b15b9912a01cb134e877c0b627cc3d
     restart: on-failure
     environment:
       - PUID=1000

--- a/firefox/umbrel-app.yml
+++ b/firefox/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: firefox
 category: networking
 name: Firefox
-version: "130.0.1"
+version: "130.0.1-hotfix"
 tagline: Firefox is a free and open-source web browser
 description: >-
   Get the browser that protects what is important.
@@ -19,9 +19,7 @@ description: >-
 
   Available in over 90 languages, and compatible with Windows, Mac and Linux machines, Firefox works no matter what you are using or where you are. Make sure your operating system is up to date for the best experience.
 releaseNotes: >-
-  This release includes several improvements and bug fixes:
-    - Fixed a regression causing some UI elements to be rendered incorrectly for users of the Saraiki localization
-    - Improved rendering of AVIF images on Linux systems
+  This is a hotfix release to fix an issue where firefox would not navigate to properly to URLs.
 
 
   Full release notes are available at https://www.mozilla.org/en-US/firefox/130.0/releasenotes


### PR DESCRIPTION
The initial 130.0.1 image digest had some broken functionality. See https://community.umbrel.com/t/latest-update-broke-firefox/19332

This PR uses the latest digest for the 130.0.1 tag which solves the issue.