### PR TITLE
Update radarr to v5.18.4.9674

### DIFF
--- a/radarr/docker-compose.yml
+++ b/radarr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/radarr:5.17.2@sha256:e633fc93b9e2cea959853d27c6acc1d0b2d1ed7db4a800f6f46fe5b217f13102
+    image: linuxserver/radarr:5.18.4@sha256:b2d2bc9bafb76073d96142bda07ea90c6d6afd9207fe4ff2d4f9d3b50fcdbd76
     environment:
       - PUID=1000
       - PGID=1000

--- a/radarr/umbrel-app.yml
+++ b/radarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: radarr
 category: media
 name: Radarr
-version: "5.17.2.9580"
+version: "5.18.4.9674"
 tagline: Your movie collection manager
 description: >-
   Radarr is a movie collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new movies and will interface with clients and indexers to grab, sort, and rename them. It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available. Note that only one type of a given movie is supported. If you want both an 4k version and 1080p version of a given movie you will need multiple instances.
@@ -29,11 +29,15 @@ gallery:
 path: ""
 releaseNotes: >-
   This update includes various improvements and new features:
-    - Added support for Tagalog and Marathi languages
-    - Improved handling of notifications and backup processes
-    - Enhanced authentication handling for download clients
-    - Various improvements to custom formats and metadata handling
-    - Multiple bug fixes and performance enhancements
+    - Added support for MediaInfo AudioLanguagesAll
+    - Improved formatting of bitrate for primary streams in media info
+    - Fixed health warning for downloading inside root folders
+    - Added option to prefer newer Usenet releases
+    - Enhanced refresh cache for tracked queue on movies update
+    - Improved parsing of releases with JPN as Japanese and KOR as Korean
+    - Added reflink support for ZFS
+    - Enhanced custom format scoring and delay profile decisions
+    - Improved Discord notifications with images
 
 
   Full release notes for Radarr are available at https://github.com/Radarr/Radarr/releases


### PR DESCRIPTION
🤖 This is an automated summary of installation tests for radarr:

- ✅ App successfully installed in umbrel-dev instance
- ✅ App successfully listed in umbrel.yaml
- ✅ App UI successfully returns a 200 status code
- 📸 Screenshot of the app:
  ![App Screenshot](https://raw.githubusercontent.com/al-lac/app-testing-screenshots/main/screenshots/1738624883877_radarr_2025-02-03T23-21-23-728Z.png)

**This PR must still be reviewed and tested before merging.**