### PR TITLE
Update vaultwarden to version 1.33.0

### DIFF
--- a/vaultwarden/docker-compose.yml
+++ b/vaultwarden/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: vaultwarden/server:1.32.7@sha256:7a0aa23c0947be3582898deb5170ea4359493ed9a76af2badf60a7eb45ac36af
+    image: vaultwarden/server:1.33.0@sha256:e81ca01351ecf40083366202b163e7a31abca04d96e2194e9e1f78a57052f65c
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/vaultwarden/umbrel-app.yml
+++ b/vaultwarden/umbrel-app.yml
@@ -47,21 +47,19 @@ description: >-
   *Please note that Vaultwarden is not associated with the Bitwarden® project nor 8bit Solutions LLC. When using this app, please report any bugs or suggestions to us directly, regardless of whatever clients you are using (mobile, desktop, browser, etc), and do not use Bitwarden®'s official support channels.
 
 releaseNotes: >-
-  Security Fixes
-  - Critical vulnerabilities requiring admin token configuration
-  - Admin backend access risks with sendmail and favicon manipulation
-  - Multi-organization user privilege exploitation potential
+  ⚠️ Security Fixes
+    - Critical vulnerabilities requiring admin token configuration
+    - Admin backend access risks with sendmail and favicon manipulation
+    - Multi-organization user privilege exploitation potential
+
 
   Key highlights in this release:
-  - Updated web-vault to v2025.1.1
-  - Added partial manage role support for collections
-  - Manager role is converted to a Custom role with either Manage All Collections or per collection.
-    Admins and Owners probably want to check and verify if the rights are still correct.
-  - The OCI containers and binaries are signed via GitHub Attestations
-    This allows you to verify an OCI image or even the vaultwarden binary located within the OCI image.
+    - Updated web-vault to v2025.1.1
+    - Added partial manage role support for collections
+    - Manager role is converted to a Custom role with either Manage All Collections or per collection. Admins and Owners probably want to check and verify if the rights are still correct.
+    - The OCI containers and binaries are signed via GitHub Attestations. This allows you to verify an OCI image or even the vaultwarden binary located within the OCI image.
 
   Full release notes are available at https://github.com/dani-garcia/vaultwarden/releases
-
 developer: Daniel García
 website: https://github.com/dani-garcia
 dependencies: []

--- a/vaultwarden/umbrel-app.yml
+++ b/vaultwarden/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: vaultwarden
 category: files
 name: Vaultwarden
-version: "1.32.7"
+version: "1.33.0"
 tagline: Unofficial Bitwarden® compatible server
 description: >-
   Vaultwarden is an alternative
@@ -45,15 +45,23 @@ description: >-
 
 
   *Please note that Vaultwarden is not associated with the Bitwarden® project nor 8bit Solutions LLC. When using this app, please report any bugs or suggestions to us directly, regardless of whatever clients you are using (mobile, desktop, browser, etc), and do not use Bitwarden®'s official support channels.
-releaseNotes: >-
-  Key highlights in this release:
-    - Fixed security vulnerability affecting organization groups (not relevant to Vaultwarden on umbrelOS)
-    - Enhanced security measures and optimizations
-    - Improved SMTP configuration handling
-    - Various bug fixes and stability improvements
 
+releaseNotes: >-
+  Security Fixes
+  - Critical vulnerabilities requiring admin token configuration
+  - Admin backend access risks with sendmail and favicon manipulation
+  - Multi-organization user privilege exploitation potential
+
+  Key highlights in this release:
+  - Updated web-vault to v2025.1.1
+  - Added partial manage role support for collections
+  - Manager role is converted to a Custom role with either Manage All Collections or per collection.
+    Admins and Owners probably want to check and verify if the rights are still correct.
+  - The OCI containers and binaries are signed via GitHub Attestations
+    This allows you to verify an OCI image or even the vaultwarden binary located within the OCI image.
 
   Full release notes are available at https://github.com/dani-garcia/vaultwarden/releases
+
 developer: Daniel García
 website: https://github.com/dani-garcia
 dependencies: []


### PR DESCRIPTION
This is pull request to update vaultwarden to version 1.33.0. 
This PR must be reviewed and tested before merging.