### PR TITLE
Remove Nitter

### DIFF
--- a/nitter/umbrel-app.yml
+++ b/nitter/umbrel-app.yml
@@ -70,3 +70,4 @@ releaseNotes: >
   - Uppercase HLS in preference description
 submitter: Jasper
 submission: https://github.com/getumbrel/umbrel-apps/pull/128
+disabled: true

--- a/nitter/umbrel-app.yml
+++ b/nitter/umbrel-app.yml
@@ -5,6 +5,9 @@ name: Nitter
 version: "38985af"
 tagline: Browse Twitter without tracking or ads
 description: >
+  ⚠️ Removal Notice: The Nitter project is no longer maintained and is non-functional due to changes in X's API. For more information, visit the project's GitHub repository.
+
+
   Nitter is a free and open source alternative Twitter front-end focused on privacy and performance.
 
 


### PR DESCRIPTION
The Nitter project is unmaintained and is now non-functional due to changes in X's API: 
https://github.com/zedeus/nitter/issues/919

This PR:
- adds `disabled: true` to the app manifest which results in Nitter not being shown in the app store on umbrelOS >= 1.0
- adds a removal notice to the app description so that umbrelOS 0.5 users are aware that it is no longer functional

This does not remove existing installs of Nitter.