### PR TITLE
App Submission: Open WebUI

### DIFF
--- a/open-webui/docker-compose.yml
+++ b/open-webui/docker-compose.yml
@@ -22,5 +22,5 @@ services:
     depends_on:
       - ollama
     environment:
-      - 'OLLAMA_BASE_URL=http://ollama:11434'
+      OLLAMA_BASE_URL: "http://open-webui_ollama_1:11434"
     restart: on-failure

--- a/open-webui/docker-compose.yml
+++ b/open-webui/docker-compose.yml
@@ -1,6 +1,12 @@
 version: '3.6'
 
 services:
+  app_proxy:
+    environment:
+      APP_HOST: open-webui_web_1
+      APP_PORT: 8080
+      PROXY_AUTH_ADD: "false"
+
   ollama:
     image: ollama/ollama:0.5.4@sha256:18bfb1d605604fd53dcad20d0556df4c781e560ebebcd923454d627c994a0e37
     volumes:
@@ -9,14 +15,12 @@ services:
       - 11434:11434
     restart: on-failure
 
-  open-webui:
+  web:
     image: ghcr.io/open-webui/open-webui:v0.4.8@sha256:c1e4f0927fb0acd53bcbd8bbc92ecaf7ca36a23ee4cb8f25ce90c541012a473a
     volumes:
       - ${APP_DATA_DIR}/data/open-webui:/app/backend/data
     depends_on:
       - ollama
-    ports:
-      - 2876:8080
     environment:
       - 'OLLAMA_BASE_URL=http://ollama:11434'
     restart: on-failure

--- a/open-webui/docker-compose.yml
+++ b/open-webui/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   ollama:
-    image: ollama/ollama:0.5.4@sha256:18bfb1d605604fd53dcad20d0556df4c781e560ebebcd923454d627c994a0e37
+    image: ollama/ollama:0.5.7@sha256:7e672211886f8bd4448a98ed577e26c816b9e8b052112860564afaa2c105800e
     volumes:
       - ${APP_DATA_DIR}/data/ollama:/root/.ollama
     # We could uncomment this if we want to expose the ollama port to the host for other external apps/programs to use. 
@@ -17,7 +17,7 @@ services:
     restart: on-failure
 
   web:
-    image: ghcr.io/open-webui/open-webui:v0.5.4@sha256:42e8fa544facc38d731e3d516fbf478abe435bb4b80798e0934930afea6c5bab
+    image: ghcr.io/open-webui/open-webui:v0.5.7@sha256:b9a3425659236186df16ccf4432a247a353e54dec9549fb475d8b57f0c29a93d
     volumes:
       - ${APP_DATA_DIR}/data/open-webui:/app/backend/data
     depends_on:

--- a/open-webui/docker-compose.yml
+++ b/open-webui/docker-compose.yml
@@ -12,5 +12,7 @@ services:
     volumes:
       - ${APP_DATA_DIR}/data/open-webui:/app/backend/data
     environment:
+      # Exported from ollama app, which is currently a required dependency.
+      # This will need to change once optional dependencies are supported.
       OLLAMA_BASE_URL: $APP_OLLAMA_URL
     restart: on-failure

--- a/open-webui/docker-compose.yml
+++ b/open-webui/docker-compose.yml
@@ -11,8 +11,9 @@ services:
     image: ollama/ollama:0.5.4@sha256:18bfb1d605604fd53dcad20d0556df4c781e560ebebcd923454d627c994a0e37
     volumes:
       - ${APP_DATA_DIR}/data/ollama:/root/.ollama
-    ports:
-      - 11434:11434
+    # We could uncomment this if we want to expose the ollama port to the host for other external apps/programs to use. 
+    # ports:
+    #   - 11434:11434
     restart: on-failure
 
   web:

--- a/open-webui/docker-compose.yml
+++ b/open-webui/docker-compose.yml
@@ -7,21 +7,10 @@ services:
       APP_PORT: 8080
       PROXY_AUTH_ADD: "false"
 
-  ollama:
-    image: ollama/ollama:0.5.7@sha256:7e672211886f8bd4448a98ed577e26c816b9e8b052112860564afaa2c105800e
-    volumes:
-      - ${APP_DATA_DIR}/data/ollama:/root/.ollama
-    # We could uncomment this if we want to expose the ollama port to the host for other external apps/programs to use. 
-    # ports:
-    #   - 11434:11434
-    restart: on-failure
-
   web:
     image: ghcr.io/open-webui/open-webui:v0.5.7@sha256:b9a3425659236186df16ccf4432a247a353e54dec9549fb475d8b57f0c29a93d
     volumes:
       - ${APP_DATA_DIR}/data/open-webui:/app/backend/data
-    depends_on:
-      - ollama
     environment:
-      OLLAMA_BASE_URL: "http://open-webui_ollama_1:11434"
+      OLLAMA_BASE_URL: $APP_OLLAMA_URL
     restart: on-failure

--- a/open-webui/docker-compose.yml
+++ b/open-webui/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.6'
+
+services:
+  ollama:
+    image: ollama/ollama:0.5.4@sha256:18bfb1d605604fd53dcad20d0556df4c781e560ebebcd923454d627c994a0e37
+    volumes:
+      - ${APP_DATA_DIR}/data/ollama:/root/.ollama
+    ports:
+      - 11434:11434
+    restart: on-failure
+
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:v0.4.8@sha256:c1e4f0927fb0acd53bcbd8bbc92ecaf7ca36a23ee4cb8f25ce90c541012a473a
+    volumes:
+      - ${APP_DATA_DIR}/data/open-webui:/app/backend/data
+    depends_on:
+      - ollama
+    ports:
+      - 2876:8080
+    environment:
+      - 'OLLAMA_BASE_URL=http://ollama:11434'
+    restart: on-failure

--- a/open-webui/docker-compose.yml
+++ b/open-webui/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.6'
+version: '3.7'
 
 services:
   app_proxy:

--- a/open-webui/docker-compose.yml
+++ b/open-webui/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     restart: on-failure
 
   web:
-    image: ghcr.io/open-webui/open-webui:v0.4.8@sha256:c1e4f0927fb0acd53bcbd8bbc92ecaf7ca36a23ee4cb8f25ce90c541012a473a
+    image: ghcr.io/open-webui/open-webui:v0.5.4@sha256:42e8fa544facc38d731e3d516fbf478abe435bb4b80798e0934930afea6c5bab
     volumes:
       - ${APP_DATA_DIR}/data/open-webui:/app/backend/data
     depends_on:

--- a/open-webui/umbrel-app.yml
+++ b/open-webui/umbrel-app.yml
@@ -15,10 +15,13 @@ description: >-
   🦙 Install Ollama: Start by installing the Ollama app from the Umbrel App Store. Ollama enables you to download and run large language models like Llama 3 and DeepSeek-R1 directly on your device.
 
 
-  ⬇️    Download a Model: In the Open WebUI app, type the name of the model you want in the search bar and click “Pull from Ollama.com.” A full list of models is available at https://ollama.com/.
+  ⬇️ Download a Model: In the Open WebUI app, type the name of the model you want in the search bar and click “Pull from Ollama.com.” A full list of models is available at https://ollama.com/.
 
 
-  🤖    Example - Running DeepSeek-R1 1.5B: To use the DeepSeek-R1 model with 1.5 billion parameters, type deepseek-r1:1.5b in the search bar and start the download. Once it's ready, you can chat with the model directly in Open WebUI.
+  🤖 Example - Running DeepSeek-R1 1.5B: To use the DeepSeek-R1 model with 1.5 billion parameters, type deepseek-r1:1.5b in the search bar and start the download. Once it's ready, you can chat with the model directly in Open WebUI.
+
+
+  ⚠️ Warning: Before running a model, make sure your device has enough free RAM to support it. Attempting to run a model that exceeds your available memory could cause your device to crash or become unresponsive. Always check the model requirements before downloading or starting it.
 developer: Open WebUI
 website: https://openwebui.com/
 submitter: al-lac

--- a/open-webui/umbrel-app.yml
+++ b/open-webui/umbrel-app.yml
@@ -3,7 +3,7 @@ id: open-webui
 name: Open WebUI
 tagline: User-friendly AI Interface
 category: ai
-version: "0.5.4"
+version: "0.5.7"
 port: 2876
 description: >-
   🌐 Open WebUI is an extensible, feature-rich, and user-friendly self-hosted WebUI designed to operate entirely offline.

--- a/open-webui/umbrel-app.yml
+++ b/open-webui/umbrel-app.yml
@@ -3,7 +3,7 @@ id: open-webui
 name: Open WebUI
 tagline: User-friendly AI Interface
 category: ai
-version: "0.4.8"
+version: "0.5.4"
 port: 2876
 description: >-
   🌐 Open WebUI is an extensible, feature-rich, and user-friendly self-hosted WebUI designed to operate entirely offline.

--- a/open-webui/umbrel-app.yml
+++ b/open-webui/umbrel-app.yml
@@ -12,11 +12,12 @@ description: >-
   🤖 It supports various LLM runners, including Ollama and OpenAI-compatible APIs.
 
 
-  🦙 This app comes packaged with [Ollama](https://ollama.com/) pre-configured to work out of the box. 
+  🦙 This app has [Ollama](https://ollama.com/) as a requirement and pre-configured so you can easily get started with your own local AI. 
   
+
   To start downloading models via Ollama, simply type in a model name in the model search bar and click "Pull from Ollama.com".
   A list of models can be found at https://ollama.com/search.
-developer: Ollama
+developer: Open WebUI
 website: https://openwebui.com/
 submitter: al-lac
 submission: https://github.com/getumbrel/umbrel-apps/pull/1977
@@ -28,6 +29,7 @@ gallery:
   - 3.jpg
 defaultUsername: ""
 defaultPassword: ""
-dependencies: []
+dependencies:
+  - ollama
 releaseNotes: ""
 path: ""

--- a/open-webui/umbrel-app.yml
+++ b/open-webui/umbrel-app.yml
@@ -8,11 +8,14 @@ port: 2876
 description: >-
   🌐 Open WebUI is an extensible, feature-rich, and user-friendly self-hosted WebUI designed to operate entirely offline.
 
-  
-  🤖 It supports various LLM runners, including Ollama and OpenAI-compatible APIs.
-  
 
-  🦙 This app comes with ollama pre-installed and configured to run on port 11434.
+  🤖 It supports various LLM runners, including Ollama and OpenAI-compatible APIs.
+
+
+  🦙 This app comes packaged with [Ollama](https://ollama.com/) pre-configured to work out of the box. 
+  
+  To start downloading models via Ollama, simply type in a model name in the model search bar and click "Pull from Ollama.com".
+  A list of models can be found at https://ollama.com/search.
 developer: Ollama
 website: https://openwebui.com/
 submitter: al-lac

--- a/open-webui/umbrel-app.yml
+++ b/open-webui/umbrel-app.yml
@@ -1,0 +1,25 @@
+manifestVersion: 1
+id: open-webui
+name: Open WebUI
+tagline: User-friendly AI Interface
+category: ai
+version: "0.4.8"
+port: 2876
+description: >-
+  🌐 Open WebUI is an extensible, feature-rich, and user-friendly self-hosted WebUI designed to operate entirely offline. 
+  
+  🤖 It supports various LLM runners, including Ollama and OpenAI-compatible APIs.
+
+  🦙 This app comes with ollama pre-installed and configured to run on port 11434.
+developer: Ollama
+website: https://openwebui.com/
+submitter: al-lac
+submission: https://github.com/getumbrel/umbrel-apps/pull/1977
+repo: https://github.com/open-webui/open-webui
+support: https://github.com/open-webui/open-webui/issues
+gallery: []
+defaultUsername: ""
+defaultPassword: ""
+dependencies: []
+releaseNotes: ""
+path: ""

--- a/open-webui/umbrel-app.yml
+++ b/open-webui/umbrel-app.yml
@@ -6,9 +6,11 @@ category: ai
 version: "0.4.8"
 port: 2876
 description: >-
-  🌐 Open WebUI is an extensible, feature-rich, and user-friendly self-hosted WebUI designed to operate entirely offline. 
+  🌐 Open WebUI is an extensible, feature-rich, and user-friendly self-hosted WebUI designed to operate entirely offline.
+
   
   🤖 It supports various LLM runners, including Ollama and OpenAI-compatible APIs.
+  
 
   🦙 This app comes with ollama pre-installed and configured to run on port 11434.
 developer: Ollama

--- a/open-webui/umbrel-app.yml
+++ b/open-webui/umbrel-app.yml
@@ -6,17 +6,19 @@ category: ai
 version: "0.5.7"
 port: 2876
 description: >-
-  🌐 Open WebUI is an extensible, feature-rich, and user-friendly self-hosted WebUI designed to operate entirely offline.
+  Open WebUI lets you chat with advanced AI models running locally on your own device or connect to online models using an API key.
 
 
-  🤖 It supports various LLM runners, including Ollama and OpenAI-compatible APIs.
+  **Getting Started with Local AI Models:**
 
 
-  🦙 This app has [Ollama](https://ollama.com/) as a requirement and pre-configured so you can easily get started with your own local AI. 
-  
+  🦙 Install Ollama: Start by installing the Ollama app from the Umbrel App Store. Ollama enables you to download and run large language models like Llama 3 and DeepSeek-R1 directly on your device.
 
-  To start downloading models via Ollama, simply type in a model name in the model search bar and click "Pull from Ollama.com".
-  A list of models can be found at https://ollama.com/search.
+
+  ⬇️    Download a Model: In the Open WebUI app, type the name of the model you want in the search bar and click “Pull from Ollama.com.” A full list of models is available at https://ollama.com/.
+
+
+  🤖    Example - Running DeepSeek-R1 1.5B: To use the DeepSeek-R1 model with 1.5 billion parameters, type deepseek-r1:1.5b in the search bar and start the download. Once it's ready, you can chat with the model directly in Open WebUI.
 developer: Open WebUI
 website: https://openwebui.com/
 submitter: al-lac

--- a/open-webui/umbrel-app.yml
+++ b/open-webui/umbrel-app.yml
@@ -22,7 +22,10 @@ submitter: al-lac
 submission: https://github.com/getumbrel/umbrel-apps/pull/1977
 repo: https://github.com/open-webui/open-webui
 support: https://github.com/open-webui/open-webui/issues
-gallery: []
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
 defaultUsername: ""
 defaultPassword: ""
 dependencies: []


### PR DESCRIPTION
# App Submission

Open WebUI

@nmfretz It could make sense to split ollama into a separate app. But it has no UI other than showing that it is running when you access the port.

Both parts do not work properly without the root user.

### 256x256 SVG icon

https://filetransfer.io/data-package/N7NbYURd#link

### Gallery images

![open-webui-1](https://github.com/user-attachments/assets/79bd0802-5b0b-4751-a855-08b1a7ca947c)
![open-webui-2](https://github.com/user-attachments/assets/ce4f053b-f366-47a2-8bea-70bf80cd0148)
![open-webui-3](https://github.com/user-attachments/assets/d0234b5e-aad4-40b0-bf1e-91ae8ec33cef)
![open-webui-4](https://github.com/user-attachments/assets/986b30a3-e097-4bea-b158-692463de15de)

### I have tested my app on:
- [x] umbrelOS on a Raspberry Pi
- [x] umbrelOS on an Umbrel Home
- [x] umbrelOS on Linux VM