### PR TITLE
Samourai Server hotfix

### DIFF
--- a/samourai-server/docker-compose.yml
+++ b/samourai-server/docker-compose.yml
@@ -24,7 +24,8 @@ services:
         ipv4_address: $APP_SAMOURAI_SERVER_DB_IP
 
   node:
-    image: louneskmt/dojo-nodejs:1.16.1@sha256:49de92774ecfcb88af1dc67f8d498641d750c4ec9acaab3c448d70c4f2d4bfe7
+    # image: louneskmt/dojo-nodejs:1.16.1@sha256:49de92774ecfcb88af1dc67f8d498641d750c4ec9acaab3c448d70c4f2d4bfe7
+    image: nmfretz/dojo-nodejs:1.16.1-rpcfix@sha256:bd047ed34e04b605c662c94ed5819322c0db65b6e3425acd3607486ef28a83ce
     init: true
     restart: on-failure
     command: "/home/node/app/wait-for-it.sh ${APP_SAMOURAI_SERVER_DB_IP}:3306 --timeout=720 --strict -- /home/node/app/restart.sh"

--- a/samourai-server/umbrel-app.yml
+++ b/samourai-server/umbrel-app.yml
@@ -2,9 +2,12 @@ manifestVersion: 1.1
 id: samourai-server
 category: bitcoin
 name: Samourai Server
-version: "1.16.1-hotfix-3"
+version: "1.16.1-hotfix-4"
 tagline: Your private backing server for Samourai Wallet
 description: >-
+  ⚠️ Whirlpool functionality no longer works due to the shutdown of Samourai's Whirlpool coordinator. Dojo functionality is unaffected.
+
+
   Samourai Server is an exclusive Umbrel app that runs Samourai Dojo
   and Whirlpool backing servers, and provides you easy step-by-step instructions
   to connect your Samourai Wallet to them. Samourai Wallet is unrivaled in
@@ -32,6 +35,9 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  This update fixes a bug where users could not connect using Whirlpool GUI
+  This update fixes a bug where Samourai Server could not connect to Bitcoin Core v28.0.
+
+
+  Note that Whirlpool functionality no longer works due to the shutdown of Samourai's Whirlpool coordinator. Dojo functionality is unaffected.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/461


### PR DESCRIPTION
This is a hotfix for the dojo-node container. It fixes an issue with the now unmaintained https://github.com/vansergen/rpc-bitcoin library which does not conform to the strict sanity check that Bitcoin Core v28.0 now carries out to determine which JSON-RPC behaviour to follow (version "1.0" vs version "2.0").

Fix: https://github.com/nmfretz/umbrel-samourai-dojo/commit/e8e439ae1f4931b7f28e6f1aeb208df704f67255

As of April 2024 Whirlpool functionality no longer works due to the shutdown of Samourai's Whirlpool coordinator. Dojo functionality is unaffected. 

This app should be updated to the latest Dojo version and Whirlpool should be removed. The current structure of this app means that this is not a quick fix. Current dojo repo:
https://github.com/Dojo-Open-Source-Project/samourai-dojo

I have tested on x86 and arm64, both fresh install and app update.  I installed Samourai Wallet via APK on an android and successfully connected to Dojo running on umbrelOS.