### PR TITLE
Update Affine to v0.18.0

### DIFF
--- a/affine/docker-compose.yml
+++ b/affine/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_PORT: 3010
 
   web:
-    image: ghcr.io/toeverything/affine-graphql:stable-b052743@sha256:75558480ae13f23e5a8f8f2384a82c37ba18ceff6ab8df70ea0db643d5242776
+    image: ghcr.io/toeverything/affine-graphql:stable-9469b13@sha256:579c20e3b20729088116bea967a779c7f05bdfe07a90e54c1fc97c4a0b149857
     restart: on-failure
     init: true
     command:

--- a/affine/docker-compose.yml
+++ b/affine/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_PORT: 3010
 
   web:
-    image: ghcr.io/toeverything/affine-graphql:stable-9469b13@sha256:579c20e3b20729088116bea967a779c7f05bdfe07a90e54c1fc97c4a0b149857
+    image: ghcr.io/toeverything/affine-graphql:stable-1623f5d@sha256:8d84044e8fe841b756c0e4252466cd5bd481d0c3bac631e9e5e127e589ccede0
     restart: on-failure
     init: true
     command:

--- a/affine/umbrel-app.yml
+++ b/affine/umbrel-app.yml
@@ -3,7 +3,7 @@ id: affine
 name: Affine
 tagline: Open source alternative to Notion, Miro, and Airtable
 category: files
-version: "0.18.0"
+version: "0.18.2"
 port: 3013
 description: >-
   A privacy-focused, local-first, open-source, and ready-to-use alternative for Notion & Miro.

--- a/affine/umbrel-app.yml
+++ b/affine/umbrel-app.yml
@@ -3,7 +3,7 @@ id: affine
 name: Affine
 tagline: Open source alternative to Notion, Miro, and Airtable
 category: files
-version: "0.17.5"
+version: "0.18.0"
 port: 3013
 description: >-
   A privacy-focused, local-first, open-source, and ready-to-use alternative for Notion & Miro.
@@ -36,7 +36,9 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  This is a bugfix release that includes improvements for message attachments.
+  This is a feature release that includes new features and multiple fixes:
+    - Database sort and linked doc improvements
+    - More properties and new settings
 
 
   For full release notes, visit https://github.com/toeverything/AFFiNE/releases


### PR DESCRIPTION
Tried to update to v0.18.1, but there does not seem to be a proper container for it.

Tested on Raspberry Pi 5.