### PR TITLE
Update GitLab to v17.8.1

### DIFF
--- a/gitlab/docker-compose.yml
+++ b/gitlab/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   gitlab:
-    image: zengxs/gitlab:17.7.0-ce.0@sha256:a353041094142d3f3192295d0973e660778db5f7637069f8e035afe45c6b88d1
+    image: zengxs/gitlab:17.8.1-ce.0@sha256:963a719edd95cc7c237e9ca4914d75d1ca9f472a3001b76ad9dfb1dad65b4732
     restart: on-failure
     hostname: '${DEVICE_DOMAIN_NAME}:8929'
     ulimits:

--- a/gitlab/hooks/pre-start
+++ b/gitlab/hooks/pre-start
@@ -21,6 +21,7 @@ VERSIONS+=("17.5.1")
 # There is no 17.5.3 final patch release for the zengxs/gitlab image to update to before 17.6
 VERSIONS+=("17.6.1")
 VERSIONS+=("17.7.0")
+VERSIONS+=("17.8.1")
 
 # List of images on migration path
 # Using zengxs/gitlab which may not have all versions listed in upgrade path tool: https://hub.docker.com/r/zengxs/gitlab/tags
@@ -30,6 +31,7 @@ IMAGES+=("zengxs/gitlab:17.3.3-ce.0@sha256:b4369fc8f2a505fdf30bae7fa2befde2a8d6f
 IMAGES+=("zengxs/gitlab:17.5.1-ce.0@sha256:61cb4c79fe55de9dc94822d5a64a07ee40ff681d6282ab5733bc8e80479451ff")
 IMAGES+=("zengxs/gitlab:17.6.1-ce.0@sha256:fac3ab00c189e7f7ef2d9170abe1028180663f5bb50dd8b84cb79c4f3053df42")
 IMAGES+=("zengxs/gitlab:17.7.0-ce.0@sha256:a353041094142d3f3192295d0973e660778db5f7637069f8e035afe45c6b88d1")
+IMAGES+=("zengxs/gitlab:17.8.1-ce.0@sha256:963a719edd95cc7c237e9ca4914d75d1ca9f472a3001b76ad9dfb1dad65b4732")
 
 find_index() {
 	local -r value="${1}"

--- a/gitlab/umbrel-app.yml
+++ b/gitlab/umbrel-app.yml
@@ -3,7 +3,7 @@ id: gitlab
 name: GitLab
 tagline: Software. Faster.
 category: developer
-version: "17.7.0"
+version: "17.8.1"
 port: 8929
 description: >-
   ⚠️ This app is RAM-intensive (+6GB recommended) and can take 15-20 minutes to start after installation on low-powered devices.
@@ -64,16 +64,16 @@ releaseNotes: >-
   The GitLab UI may be unresponsive for a few minutes after the update, which is completely normal.
 
 
-  Key improvements released in GitLab 17.7 :
-    - New Planner user role
-    - New user contribution and membership mapping available in direct transfer
-    - Rotate personal, project, and group access tokens in the UI
-    - Set your preferred text editor as default
-    - Unicode 15.1 emoji support
-    - Kubernetes 1.31 support
-    - Bug fixes, performance improvements, and UI improvements
+  Key improvements released in GitLab 17.8 :
+    - Enhance security with protected container repositories
+    - List the deployments related to a release
+    - Machine learning model experiments tracking in GA
+    - Track multiple to-do items in an issue or merge request
+    - Primary domain redirect for GitLab Pages
+    - Pipeline limits available in GitLab Community Edition
+    - Bug and security fixes, performance improvements, and UI improvements
 
-  Full release notes are available at : https://about.gitlab.com/releases/2024/12/19/gitlab-17-7-released/
+  Full release notes are available at : https://about.gitlab.com/releases/2025/01/16/gitlab-17-8-released/
 dependencies: []
 path: ""
 deterministicPassword: true


### PR DESCRIPTION
Update GitLab to most recent release

Key improvements released in GitLab 17.8 :
- Enhance security with protected container repositories
- List the deployments related to a release
- Machine learning model experiments tracking in GA
- Track multiple to-do items in an issue or merge request
- Primary domain redirect for GitLab Pages
- Pipeline limits available in GitLab Community Edition
- Bug and security fixes, performance improvements, and UI improvements

Tested on RPi 5 8GB and working ✅