### PR TITLE
Update LND to 18.3-beta

### DIFF
--- a/lightning/docker-compose.yml
+++ b/lightning/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
   lnd:
     hostname: "${DEVICE_DOMAIN_NAME}" # Needed so LND can generate a valid cert
-    image: lightninglabs/lnd:v0.18.0-beta@sha256:dab0f5ae09615066d4c0f29f6f7444ab7e6c8a2548f56ea50288236b542095d4
+    image: lightninglabs/lnd:v0.18.3-beta@sha256:f86bbec4dfb370436384db5d67732bbd627bf6b7f574bde3d5eed32242132287
     command: "${APP_LIGHTNING_COMMAND}"
     user: 1000:1000
     restart: unless-stopped

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: lightning
 category: bitcoin
 name: Lightning Node
-version: "v0.18.3-beta"
+version: "0.18.3-beta"
 tagline: Run your personal Lightning Network node
 description: >-
   Run your personal Lightning Network node, and join the future of Bitcoin today.

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -22,13 +22,10 @@ description: >-
 
   An official app from Umbrel.
 releaseNotes: >-
-  ⚠️ Please allow a few minutes for your Lightning Node to come online after updating to this version. Nodes running with Watchtower Client enabled (wtclient.active=true) will not be able to downgrade to a previous version of lnd after updating to this version.
+  This release updates the underlying Lightning Network Daemon (LND) to v0.18.3-beta, which includes bug fixes and stability improvements, as well as support for sending and receiving blinded paths using BOLT 11 invoices.
 
 
-  This release updates LND to v0.18.3-beta. This is a minor release with primarily bug fixes and stability improvements. One notable protocol feature extended in this release is: blinded paths. With this release, support for sending and receiving blinded paths using BOLT 11 invoices has been added.
-
-
-  Full LND v0.18.3-beta release notes can be found at https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.18.3.md
+  Full release notes can be found at https://github.com/lightningnetwork/lnd/releases
 developer: Umbrel
 website: https://umbrel.com
 dependencies:

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: lightning
 category: bitcoin
 name: Lightning Node
-version: "v0.18.0-beta"
+version: "v0.18.3-beta"
 tagline: Run your personal Lightning Network node
 description: >-
   Run your personal Lightning Network node, and join the future of Bitcoin today.
@@ -25,10 +25,10 @@ releaseNotes: >-
   ⚠️ Please allow a few minutes for your Lightning Node to come online after updating to this version. Nodes running with Watchtower Client enabled (wtclient.active=true) will not be able to downgrade to a previous version of lnd after updating to this version.
 
 
-  This release updates LND to v0.18.0-beta. This is a major release that includes support for blinded paths (forwarding), a new native SQL invoice database, deadline aware HTLC/commitment transaction RBF/CPFP fee bumping, experimental support for inbound channel fees (discount only), first class probing for payment fee estimation, testmempoolaccept awareness for all transaction publishing, and much more!
+  This release updates LND to v0.18.3-beta. This is a major release that includes support for blinded paths (forwarding), a new native SQL invoice database, deadline aware HTLC/commitment transaction RBF/CPFP fee bumping, experimental support for inbound channel fees (discount only), first class probing for payment fee estimation, testmempoolaccept awareness for all transaction publishing, and much more!
 
 
-  Full LND v0.18.0-beta release notes can be found at https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.18.0.md
+  Full LND v0.18.3-beta release notes can be found at https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.18.3.md
 developer: Umbrel
 website: https://umbrel.com
 dependencies:

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -25,7 +25,7 @@ releaseNotes: >-
   ⚠️ Please allow a few minutes for your Lightning Node to come online after updating to this version. Nodes running with Watchtower Client enabled (wtclient.active=true) will not be able to downgrade to a previous version of lnd after updating to this version.
 
 
-  This release updates LND to v0.18.3-beta. This is a major release that includes support for blinded paths (forwarding), a new native SQL invoice database, deadline aware HTLC/commitment transaction RBF/CPFP fee bumping, experimental support for inbound channel fees (discount only), first class probing for payment fee estimation, testmempoolaccept awareness for all transaction publishing, and much more!
+  This release updates LND to v0.18.3-beta. This is a minor release with primarily bug fixes and stability improvements. One notable protocol feature extended in this release is: blinded paths. With this release, support for sending and receiving blinded paths using BOLT 11 invoices has been added.
 
 
   Full LND v0.18.3-beta release notes can be found at https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.18.3.md


### PR DESCRIPTION
Bumps LND from 18.0-beta to 18.3-beta

18.3-beta release notes: https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.18.3.md
18.2-beta release notes: https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.18.2.md
18.1-beta release notes: https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.18.1.md
