### PR TITLE
Update immich to version 1.125.6 and disable umbrel app proxy

### DIFF
--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: ghcr.io/immich-app/immich-server:v1.125.3@sha256:da47ef138aef097358da675ff20cdfb2b995c025be489657ae0ad63539511182
+    image: ghcr.io/immich-app/immich-server:v1.125.6@sha256:07e45e10be9539f04dd3a819286b5b308b08142eeff7bc58a89bf21d97237d55
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
     environment:
@@ -33,7 +33,7 @@ services:
     restart: on-failure
 
   machine-learning:
-    image: ghcr.io/immich-app/immich-machine-learning:v1.125.3@sha256:7914728ed016cf6c546c7541890fee3a1e25728e6f3abc9d61a999060a41bb2d
+    image: ghcr.io/immich-app/immich-machine-learning:v1.125.6@sha256:0ca72dae460b7fd2dbd0ca146fdddfd26b1c1af783f37659c2f1bdd546fdf1e4
     volumes:
       - ${APP_DATA_DIR}/data/model-cache:/cache
     environment:

--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -19,10 +19,10 @@ services:
     environment:
       APP_HOST: immich_server_1
       APP_PORT: 2283
-      PROXY_AUTH_WHITELIST: "/api/*,/search/*"
+      PROXY_AUTH_ADD: "false"
 
   server:
-    image: ghcr.io/immich-app/immich-server:v1.125.1@sha256:9a7fdfb1679017ce853e5ef9d7280744a98369c72ff17a90957ae3cc68a1985a
+    image: ghcr.io/immich-app/immich-server:v1.125.3@sha256:da47ef138aef097358da675ff20cdfb2b995c025be489657ae0ad63539511182
     volumes:
       - ${APP_DATA_DIR}/data/upload:/usr/src/app/upload
     environment:
@@ -33,7 +33,7 @@ services:
     restart: on-failure
 
   machine-learning:
-    image: ghcr.io/immich-app/immich-machine-learning:v1.125.1@sha256:c0740b545ac84ca6cd73265f6beca2c65317b383dc7e4d89dc1d1daf63d895f6
+    image: ghcr.io/immich-app/immich-machine-learning:v1.125.3@sha256:7914728ed016cf6c546c7541890fee3a1e25728e6f3abc9d61a999060a41bb2d
     volumes:
       - ${APP_DATA_DIR}/data/model-cache:/cache
     environment:

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: immich
 category: files
 name: Immich
-version: "v1.125.3"
+version: "v1.125.6"
 tagline: High-performance photo and video backup solution
 description: >-
   An open-source and high-performance self-hosted backup solution for the videos and photos on your mobile device
@@ -55,6 +55,10 @@ releaseNotes: >-
     - Fixed multiple timeline and album display issues affecting photo browsing experience
     - Resolved photo management features including LivePhotos, thumbnails, and location editing
     - Fixed database migration issues affecting search, timezone handling, and EXIF data
+    - Fixed a bug where the album page cannot be accessed if any album with its assets is in the trash.
+    - Fixed a bug where deduplication detection doesn't return any result
+    - Fixed a bug where the date picker component caused a rendering error if the app language was not in English
+    - Fixed a bug where thumbnail generation job queue all person faces at midnight
 
   Full release notes are found at https://github.com/immich-app/immich/releases
 developer: Alex Tran

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: immich
 category: files
 name: Immich
-version: "v1.125.1"
+version: "v1.125.3"
 tagline: High-performance photo and video backup solution
 description: >-
   An open-source and high-performance self-hosted backup solution for the videos and photos on your mobile device
@@ -48,16 +48,13 @@ releaseNotes: >-
   ⚠️ As usual, please check that your mobile app is compatible with this release of Immich.
 
 
-  ⚠️ This release includes an important Node.js security update. While these vulnerabilities likely don't affect Immich, updating is recommended.
+  ⚠️ This update disables the Umbrel App Proxy authentication. Authentication is now handled by the Immich app itself.
 
 
   Key improvements in this release:
-    - Major database performance improvements for faster overall app experience
-    - New share-to mechanism on mobile app to share media directly from other apps
-    - Slideshow mode now available everywhere in the web app
-    - Added lens information display in the detail panel
-    - Fixed Android app issues with newly taken photos and video playback
-    - Various other performance improvements and bug fixes
+    - Fixed multiple timeline and album display issues affecting photo browsing experience
+    - Resolved photo management features including LivePhotos, thumbnails, and location editing
+    - Fixed database migration issues affecting search, timezone handling, and EXIF data
 
   Full release notes are found at https://github.com/immich-app/immich/releases
 developer: Alex Tran


### PR DESCRIPTION
Tested update and fresh install on Umbrel Home. Fresh install on Raspberry Pi 5. (Took a long time to start on the Pi)

I disabled the app proxy authentication as immich comes with authentication built in. 
This way users are able to setup a reverse proxy in front of immich for external access. Please let me know if it is ok like this @nmfretz.