### PR TITLE
Update Jam to v0.3.0

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   web:
-    image: ghcr.io/joinmarket-webui/jam-dev-standalone:v0.2.0-clientserver-v0.9.11-patch-20240521@sha256:6716161d0a5d4514d6744bf8351c7490f3446a7ba52eb736e10ec62ffb0dc491
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.3.0-clientserver-v0.9.11@sha256:5047d29a59d5892f2eb77d5c9a7f9ad15105ccaae44e6b3deb5a04bc4e76de6f
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: jam
 category: bitcoin
 name: Jam
-version: "0.2.0-patch-20240521"
+version: "0.3.0"
 tagline: Your sats. Your privacy. Your profit.
 description: >-
   Jam is a user-interface for JoinMarket with focus on
@@ -13,7 +13,17 @@ description: >-
 
   The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 releaseNotes: >-
-  This is a patch release that makes Jam v0.2.0 compatible with the Raspberry Pi 5 on umbrelOS.
+  - Send: Quickly freeze/unfreeze UTXOs
+
+  - Send: Review eligible or selected UTXOs
+
+  - Feature: Ability to trigger a rescan of the timechain
+
+  - Orderbook: Display fidelity bond value and locktime data
+
+  - Earn: Display simple stats on earn report
+
+  - UI: Various UI improvements and bugfixes
 developer: JoinMarket WebUI Org.
 website: https://jamapp.org
 dependencies:

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -24,6 +24,9 @@ releaseNotes: >-
   - Earn: Display simple stats on earn report
 
   - UI: Various UI improvements and bugfixes
+
+
+  Full release notes can be found at https://github.com/joinmarket-webui/jam/releases
 developer: JoinMarket WebUI Org.
 website: https://jamapp.org
 dependencies:


### PR DESCRIPTION
This version includes:
- Jam: [v0.3.0](https://github.com/joinmarket-webui/jam/releases/tag/v0.3.0)
- joinmarket-clientserver: [v0.9.11](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.11)

All notable changes of the UI can be seen in the [Jam v0.3.0 changelog](https://github.com/joinmarket-webui/jam/blob/v0.3.0/CHANGELOG.md)
