### PR TITLE
Update Mattermost to v10.3.1

### DIFF
--- a/mattermost/docker-compose.yml
+++ b/mattermost/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
   
   app:
-    image: alexlack/mattermost-app:v10.2.1@sha256:8caaad949601b961d44d4f57d387c5c8a392db992082dbd0916ff0a891aa7c0e
+    image: alexlack/mattermost-app:v10.3.1@sha256:bfc5ffe1362b16f635e4963862b0d9b649f78b7616994c640793cb4d494a99ae
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -30,7 +30,7 @@ services:
       - db
 
   db:
-    image: alexlack/mattermost-db:v10.2.1@sha256:9cc76651b07fb8b4f7bacdf7adec2195ecf9fc4d790ef411140921c972628df0
+    image: alexlack/mattermost-db:v10.3.1@sha256:73580144209dc1402de7c85695664be020625355d799e7c4c9cbd22c6f54360f
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/mattermost/umbrel-app.yml
+++ b/mattermost/umbrel-app.yml
@@ -3,7 +3,7 @@ id: mattermost
 name: Mattermost
 tagline: Team Chat, Open Source, Self-Hosted
 category: social
-version: "10.2.1"
+version: "10.3.1"
 port: 8765
 description: >-
   🚉 Mattermost is an open-source platform designed for secure collaboration throughout the software development lifecycle.
@@ -31,16 +31,25 @@ defaultUsername: ""
 defaultPassword: ""
 dependencies: []
 releaseNotes: >-
-  Mattermost v10.2.1 contains low to medium severity level security fixes. Upgrading to this release is recommended.
+  Mattermost v10.3.1 and v10.3.0 contain multiple new features, improvements, and bug fixes.
 
 
-  Other updates:
+  Key Updates:
 
-  - Fixed an issue where plugin settings got wiped if the plugin declared some of its fields as secrets MM-61441.
+  - New draft messages view
 
-  - Pre-packaged Calls plugin v1.3.2.
+  - Copilot plugin enabled by default
 
-  - Contains no database or functional changes.
+  - Updated minimum Edge and Chrome versions to 130+
+
+  - Classic Mobile App deprecated—upgrade to v2 Mobile App
+
+
+  Fixes:
+
+  - Improved Desktop App performance, post drafts, and status syncing
+
+  - Fixed user status syncing and search input accessibility issues
 
 
   Full release notes are available at https://docs.mattermost.com/about/mattermost-v10-changelog.html


### PR DESCRIPTION
Tested update and install on Raspberry Pi 5 and Umbrel Home.