### PR TITLE
Update Torq to v2.1.0

### DIFF
--- a/torq/docker-compose.yml
+++ b/torq/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 7028
 
   web:
-    image: lncapital/torq:2.0.4@sha256:e3debd8d4681fd7b9841b24a004261cc4ac5d8643d5f516117e9451444fac214
+    image: lncapital/torq:2.1.0@sha256:ae21fefde17120d414c5db69857606d52e837204d2e798bd8b9dec3b98ecb93f
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/torq/umbrel-app.yml
+++ b/torq/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: torq
 category: bitcoin
 name: Torq
-version: "v2.0.4"
+version: "v2.1.0"
 tagline: Scalable Node Management Software
 description: >-
   Operating a Lightning node requires a lot of work. You need to monitor your channels, rebalance them, keep track of your fees and much more.
@@ -51,28 +51,24 @@ gallery:
   - 4.jpg
   - 5.jpg
 releaseNotes: >-
-  A lot of improvements have been made in this release. It's hard to cover it all but here are some highlights:
-  
-    - Add advanced outputs table (UTXO management), with the ability to lock/unlock individual outputs.
-    - LND v0.18 support (+ inbound fees)
-    - CLN v24.05 support
-    - Tighter CLN integration via Torq plugin
-    - Fix opening a channel with CLN (missing close-to address)
-    - Fix CLN+LND on-chain transaction import (this will reimport on-chain transactions)
-    - Torq will import transactions + transaction inputs and outputs
-    - We advise to configure bitcoind connection details for extra annotation
-    - Ability to integrate Electrum (for unconfirmed on-chain notification support)
-    - System/workflow variables/templates in workflows
-    - example 1: proportionate fee template: 2000 - ({{Channels.peerGauge}} * 2000)
-    - example 2: dynamic max HTLC amount: {{Channels.localBalance}} / 2
-    - Channel open interceptor workflow (LND and CLN)
-    - Email is now a notification type in workflows (using SMTP)
-    - Ability to trigger a workflow via gRPC (and specify workflow/system variables)
-    - Manual and automatic emergency recovery file / SCB (for CLN and LND)
-    - Automatic includes: email, Github, dropbox, gdrive
-    - Beta feature: (Unauthenticated) Implementation agnostic Torq gRPC
-    - With methods: GetActiveNodes, GetNodeInformation, ConnectPeer, DisconnectPeer, OpenChannel, CloseChannel, SendPayment, CreateInvoice, CreateAddress, TagPeer, TriggerWorkflow, GetOnChainTransactionsByAddress, GetOnChainFeeEstimates, WaitInvoiceSettledByPaymentHash, SubscribeInvoiceStatuses, WaitOnChainTransactionsByAddress, SubscribeOnChainTransactions
-    - Package upgrades
+  v2.1 release notes:
+    - bitcoind wallet as a node type (Torq now has on-chain wallet support for CLN, LND and bitcoind)
+    - bitcoind existing on-chain address listing
+    - management of UTXO locking 
+    - improved transaction output visualizations (and backend)
+    - improve transaction output linking to channels (funding/closing transactions)
+    - LND: sweep transaction output linking to channels
+    - Torq gRPC (BETA feature):
+      - New call SubscribeBlockHeight
+      - New call PayOnChain
+      - New call DecodeInvoice
+      - New call GetInvoiceStatus
+      - We have been streamlining our names in the proto file (so breaking changes)
+    - Various small fixes
+
+  Note 1: There are database migrations in this release so if you want to be able to roll back, you need to create a backup before updating.
+  Note 2: You get the best Torq experience if you specify bitcoind connection details in your configuration file (or command line).
+
 path: ""
 defaultUsername: ""
 deterministicPassword: false


### PR DESCRIPTION
Hi, new update for Torq. Here are the details :)

v2.1 release notes:
 - bitcoind wallet as a node type (Torq now has on-chain wallet support for CLN, LND and bitcoind)
 - bitcoind existing on-chain address listing
 - management of UTXO locking 
 - improved transaction output visualizations (and backend)
 - improve transaction output linking to channels (funding/closing transactions)
 - LND: sweep transaction output linking to channels
 - Torq gRPC (BETA feature):
   - New call SubscribeBlockHeight
   - New call PayOnChain
   - New call DecodeInvoice
   - New call GetInvoiceStatus
   - We have been streamlining our names in the proto file (so breaking changes)
 - Various small fixes

Note 1: There are database migrations in this release so if you want to be able to roll back, you need to create a backup before updating.
Note 2: You get the best Torq experience if you specify bitcoind connection details in your configuration file (or command line).