### PR TITLE
feat(jellyfin): Add hardware-accelerated video decoding support for Jellyfin

### DIFF
--- a/jellyfin/docker-compose.yml
+++ b/jellyfin/docker-compose.yml
@@ -20,10 +20,3 @@ services:
     ports:
       # Service auto-discovery
       - 7359:7359/udp
-    devices:
-      - /dev/dri:/dev/dri
-      - /dev/vcsm:/dev/vcsm
-      - /dev/vchiq:/dev/vchiq
-      - /dev/video10:/dev/video10
-      - /dev/video11:/dev/video11
-      - /dev/video12:/dev/video12

--- a/jellyfin/docker-compose.yml
+++ b/jellyfin/docker-compose.yml
@@ -20,3 +20,10 @@ services:
     ports:
       # Service auto-discovery
       - 7359:7359/udp
+    devices:
+      - /dev/dri:/dev/dri
+      - /dev/vcsm:/dev/vcsm
+      - /dev/vchiq:/dev/vchiq
+      - /dev/video10:/dev/video10
+      - /dev/video11:/dev/video11
+      - /dev/video12:/dev/video12

--- a/jellyfin/hooks/pre-install
+++ b/jellyfin/hooks/pre-install
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Path to docker-compose.yml one directory up from the hooks folder
+COMPOSE_FILE="$(cd "$(dirname "$0")" && pwd)/../docker-compose.yml"
+
+# Dynamic device mapping for hardware acceleration
+DEVICE_MAPPINGS=""
+
+# Check for DRI devices
+if [ -e /dev/dri ]; then
+    DEVICE_MAPPINGS+="      - /dev/dri:/dev/dri\n"
+fi
+
+# Check for Raspberry Pi specific devices
+if [ -e /dev/vcsm ]; then
+    DEVICE_MAPPINGS+="      - /dev/vcsm:/dev/vcsm\n"
+fi
+
+if [ -e /dev/vchiq ]; then
+    DEVICE_MAPPINGS+="      - /dev/vchiq:/dev/vchiq\n"
+fi
+
+# Check for video devices
+for i in {10..12}; do
+    if [ -e "/dev/video$i" ]; then
+        DEVICE_MAPPINGS+="      - /dev/video$i:/dev/video$i\n"
+    fi
+done
+
+# Update docker-compose.yml with dynamic device mappings
+if [ -n "$DEVICE_MAPPINGS" ]; then
+    {
+        # Use printf instead of echo to prevent unwanted newlines
+        [ "$(tail -c1 "$COMPOSE_FILE")" != "" ] && printf "\n"
+        printf "    devices:\n"
+        printf "${DEVICE_MAPPINGS%\\n}"  # Remove trailing newline
+    } >> "$COMPOSE_FILE"
+fi


### PR DESCRIPTION
… server by mapping required GPU device nodes (/dev/dri, /dev/vcsm, /dev/vchiq, and /dev/video*) in the Docker Compose configuration.

#### **Context:**  
The current Docker Compose configuration for the Jellyfin server does not include hardware-accelerated video decoding capabilities. This feature is essential for improving media playback performance, especially for high-definition video streams, by leveraging GPU-based transcoding.  

#### **Proposed Changes:**  
Modify the `docker-compose.yml` to include the following device mappings:  
- `/dev/dri`: Enables Direct Rendering Infrastructure (DRI) for GPU access.  
- `/dev/vcsm` and `/dev/vchiq`: Facilitates GPU memory and communication, particularly for Raspberry Pi systems.  
- `/dev/video10`, `/dev/video11`, `/dev/video12`: Grants access to video device nodes for hardware-based video encoding/decoding.  

#### **Benefits:**  
- Enables hardware-based transcoding for Jellyfin, reducing CPU usage.  
- Enhances performance during media playback, particularly for high-definition and 4K content.  
- Provides compatibility with GPUs and Raspberry Pi-specific hardware.  

#### **Steps to Validate:**  
1. Update the `docker-compose.yml` file with the proposed changes.  
2. Deploy the updated Jellyfin container.  
3. Run `docker exec <container_name> ls -l /dev/` to verify the container has access to the mapped devices.  
4. Check Jellyfin's playback settings and logs to confirm that hardware acceleration is enabled and functional.  

#### **Notes:**  
- Ensure the host system has the appropriate GPU drivers installed and configured.  
- Additional Jellyfin configuration may be required to enable hardware acceleration in the application itself.