### PR TITLE
lightning-terminal: update to v0.14.0-alpha

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.13.6-alpha@sha256:56e5aeb55164319c0d624f053dbcd2e5271fcaf5df875a4206d520a29bfdf3c3
+    image: lightninglabs/lightning-terminal:v0.14.0-alpha@sha256:1fec11bdf96a1c628f29b8f6f106decebc68d03b1bf240779d419290a003aa95
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.13.6-alpha"
+version: "0.14.0-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -56,7 +56,8 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  This release of Lightning Terminal (LiT) is a hotfix for LiT v0.13.5-alpha, which updated the integrated Loop daemon.
+  This release of Lightning Terminal (LiT) ships the first non-experimental version of Taproot Asset Channels! It also
+  updates the integrated LND and Loop daemons.
 
 
   IMPORTANT NOTE: To avoid loss of funds, it's imperative that you read the
@@ -94,7 +95,7 @@ releaseNotes: >-
   feedback from the community.
 
 
-  This release packages LND v0.18.3-beta, Taproot Assets Daemon v0.4.1-alpha,
-  Loop v0.28.8-beta, Pool v0.6.4-beta and Faraday v0.2.13-alpha.
+  This release packages LND v0.18.4-beta, Taproot Assets Daemon v0.5.0-alpha,
+  Loop v0.29.0-beta, Pool v0.6.4-beta and Faraday v0.2.13-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
In this PR we bump Litd to v0.14.0-alpha. Apologies for the delay of the update over the holidays. 

See the release notes here: https://github.com/lightninglabs/lightning-terminal/blob/master/docs/release-notes/release-notes-0.14.0.md

Happy to address any feedback if needed :)!