### PR TITLE
Update Bitcoin Node to v28.0

### DIFF
--- a/bitcoin/docker-compose.yml
+++ b/bitcoin/docker-compose.yml
@@ -40,7 +40,7 @@ services:
         ipv4_address: $APP_BITCOIN_IP
 
   bitcoind:
-    image: getumbrel/bitcoind:v27.1@sha256:c5c7a98af15bedf73401d9623b192ad8e920e94b8cd23474553bf9bd30a31407
+    image: getumbrel/bitcoind:v28.0@sha256:95c5eb9778fc0050e185b22700061fb7e7d71a0c27860067461bed2afcfbe5c4
     user: "1000:1000"
     command: "${APP_BITCOIN_COMMAND}"
     restart: unless-stopped

--- a/bitcoin/docker-compose.yml
+++ b/bitcoin/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3005
   
   server:
-    image: getumbrel/umbrel-bitcoin:v0.7.0@sha256:f2bb98c962fbad13991ceeda1308bbfaca13cc7cd5cb7d6b2e0d1d06e6123072
+    image: getumbrel/umbrel-bitcoin:v0.8.0@sha256:38465d8e3744223201993950954f0644841587d741e66d200d92b68ca719e6c1
     depends_on: [bitcoind]
     restart: on-failure
     volumes:

--- a/bitcoin/exports.sh
+++ b/bitcoin/exports.sh
@@ -120,6 +120,8 @@ BIN_ARGS+=( "-zmqpubsequence=tcp://0.0.0.0:${APP_BITCOIN_ZMQ_SEQUENCE_PORT}" )
 # BIN_ARGS+=( "-rpcworkqueue=128" )
 # We can remove depratedrpc=create_bdb in a future update once Jam (JoinMarket) implements descriptor wallet support
 BIN_ARGS+=( "-deprecatedrpc=create_bdb" )
+# Required for LND compatibility. We can remove deprecatedrpc=warnings in a future update once LND releases a version with this fix: https://github.com/btcsuite/btcd/pull/2245
+BIN_ARGS+=( "-deprecatedrpc=warnings" )
 
 export APP_BITCOIN_COMMAND=$(IFS=" "; echo "${BIN_ARGS[@]}")
 

--- a/bitcoin/exports.sh
+++ b/bitcoin/exports.sh
@@ -24,7 +24,9 @@ BITCOIN_ENV_FILE="${EXPORTS_APP_DIR}/.env"
 			"main")
 				BITCOIN_NETWORK="mainnet";;
 			"test")
-				BITCOIN_NETWORK="testnet";;
+				BITCOIN_NETWORK="testnet3";;
+			"testnet4")
+				BITCOIN_NETWORK="testnet4";;
 			"signet")
 				BITCOIN_NETWORK="signet";;
 			"regtest")
@@ -64,11 +66,16 @@ fi
 
 if [[ "${APP_BITCOIN_NETWORK}" == "mainnet" ]]; then
 	BITCOIN_CHAIN="main"
-elif [[ "${APP_BITCOIN_NETWORK}" == "testnet" ]]; then
+elif [[ "${APP_BITCOIN_NETWORK}" == "testnet3" ]]; then
 	BITCOIN_CHAIN="test"
 	# export APP_BITCOIN_RPC_PORT="18332"
 	# export APP_BITCOIN_P2P_PORT="18333"
 	# export APP_BITCOIN_TOR_PORT="18334"
+elif [[ "${APP_BITCOIN_NETWORK}" == "testnet4" ]]; then
+	BITCOIN_CHAIN="testnet4"
+	# export APP_BITCOIN_RPC_PORT="48332"
+	# export APP_BITCOIN_P2P_PORT="48333"
+	# export APP_BITCOIN_TOR_PORT="48334"
 elif [[ "${APP_BITCOIN_NETWORK}" == "signet" ]]; then
 	BITCOIN_CHAIN="signet"
 	# export APP_BITCOIN_RPC_PORT="38332"
@@ -94,6 +101,7 @@ BIN_ARGS=()
 # BIN_ARGS+=( "-bind=${APP_BITCOIN_NODE_IP}" )
 # BIN_ARGS+=( "-port=${APP_BITCOIN_P2P_PORT}" )
 # BIN_ARGS+=( "-rpcport=${APP_BITCOIN_RPC_PORT}" )
+# We hardcode the ports p2p and rpc ports to always be the same for all networks
 BIN_ARGS+=( "-port=8333" )
 BIN_ARGS+=( "-rpcport=8332" )
 BIN_ARGS+=( "-rpcbind=${APP_BITCOIN_NODE_IP}" )

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bitcoin
 category: bitcoin
 name: Bitcoin Node
-version: "27.1"
+version: "28.0"
 tagline: Run your personal node powered by Bitcoin Core
 description: >-
   Run your Bitcoin node and independently store and validate
@@ -42,10 +42,10 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This release updates Bitcoin Core to v27.1, which includes various bug fixes and performance improvements.
-
-
-  Full Bitcoin Core release notes for this release are found at https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-27.1.md
+  Highlights:
+    - Bitcoin Core Update: Bitcoin Core has been updated to v28.0, which includes new features, bug fixes, and performance improvements. See the full Bitcoin Core release notes at https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-28.0.md
+    - Testnet4 Availability: Testnet4 is now accessible via Advanced Settings. Testnet3 remains available but is expected to be removed in a future Bitcoin Core release.
+    - Configuration Update: The mempoolfullrbf setting is now enabled by default for new installs. If you're upgrading from a previous version, your current mempoolfullrbf setting will not be changed. This can be adjusted in Advanced Settings.
 widgets:
   - id: "stats"
     type: "four-stats"


### PR DESCRIPTION
- updates bitcoind to v28.0: https://github.com/getumbrel/docker-bitcoind
- updates getumbrel/umbrel-bitcoin to v0.8.0: https://github.com/getumbrel/umbrel-bitcoin/commits/master/
  
  <img width="681" alt="image" src="https://github.com/user-attachments/assets/296b162d-fd2b-4093-b12f-c0ecf4c85098">

- `deprecatedrpc=warnings` has been added as a flag at startup for compatibility with LND https://github.com/getumbrel/umbrel-apps/pull/1709/commits/213323c35a6b985083892abdd07f34a55506f5a2

  https://x.com/roasbeef/status/1842956355516223824
  <img width="594" alt="image" src="https://github.com/user-attachments/assets/26f89be8-a6c1-4063-8810-6afda39182e9">