### PR TITLE
TDEX Provider hotfix

### DIFF
--- a/tdex/exports.sh
+++ b/tdex/exports.sh
@@ -2,6 +2,3 @@ export APP_TDEX_PORT="9092"
 
 daemon_hidden_service_file="${EXPORTS_TOR_DATA_DIR}/app-${EXPORTS_APP_ID}-daemon/hostname"
 export APP_TDEX_DAEMON_HIDDEN_SERVICE="$(cat "${daemon_hidden_service_file}" 2>/dev/null || echo "daemon_not_yet_set.onion")"
-
-# Necessary for the tdexd daemon to be able to write to the volume
-sudo chmod -R 777 "${UMBREL_ROOT}/app-data/tdex/tdex-data"

--- a/tdex/umbrel-app.yml
+++ b/tdex/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: tdex
 category: bitcoin
 name: TDEX Provider
-version: "1.0.1"
+version: "1.0.1-hotfix"
 tagline: Provide liquidity on the TDEX Network, an open protocol to trade Liquid Network assets
 description: >-
   A liquidity provider holds Liquid reserves of both a BASE_ASSET-QUOTE_ASSET in his non-custodial Liquid hot-wallet,
@@ -17,6 +17,12 @@ description: >-
   constant product market-making. In short, this model generates a full order-book based on an initial price for the market.
   Every transaction that occurs on this market will adjust the prices of the market accordingly.
 releaseNotes: >-
+  This is a hotfix release that fixes a bug preventing new installations of the TDEX Provider app from working.
+  
+  
+  Previous 1.0.1 release notes:
+  
+
   🚨 IMPORTANT: Please ensure you have your 24-word recovery phrase written down BEFORE updating.
   This update will require you to restore your wallet from the 24-word recovery phrase.
 


### PR DESCRIPTION
This update removes legacy exports.sh logic that was preventing new installs from completing successfully.