### PR TITLE
Update syncthing to version 1.29.1

### DIFF
--- a/syncthing/docker-compose.yml
+++ b/syncthing/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8384
 
   server:
-    image: syncthing/syncthing:1.28.1@sha256:289b4ca86d77e4938d3e0af7d11f5c0a0fb786e469d5f697c25ab0f9e1f29f34
+    image: syncthing/syncthing:1.29.1@sha256:2029144fbafe92c64b355c8ae29faa24fe1b5753d55a5d8702193da2a947365e
     restart: on-failure
     stop_grace_period: 1m
     hostname: umbrel

--- a/syncthing/docker-compose.yml
+++ b/syncthing/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8384
 
   server:
-    image: syncthing/syncthing:1.29.1@sha256:2029144fbafe92c64b355c8ae29faa24fe1b5753d55a5d8702193da2a947365e
+    image: syncthing/syncthing:1.29.1@sha256:982cac030eecabfd6e6ce293e14b282fb9a89704a101e5456bfb7b4b7ba037a1
     restart: on-failure
     stop_grace_period: 1m
     hostname: umbrel

--- a/syncthing/umbrel-app.yml
+++ b/syncthing/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: syncthing
 category: files
 name: Syncthing
-version: "1.28.1"
+version: "1.29.1"
 tagline: Peer-to-peer file synchronization between your devices
 description: >-
   Syncthing is a peer-to-peer continuous file synchronization
@@ -27,11 +27,12 @@ path: ""
 defaultPassword: ""
 releaseNotes: >-
   This release includes bug fixes and improvements:
-    - Fixed issues with folder synchronization status display
-    - Improved dark theme support in the web interface
-    - Enhanced handling of symbolic links on Android
-    - Fixed various UI display issues on mobile devices
-    - Improved handling of directory junctions
+    - Fixed issues with socket file handling on Linux systems
+    - Improved GUI address handling for Unix sockets
+    - Enhanced folder synchronization behavior
+    - Clarified system log messages
+    - Fixed web interface login and stability issues
+    - Important API changes for developers
 
 
   Full release notes can be found at https://github.com/syncthing/syncthing/releases


### PR DESCRIPTION
Tested on Umbrel Home.

Closes #2029 