### PR TITLE
Update wikijs to v2.5.306

### DIFF
--- a/wikijs/docker-compose.yml
+++ b/wikijs/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
   
   server:
-    image: linuxserver/wikijs:2.5.305@sha256:7b58bd78f743a0dd4112d7c494cb4d719797953d1dfbc80d981bf49216cf598a
+    image: linuxserver/wikijs:2.5.306@sha256:4868253594b2511b7c6054aa83695332bf3e77257b667c84e276e62668e36b62
     restart: on-failure
     environment:
       - PUID=1000

--- a/wikijs/umbrel-app.yml
+++ b/wikijs/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: wikijs
 category: developer
 name: WikiJS
-version: "2.5.305"
+version: "2.5.306"
 tagline: Make documentation a joy to write
 description: >-
   The most powerful and extensible open source Wiki software.
@@ -30,7 +30,10 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  This update improves compatibility with the latest version of Elasticsearch.
+  This update includes the following changes:
+    - Added a git always namespace option
+    - Fixed an issue with HA mode activation
+    - Improved compatibility with Elasticsearch
 
 
   Full release notes are found at https://github.com/requarks/wiki/releases


### PR DESCRIPTION
🤖 This is an automated summary of installation tests for wikijs:

- ✅ App successfully installed in umbrel-dev instance
- ✅ App successfully listed in umbrel.yaml
- ✅ App UI successfully returns a 200 status code
- 📸 Screenshot of the app:
  ![App Screenshot](https://raw.githubusercontent.com/al-lac/app-testing-screenshots/main/screenshots/1738624400899_wikijs_2025-02-03T23-13-20-706Z.png)

**This PR must still be reviewed and tested before merging.**