### PR TITLE
Update jackett to v0.22.1363

### DIFF
--- a/jackett/docker-compose.yml
+++ b/jackett/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/* /dl/*"
 
   server:
-    image: linuxserver/jackett:0.22.1323@sha256:5b4b89f20656a331b4bf1a816a6bd3de633290867468870593999f13a27ba99e
+    image: linuxserver/jackett:0.22.1363@sha256:f36bf93ca36dcc4d1aa3cede5a1f5c801462ecdaebe80f789986011062fcb6a0
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/config

--- a/jackett/umbrel-app.yml
+++ b/jackett/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jackett
 category: media
 name: Jackett
-version: "0.22.1323"
+version: "0.22.1363"
 tagline: API support for your favorite torrent trackers
 description: >-
   Jackett works as a proxy server: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious, etc) into tracker-site-specific http queries,
@@ -35,8 +35,9 @@ gallery:
 path: ""
 releaseNotes: >-
   This release includes improvements for various trackers and functionality:
-    - Updated domain configurations and categories for multiple trackers
-    - Enhanced search functionality
+    - Updated domain configurations for multiple trackers
+    - Enhanced search functionality and release name handling
+    - Improved language cleanup for certain trackers
     - General performance and stability improvements
 
 


### PR DESCRIPTION
🤖 This is an automated summary of installation tests for jackett:

- ✅ App successfully installed in umbrel-dev instance
- ✅ App successfully listed in umbrel.yaml
- ✅ App UI successfully returns a 200 status code
- 📸 Screenshot of the app:
  ![App Screenshot](https://raw.githubusercontent.com/al-lac/app-testing-screenshots/main/screenshots/1738623186710_jackett_2025-02-03T22-53-06-513Z.png)

**This PR must still be reviewed and tested before merging.**