### PR TITLE
Update gitea to v1.23.3

### DIFF
--- a/gitea/docker-compose.yml
+++ b/gitea/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: gitea/gitea:1.23.1-rootless@sha256:ce2ea016e72ea2748d34c79c63563c8084b6275461cae00b34e343be2abd2a04
+    image: gitea/gitea:1.23.3-rootless@sha256:96899d07bfcc84a42bfbab2ff2cb711f0e5f25bae06dd187a3fb080c8f8233a2
     user: "1000:1000"
     restart: on-failure
     ports:

--- a/gitea/umbrel-app.yml
+++ b/gitea/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: gitea
 category: developer
 name: Gitea
-version: "1.23.1"
+version: "1.23.3"
 tagline: A painless self-hosted Git service
 description: >-
   Gitea is a painless self-hosted Git service. It is similar to
@@ -44,6 +44,13 @@ defaultPassword: ""
 releaseNotes: >
   This is a major update of Gitea that includes various new features, enhancements, performance improvements, and bug fixes.
 
+  Security fixes and improvements:
+    - Build Gitea with Golang v1.23.6 to fix security bugs
+
+  Bug fixes:
+    - Fix a bug caused by status webhook template
+
+  Instances on Gitea Cloud will be automatically upgraded to this version during the specified maintenance window.
 
   As always, please review the full release notes for any changes that may affect your setup: https://github.com/go-gitea/gitea/releases
 torOnly: false

--- a/gitea/umbrel-app.yml
+++ b/gitea/umbrel-app.yml
@@ -42,15 +42,15 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >
-  This is a major update of Gitea that includes various new features, enhancements, performance improvements, and bug fixes.
+  This update includes various enhancements and bug fixes:
 
-  Security fixes and improvements:
     - Build Gitea with Golang v1.23.6 to fix security bugs
-
-  Bug fixes:
     - Fix a bug caused by status webhook template
-
-  Instances on Gitea Cloud will be automatically upgraded to this version during the specified maintenance window.
+    - Improved clone button functionality
+    - Enhanced repository homepage styling
+    - Added confirmation dialog for "sync fork" action
+    - Improved tracked time display and sync fork behavior
+    - Fixed various UI and functionality issues
 
   As always, please review the full release notes for any changes that may affect your setup: https://github.com/go-gitea/gitea/releases
 torOnly: false


### PR DESCRIPTION
🤖 This is an automated summary of installation tests for gitea:

- ✅ App successfully installed in umbrel-dev instance
- ✅ App successfully listed in umbrel.yaml
- ✅ App UI successfully returns a 200 status code
- 📸 Screenshot of the app:
  ![App Screenshot](https://raw.githubusercontent.com/al-lac/app-testing-screenshots/main/screenshots/1738872412945_gitea_2025-02-06T20-06-52-743Z.png)

Tested update on Umbrel Home.