### PR TITLE
Remove ItchySats from app store

### DIFF
--- a/itchysats/umbrel-app.yml
+++ b/itchysats/umbrel-app.yml
@@ -66,3 +66,4 @@ releaseNotes: >-
   Full changelog can be found here: https://github.com/itchysats/itchysats/releases/tag/0.7.0
 submitter: 10101
 submission: https://github.com/getumbrel/umbrel/pull/1149
+disabled: true

--- a/itchysats/umbrel-app.yml
+++ b/itchysats/umbrel-app.yml
@@ -5,6 +5,9 @@ name: ItchySats
 version: "0.7.0"
 tagline: Peer-2-peer derivatives on Bitcoin
 description: >-
+  ⚠️ Removal Notice: The ItchySats project is no longer maintained and is non-functional. For more information, visit the project's GitHub repository.
+
+
   ItchySats enables peer-2-peer CFD trading on Bitcoin using DLCs
   (discreet log contracts). No account needed, no trusted third-party - just you
   and your keys.


### PR DESCRIPTION
The ItchySats project is unmaintained and is now non-functional: https://github.com/get10101/itchysats

```
$ sudo docker logs -f itchysats_web_1
Error: failed to lookup address information: Name or service not known
```

This PR:
- adds `disabled: true` to the app manifest which results in ItchySats not being shown in the app store on umbrelOS >= 1.0
- adds a removal notice to the app description so that umbrelOS 0.5 users are aware that it is no longer functional