### PR TITLE
Update Public Pool - Bitcoin Core v28 compatibility

### DIFF
--- a/public-pool/docker-compose.yml
+++ b/public-pool/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - DOMAIN=$DEVICE_DOMAIN_NAME
 
   server:
-    image: sethforprivacy/public-pool:820d8d1@sha256:2074bdad3930ad6e07e73f03cc07970cc5c912ab597bc7f11565d22038695d74
+    image: sethforprivacy/public-pool:9c14003@sha256:becfe82228a4cc814da8832d0c909000a382e2b39ef8a5d5cb6a8fb0bc554850
     restart: on-failure
     stop_grace_period: 30s
     ports:

--- a/public-pool/docker-compose.yml
+++ b/public-pool/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   web:
-    image: smolgrrr/public-pool-ui:c20eb2b@sha256:4774f022ca35a2241a8c36fa1a0c927ceef0f4111be79687ee77e166aecaebdb
+    image: smolgrrr/public-pool-ui:8cd2563@sha256:95884d33475b1681cf645831aefadb0cc31a89c6f537ede643251bc874311804
     restart: on-failure
     stop_grace_period: 30s
     environment:

--- a/public-pool/docker-compose.yml
+++ b/public-pool/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   web:
-    image: smolgrrr/public-pool-ui:8cd2563@sha256:95884d33475b1681cf645831aefadb0cc31a89c6f537ede643251bc874311804
+    image: smolgrrr/public-pool-ui:c20eb2b@sha256:4774f022ca35a2241a8c36fa1a0c927ceef0f4111be79687ee77e166aecaebdb
     restart: on-failure
     stop_grace_period: 30s
     environment:

--- a/public-pool/docker-compose.yml
+++ b/public-pool/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - API_SECURE=false
       - ENABLE_SOLO=true
       - ENABLE_PROXY=false
+      - POOL_IDENTIFIER="Public Pool on Umbrel"
 
   proxy:
     image: nginx:1.25.3@sha256:4c0fdaa8b6341bfdeca5f18f7837462c80cff90527ee35ef185571e1c327beac

--- a/public-pool/umbrel-app.yml
+++ b/public-pool/umbrel-app.yml
@@ -27,6 +27,7 @@ path: ""
 releaseNotes: >-
   This update brings Bitcoin Core v28 compatibility to Public Pool, along with a number of other improvements.
 
+
   If you have already updated your Bitcoin Node app to v28.0 and Public Pool is not working, this update will fix it.
 defaultPassword: ""
 submitter: smolgrrr

--- a/public-pool/umbrel-app.yml
+++ b/public-pool/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: public-pool
 category: bitcoin
 name: Public Pool
-version: "820d8d1"
+version: "9c14003"
 tagline: Fully Open Source Solo Bitcoin Mining Pool
 description: >-
   Run your own Bitcoin Solo Mining Pool with no fees.
@@ -25,9 +25,9 @@ gallery:
   - 3.jpg
 path: ""
 releaseNotes: >-
-  This update includes some performance improvements, and UI changes.
+  This update brings Bitcoin Core v28 compatibility to Public Pool, along with a number of other improvements.
 
-  See changes here: https://github.com/benjamin-wilson/public-pool
+  If you have already updated your Bitcoin Node app to v28.0 and Public Pool is not working, this update will fix it.
 defaultPassword: ""
 submitter: smolgrrr
 submission: https://github.com/getumbrel/umbrel-apps/pull/915


### PR DESCRIPTION
This PR updates Public Pool with a fix for Bitcoin Core v28 compatibility:
https://github.com/benjamin-wilson/public-pool/pull/66

Thanks to @remcoros for the fix, @benjamin-wilson for the timely merge, and @sethforprivacy for building and maintaining the docker image.