### PR TITLE
Update btcpay-server to v2.0.5

### DIFF
--- a/btcpay-server/docker-compose.yml
+++ b/btcpay-server/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.5.12@sha256:0ec6bd81802773bb16f162aad430be7bd0bb4e57b6786414c86d0e870faab734
+    image: nicolasdorier/nbxplorer:2.5.17@sha256:d3a882a32df61d7de3ac802c65f47718b1e9ddea09bf29d7a108871eb815b43c
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       NBXPLORER_BTCHASTXINDEX: 1
 
   web:
-    image: btcpayserver/btcpayserver:2.0.3@sha256:4532240e9b3735bfeb8fbdc188dd6f93849647462939a92dca2a81f169a5b236
+    image: btcpayserver/btcpayserver:2.0.5@sha256:14dc2f6ca638d126f17d53d7bfa89c798b82f241b9307c113a84b29df8481ab6
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/btcpay-server/umbrel-app.yml
+++ b/btcpay-server/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: btcpay-server
 category: bitcoin
 name: BTCPay Server
-version: "2.0.3"
+version: "2.0.5"
 tagline: Accept Bitcoin payments with 0 fees & no 3rd party
 description: >-
   BTCPay Server is a payment processor that allows you to receive
@@ -34,18 +34,13 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  🚨 If you are using the Nostr or Blink plugin, consider this release security-critical. Without it, an attacker with access to a pull payment could drain the Lightning wallet without limit.
-
-
   Highlights:
-    - Added support for histograms displaying Lightning data and corresponding API endpoints in the Greenfield API.
-    - Introduced image upload functionality for app items in the Greenfield API.
-    - Made the creation of payout methods optional when creating a pull payment via the Greenfield API.
-    - Updated button icons in the Point of Sale (POS) interface.
-    - Enhanced error messages for on-chain-related operations in the Greenfield API.
-    - Improved the API documentation for invoice payment tolerance.
-    - Added a specific error message for Lightning payouts that fail due to no route being found.
-    - Adjusted brand color handling for better UI consistency.
+    - Added QR Code support for store invitation emails.
+    - Introduced rate providers for Norwegian exchanges (Bitmynt and Bare Bitcoin).
+    - Improved store user management with enhanced API functionality and documentation.
+    - Admins can now view users’ invoices.
+    - Added a “Copy Link” button for pull payment actions.
+    - Enhanced UI consistency and plugin customization options.
     - Various bug fixes.
 
   Full release notes can be found at https://github.com/btcpayserver/btcpayserver/releases.


### PR DESCRIPTION
Updates both btcpayserver and nbxplorer containers. Requires testing before merge.