### PR TITLE
Update Linkwarden to version 2.9.3 and run as root

### DIFF
--- a/linkwarden/docker-compose.yml
+++ b/linkwarden/docker-compose.yml
@@ -22,7 +22,7 @@ services:
   app:
     image: ghcr.io/linkwarden/linkwarden:v2.9.3@sha256:0d9ab9dcf70aaf81fddbaf2d215a057670fff5eb01ef7cfd97b08900ffcddd1c
     environment:
-      - DATABASE_URL=postgresql://postgres:linkwarden@postgres:5432/postgres
+      - DATABASE_URL=postgresql://postgres:linkwarden@linkwarden_postgres_1:5432/postgres
       - NEXTAUTH_URL=http://${DEVICE_DOMAIN_NAME}:8233/api/v1/auth
       - NEXTAUTH_SECRET=linkwarden
     restart: on-failure

--- a/linkwarden/docker-compose.yml
+++ b/linkwarden/docker-compose.yml
@@ -21,8 +21,7 @@ services:
       timeout: 5s
       retries: 5
   app:
-    image: ghcr.io/linkwarden/linkwarden:v2.8.3@sha256:7f80a03d688c3e5d9ec6b34f5b65cd861ff8c9eb08d12932dc8fc7482991f238
-    user: "1000:1000"
+    image: ghcr.io/linkwarden/linkwarden:v2.9.3@sha256:0d9ab9dcf70aaf81fddbaf2d215a057670fff5eb01ef7cfd97b08900ffcddd1c
     environment:
       - DATABASE_URL=postgresql://postgres:linkwarden@postgres:5432/postgres
       - NEXTAUTH_URL=http://${DEVICE_DOMAIN_NAME}:8233/api/v1/auth

--- a/linkwarden/docker-compose.yml
+++ b/linkwarden/docker-compose.yml
@@ -9,7 +9,6 @@ services:
   
   postgres:
     image: postgres:16-alpine@sha256:0366402213df5db03c47ff80bcc697e92c8be0c213d03c941df1fc42d1ba9560
-    user: "1000:1000"
     environment:
       - POSTGRES_PASSWORD=linkwarden
     restart: on-failure

--- a/linkwarden/umbrel-app.yml
+++ b/linkwarden/umbrel-app.yml
@@ -3,7 +3,7 @@ id: linkwarden
 name: Linkwarden
 tagline: Bookmark Preservation for Individuals and Teams
 category: social
-version: "2.8.3"
+version: "2.9.3"
 port: 8233
 description: >-
   📚 Linkwarden is a self-hosted, open-source collaborative bookmark manager to collect, organize and archive webpages.
@@ -26,5 +26,15 @@ gallery:
 defaultUsername: ""
 defaultPassword: ""
 dependencies: []
-releaseNotes: ""
+releaseNotes: >-
+  This update contains several new features and various bug fixes:
+
+
+    - Added automatic tagging of links using AI
+    - New customizable color themes
+    - Browser extension now captures articles directly
+    - Added RSS feed support for public collections
+    - Added Polish and Russian language support
+    - Added import support from Omnivore
+    - Fixed various bugs and improved stability
 path: ""


### PR DESCRIPTION
Tested update on Umbrel Home and fresh install on Raspberry Pi 5.

I noticed some bugs like Linkwarden not being able to create snapshots of websites. This is due to the fact that official support for non-root is still missing. 
There is already a PR open for non-root support: linkwarden/linkwarden#779 

Also changed the database url as I have seem some errors in the logs. Changing it to the full name seems to fix it.

Would run it as root for the time being if that is ok @nmfretz