### PR TITLE
Re-enable Specter desktop

### DIFF
--- a/specter-desktop/docker-compose.yml
+++ b/specter-desktop/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 25441
 
   web:
-    image: lncm/specter-desktop:v2.0.2@sha256:aeda6dfaa3f82c7bd3e1c6ba61388df02bd0c22a59412d2bbed3c792fb0b3702
+    image: lncm/specter-desktop:v2.1.1@sha256:cc3c718086efa4a906e0d6178e14288484cdf69c48d29becb58b8efd8524c5ef
     stop_signal: SIGINT
     restart: on-failure
     stop_grace_period: 1m

--- a/specter-desktop/umbrel-app.yml
+++ b/specter-desktop/umbrel-app.yml
@@ -1,14 +1,11 @@
-manifestVersion: 1.2
+manifestVersion: 1
 id: specter-desktop
 category: bitcoin
 name: Specter Desktop
-version: "2.0.2"
+version: "2.1.2"
 tagline: Multisig with hardware wallets made easy
 description: >-
-  ⚠️ Removal Notice: Specter Desktop currently does not work with Bitcoin Core v28. Specter Desktop developers are aware of the issue: https://github.com/cryptoadvance/specter-desktop/issues/2473. 
-
-
-  Specter Desktop can be used to connect to the Bitcoin Core running on your Umbrel or an Electrum Server.
+  Specter Desktop can be used to connect to an Electrum Server.
   It functions as a watch-only coordinator for multi-signature and single-key
   Bitcoin wallets. At the moment Specter Desktop is working with all major
   hardware wallets including:
@@ -56,7 +53,6 @@ releaseNotes: >-
   ⚠️ As usual, please create a full backup of Specter before updating by going to Settings in the app and clicking "Download Specter backup (zip file).
 
 
-  This is a large update that takes Specter Desktop from 1.14.5 to 2.0.2! Full release notes and detailed information is available at https://github.com/cryptoadvance/specter-desktop/releases
+  This is a large update that takes Specter Desktop from 2.0.2 to 2.1.1! Full release notes and detailed information is available at https://github.com/cryptoadvance/specter-desktop/releases
 submitter: k9ert
 submission: https://github.com/getumbrel/umbrel/pull/339
-disabled: true

--- a/specter-desktop/umbrel-app.yml
+++ b/specter-desktop/umbrel-app.yml
@@ -5,7 +5,7 @@ name: Specter Desktop
 version: "2.1.2"
 tagline: Multisig with hardware wallets made easy
 description: >-
-  Specter Desktop can be used to connect to an Electrum Server.
+  Specter Desktop can be used to connect to the Bitcoin Core running on your Umbrel or an Electrum Server.
   It functions as a watch-only coordinator for multi-signature and single-key
   Bitcoin wallets. At the moment Specter Desktop is working with all major
   hardware wallets including:

--- a/specter-desktop/umbrel-app.yml
+++ b/specter-desktop/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: specter-desktop
 category: bitcoin
 name: Specter Desktop
-version: "2.1.2"
+version: "2.1.1"
 tagline: Multisig with hardware wallets made easy
 description: >-
   Specter Desktop can be used to connect to the Bitcoin Core running on your Umbrel or an Electrum Server.


### PR DESCRIPTION
Reverts #1743 and updates to the latest Specter, which is compatible with Bitcoin Core 28.