### PR TITLE
Remove (temporarily) Specter Desktop from app store

### DIFF
--- a/specter-desktop/umbrel-app.yml
+++ b/specter-desktop/umbrel-app.yml
@@ -1,4 +1,4 @@
-manifestVersion: 1
+manifestVersion: 1.2
 id: specter-desktop
 category: bitcoin
 name: Specter Desktop
@@ -56,3 +56,4 @@ releaseNotes: >-
   This is a large update that takes Specter Desktop from 1.14.5 to 2.0.2! Full release notes and detailed information is available at https://github.com/cryptoadvance/specter-desktop/releases
 submitter: k9ert
 submission: https://github.com/getumbrel/umbrel/pull/339
+disabled: true

--- a/specter-desktop/umbrel-app.yml
+++ b/specter-desktop/umbrel-app.yml
@@ -5,6 +5,9 @@ name: Specter Desktop
 version: "2.0.2"
 tagline: Multisig with hardware wallets made easy
 description: >-
+  ⚠️ Removal Notice: Specter Desktop currently does not work with Bitcoin Core v28. Specter Desktop developers are aware of the issue: https://github.com/cryptoadvance/specter-desktop/issues/2473. 
+
+
   Specter Desktop can be used to connect to the Bitcoin Core running on your Umbrel or an Electrum Server.
   It functions as a watch-only coordinator for multi-signature and single-key
   Bitcoin wallets. At the moment Specter Desktop is working with all major


### PR DESCRIPTION
This PR removes Specter Desktop from the app store, due to a bug that prevents in from working with Bitcoin Core v28:
https://github.com/cryptoadvance/specter-desktop/issues/2473

It can be re-enabled in the app store once a new version of Specter Desktop has been released by the Specter team.

Behaviour for umbrelOS >= 1.0 users: the app will no longer show up in the app store

Behaviour for umbrelOS 0.5 users: the app will show up with a removal notice in the app description. If a user attempts to install the app they will see this error in the UI:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/4348e2a4-8450-49d0-8dc8-7cfca01fee84">
