### PR TITLE
Update pocketbase to version 0.23.12 and create initial superuser

### DIFF
--- a/pocketbase/data/migrations/initial_superuser.js
+++ b/pocketbase/data/migrations/initial_superuser.js
@@ -1,0 +1,22 @@
+// https://pocketbase.io/docs/js-migrations/#creating-initial-superuser
+// pb_migrations/1687801090_initial_superuser.js
+
+migrate((app) => {
+  let superusers = app.findCollectionByNameOrId("_superusers")
+
+  let record = new Record(superusers)
+
+  // note: the values can be eventually loaded via $os.getenv(key)
+  // or from a special local config file
+  record.set("email", "umbrel@umbrel.local")
+  record.set("password", "umbrel-pocketbase")
+
+  app.save(record)
+}, (app) => { // optional revert operation
+  try {
+      let record = app.findAuthRecordByEmail("_superusers", "umbrel@umbrel.local")
+      app.delete(record)
+  } catch {
+      // silent errors (probably already deleted)
+  }
+})

--- a/pocketbase/docker-compose.yml
+++ b/pocketbase/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
   
   app:
-    image: ghcr.io/muchobien/pocketbase:0.23.7@sha256:782f35e9f518f8b12152dca355de666f54002a3822765ff518dbcb21b0f8d0e8
+    image: ghcr.io/muchobien/pocketbase:0.23.12@sha256:ceaa734390fd0a83ac795fe99e22b6481bc757b45ef016234f2b56ea43fc9209
     # pocketbase needs to run as root
     # user: "1000:1000"
     restart: on-failure
@@ -17,3 +17,4 @@ services:
       - ${APP_DATA_DIR}/data/data:/pb_data
       - ${APP_DATA_DIR}/data/public:/pb_public
       - ${APP_DATA_DIR}/data/hooks:/pb_hooks
+      - ${APP_DATA_DIR}/data/migrations:/pb_migrations

--- a/pocketbase/umbrel-app.yml
+++ b/pocketbase/umbrel-app.yml
@@ -3,7 +3,7 @@ id: pocketbase
 name: PocketBase
 tagline: Open Source backend for your next SaaS and Mobile app in 1 file
 category: developer
-version: "0.23.7"
+version: "0.23.12"
 port: 5400
 description: >-
   PocketBase is an open source backend consisting of embedded database (SQLite) with realtime subscriptions, built-in auth management, convenient dashboard UI and simple REST-ish API.
@@ -29,6 +29,8 @@ description: >-
   Use as a standalone app OR as a framework, that you can extend via Go and JavaScript hooks to create your own custom portable backend.
 developer: PocketBase
 website: https://pocketbase.io/
+defaultUsername: "umbrel@umbrel.local"
+defaultPassword: "umbrel-pocketbase"
 submitter: Sharknoon
 submission: https://github.com/getumbrel/umbrel-apps/pull/1082
 repo: https://github.com/pocketbase/pocketbase
@@ -41,10 +43,15 @@ gallery:
 path: /_/
 dependencies: []
 releaseNotes: >-
-  This release includes improvements to error handling and stability:
-    - Fixed issues with JavaScript error handling
-    - Enhanced system reliability
-    - Improved overall performance
+  ⚠️ This release includes a security fix for email template handling. If you use custom mail templates with user-provided content, please update immediately.
+
+
+  Key improvements in this release:
+    - Fixed a security vulnerability in email template handling
+    - Enhanced system stability and performance
+    - Improved error handling
+    - Added version mismatch warning logs for SQLite dependencies
+    - Removed file size restrictions for backup uploads
 
 
   Full release notes are found at https://github.com/pocketbase/pocketbase/releases

--- a/pocketbase/umbrel-app.yml
+++ b/pocketbase/umbrel-app.yml
@@ -46,6 +46,9 @@ releaseNotes: >-
   ⚠️ This release includes a security fix for email template handling. If you use custom mail templates with user-provided content, please update immediately.
 
 
+  🔐 Login Credentials: This update includes default admin credentials for new app installations. These credentials can and should be changed after first login. Existing users will not be affected and will continue to use their existing credentials.
+
+
   Key improvements in this release:
     - Fixed a security vulnerability in email template handling
     - Enhanced system stability and performance


### PR DESCRIPTION
This PR updates pocketbase to version 0.23.12 and creates the initial superuser with a migration script.

Due to changes made to pocketbase starting with version 0.23, the intial superuser creation has to happen via the cli, the URL that is shown on the terminal or a migration script. See: https://github.com/pocketbase/pocketbase/discussions/5814

Tested both an upgrade and a fresh install on the Raspberry Pi 5 and Umbrel Home.

Existing users / admins will not be touched.

Closes #1969 