### PR TITLE
Update mempool to v3.0.1 and set max heap size to 2gb

### DIFF
--- a/mempool/docker-compose.yml
+++ b/mempool/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_MEMPOOL_PORT
       PROXY_AUTH_ADD: "false"
   web:
-    image: mempool/frontend:v3.0.0@sha256:ec84195e6d3050841efef99b9db2ec6f3b8cd64611df0c8dae026a41931ae58c
+    image: mempool/frontend:v3.0.1@sha256:f3a74d2ca47dfa679f8da5a2b22bd714164794dc2fd088ef8779a79b21d4e742
     user: "1000:1000"
     init: true
     restart: on-failure
@@ -23,7 +23,7 @@ services:
       default:
         ipv4_address: $APP_MEMPOOL_IP
   api:
-    image: mempool/backend:v3.0.0@sha256:d48122e60e5f8fdd74874e23578ea606dbd3cd52bd2eeb2b68b56e69e54e3d82
+    image: mempool/backend:v3.0.1@sha256:4daa540727d3a830e71fb9f1ae281d1393be5077177c7d714066d450fb8f5bbf
     user: "1000:1000"
     init: true
     restart: on-failure
@@ -58,6 +58,7 @@ services:
       LND_MACAROON_PATH: "/lnd/data/chain/bitcoin/$APP_BITCOIN_NETWORK/readonly.macaroon"
       LND_REST_API_URL: "https://$APP_LIGHTNING_NODE_IP:$APP_LIGHTNING_NODE_REST_PORT"
       LND_TIMEOUT: 120000
+      NODE_OPTIONS: "--max-old-space-size=2048"
     networks:
        default:
          ipv4_address: $APP_MEMPOOL_API_IP

--- a/mempool/umbrel-app.yml
+++ b/mempool/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: mempool
 category: bitcoin
 name: mempool
-version: "3.0.0"
+version: "3.0.1"
 tagline: Explore the full Bitcoin ecosystem
 description: >-
   Be your own explorer.
@@ -13,36 +13,10 @@ description: >-
 
   This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com
 releaseNotes: >-
-  The Mempool Open Source Project® v3.0.0 is here!
+  This update brings faster block indexing and limits memory usage for better performance.
 
 
-  This release features integration with our new Mempool Accelerator™ service to help you get your stuck Bitcoin transactions confirmed quickly.
-  You can now submit accceleration requests directly to mempool.space from your own self-hosted instance of The Mempool Open Source Project®.
-  
-
-  Highlights:
-
-    - Added Mempool Accelerator™ to accelerate TX from your own instance
-    - Added Mempool Googles™ new mempool and blockchain analytics tool
-    - Added RBF Timeline visualizations including support for FullRBF
-    - Added CPFP and Effective Fee calculations in block visualizations
-    - Added Liquid Network audit tool to verify holdings vs liabilities
-    - Added new Wallet Balance widget for embedding into external sites
-    - Added customizable CSS themes including a new high-contrast mode
-    - Added optional support for FreecurrencyAPI fiat currencies
-    - Added optional Redis support for faster in-memory database
-    - Added support for legacy P2PK addresses and outputs
-    - Added new block fees graph at /graphs/mining/block-fees
-    - Added new fiat calculator at /tools/calculator
-    - Re-implemented our GBT algorithm in rust for high performance
-    - Re-designed transaction page with new mobile "pizza tracker" UI
-    - Re-designed address page with new balance history over time
-    - Improved Block Audit for accelerated transaction out-of-band fees
-    - Improved Websocket API to support tracking multiple addresses
-    - Improved search box now supports searching multiple networks
-    - Improved TV View to add new circular clock face view
-
-  Full release notes are found at https://github.com/mempool/mempool/releases
+  Full release notes for the previous major update to version 3.0.0 are found at https://github.com/mempool/mempool/releases
 developer: Mempool Space K.K.
 website: https://mempool.space/about
 dependencies:


### PR DESCRIPTION
This release enables the Rust Get Block Template implementation by default for faster block indexing, there are no other code changes.

We're also taking the opportunity to limit the max heap size of the backend node process to 2gb.