### PR TITLE
Update homebox to version 0.17.1

### DIFF
--- a/homebox/docker-compose.yml
+++ b/homebox/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       APP_PORT: 7745
     
   web:
-    image: ghcr.io/sysadminsmedia/homebox:0.15.2-rootless@sha256:ee0b4d807e330f2bae6e24aec1c3093dce06dab3b8f1434564f286cd07649d07
+    image: ghcr.io/sysadminsmedia/homebox:0.17.1-rootless@sha256:91a4082624b621cc850192b00b07af840dd3b1c2c454f151ec8bb5d506deae25
     restart: on-failure
     user: 1000:1000
     environment:

--- a/homebox/umbrel-app.yml
+++ b/homebox/umbrel-app.yml
@@ -3,7 +3,7 @@ id: homebox
 name: HomeBox
 tagline: An inventory and organization system built for the home user
 category: files
-version: "0.15.2"
+version: "0.17.1"
 port: 7745
 description: >-
   Homebox is an inventory and organization system built for the home user! With a focus on simplicity and ease of use, Homebox is the perfect solution for your home inventory, organization, and management needs. 
@@ -24,9 +24,19 @@ torOnly: false
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Development of HomeBox has been taken over by SysAdmins Media, since the original developer is no longer maintaining the project.
-  More information can be found at https://github.com/sysadminsmedia/homebox
+  ⚠️ Important security update that fixes vulnerabilities in go dependencies
 
+
+  This release includes several new features and fixes:
+
+    - Added offline mode support so you can use the app without internet
+    - Copy item links with one click
+    - Easily create and add labels to items
+    - Added different types of measurement units for labels
+    - Improved location sorting and display
+    - Items now show their labels in the details view
+    - Export files now include timestamps
+    - Various bug fixes and performance improvements, including better text wrapping and currency handling
 
   Full release notes can be found at https://github.com/sysadminsmedia/homebox/releases
 submitter: Xosten


### PR DESCRIPTION
The split between architectures was finally fixed in sysadminsmedia/homebox#365 🎉 

Tested update and fresh install on Raspberry Pi 5 and Umbrel Home.