### PR TITLE
App Submission: LNbits Holesail Proxy

### DIFF
--- a/lnbits-holesail-proxy/docker-compose.yml
+++ b/lnbits-holesail-proxy/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: lnbits-holesail-proxy_web_1
+      APP_PORT: 3107
+  web:
+    image: orenz0/holesail-server-manager:v1.0.7@sha256:23782c148dd09ff20ab70d06fc116afd7d8adc6e5679c682c5f944ef1d305b9b
+    restart: on-failure
+    stop_grace_period: 1m
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+    environment:
+      HSM_DATA_FILE: /data/hsm.json
+      HSM_HOST: 0.0.0.0
+      HSM_PORT: 3107
+      HSM_TITLE: LNbits Holesail Proxy
+      HSM_TARGET_ADDRESS: lnbits_web_1
+      HSM_TARGET_PORT: 3007

--- a/lnbits-holesail-proxy/umbrel-app.yml
+++ b/lnbits-holesail-proxy/umbrel-app.yml
@@ -1,0 +1,25 @@
+manifestVersion: 1
+id: lnbits-holesail-proxy
+category: bitcoin
+name: LNbits Holesail Proxy
+version: "1.0.7"
+tagline: A Holesail proxy to connect remotely to your LNbits
+description: >-
+  Running Umbrel behind a home router (NAT) without a public domain?
+  TOR is too slow?
+  This app will allow you (and your friends) to connect remotely to your LNbits, using a Holesail - an instant P2P tunnel to bypass any network, firewall, NAT restrictions.
+  Note: The tunnel only works when the client side is running from outside the local network (which is the main use case of this app).
+releaseNotes: ""
+developer: oren-z0
+website: https://github.com/oren-z0/holesail-server-manager
+dependencies:
+  - lnbits
+repo: https://github.com/oren-z0/holesail-server-manager
+support: https://github.com/oren-z0/holesail-server-manager/discussions
+port: 3107
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: oren-z0
+submission: https://github.com/getumbrel/umbrel-apps/pull/2007

--- a/lnbits-holesail-proxy/umbrel-app.yml
+++ b/lnbits-holesail-proxy/umbrel-app.yml
@@ -6,8 +6,12 @@ version: "1.0.7"
 tagline: A Holesail proxy to connect remotely to your LNbits
 description: >-
   Running Umbrel behind a home router (NAT) without a public domain?
+
   TOR is too slow?
+
   This app will allow you (and your friends) to connect remotely to your LNbits, using a Holesail - an instant P2P tunnel to bypass any network, firewall, NAT restrictions.
+
+  
   Note: The tunnel only works when the client side is running from outside the local network (which is the main use case of this app).
 releaseNotes: ""
 developer: oren-z0

--- a/lnbits-holesail-proxy/umbrel-app.yml
+++ b/lnbits-holesail-proxy/umbrel-app.yml
@@ -21,7 +21,10 @@ dependencies:
 repo: https://github.com/oren-z0/holesail-server-manager
 support: https://github.com/oren-z0/holesail-server-manager/discussions
 port: 3107
-gallery: []
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
 path: ""
 defaultUsername: ""
 defaultPassword: ""


### PR DESCRIPTION
# App Submission

I want to mention that I'm not part of either https://lnbits.com or https://holesail.io . I just found Holesail as a very useful way to connect to my LNbits remotely even if it runs behind NAT  - without the overhead of TOR.

Notice the first commit that makes changes to the LNbits app submission in order to expose its port to the holesail proxy.
Since LNbits work on port 3007, I think it would be nice if the proxy worked on port 3107 (and likewise, if we implement similar proxies for other apps, we could have the proxy management port number to be the app port number + 100).
LNbits should also have a fixed ip address, exposed to the proxy.

### App name
LNbits Holesail Proxy

### 256x256 SVG icon
I only have a png for the holesail.io logo. I think a good icon would combine the logos of LNbits and Holesail like this:
![logo](https://github.com/user-attachments/assets/54ddbf58-3c89-4fe7-bf45-61b6aa163440)

### Gallery images

![Screenshot 2025-01-04 at 2 33 12](https://github.com/user-attachments/assets/25ab4a2f-30a6-48a9-a3cb-2564e217ef36)
![Screenshot 2025-01-04 at 2 33 27](https://github.com/user-attachments/assets/bead1bbe-6ed4-4606-a5ee-ab4e73ca16b0)
![Screenshot 2025-01-04 at 2 33 31](https://github.com/user-attachments/assets/9c5a7abb-f2d7-4a88-b5d0-904031f93a6b)
![Screenshot 2025-01-04 at 2 31 14](https://github.com/user-attachments/assets/f2a733d5-29c6-4ced-8544-9f6507e7e384)

### I have tested my app on:
- [v] umbrelOS on a Raspberry Pi
- [ ] umbrelOS on an Umbrel Home
- [ ] umbrelOS on Linux VM

