### PR TITLE
Update PeerSwap to v1.7.7

### DIFF
--- a/peerswap/docker-compose.yml
+++ b/peerswap/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 1984
 
   web:
-    image: ghcr.io/impa10r/peerswap-web:v1.7.6@sha256:0347b64f4899a955f1cc9d7d50e9d78ba9fa3836a4f1f4ed6aba53d038b7aa6a
+    image: ghcr.io/impa10r/peerswap-web:v1.7.7@sha256:f01b4e69fb9f491880d139d09183c6e548f4ffa20a03159c50cb4689f8b3f30b
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/peerswap/docker-compose.yml
+++ b/peerswap/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 1984
 
   web:
-    image: ghcr.io/impa10r/peerswap-web:v1.7.7@sha256:f01b4e69fb9f491880d139d09183c6e548f4ffa20a03159c50cb4689f8b3f30b
+    image: ghcr.io/impa10r/peerswap-web:v1.7.7@sha256:c7d37ff47054b462dd1edc5c06174ad12d36a82602b30966ac225af316908abe
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/peerswap/umbrel-app.yml
+++ b/peerswap/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: peerswap
 category: bitcoin
 name: PeerSwap
-version: "1.7.6"
+version: "1.7.7"
 tagline: Balance your lightning channels with Liquid BTC
 description: PeerSwap enables Lightning Network nodes to balance their channels by facilitating atomic swaps with direct peers. PeerSwap enhances decentralization of the Lightning Network by enabling all nodes to be their own swap provider. No centralized coordinator, no 3rd party rent collector, and lowest cost channel balancing means small nodes can better compete with large nodes. Includes channel AutoFees, Liquid Peg-in and BTC send with coin select + fee bump functionality.
 developer: PeerSwap Project


### PR DESCRIPTION
- Fix Auto Fee not working for channels with no outbound forwards
- Better indication when all channels with a peer are inactive
- Catch Bitcoin Core and Elements Core RPC errors
- Fix telegram bot panic on wrong token or chat id
- Allow Bitcoin fee rates with 0.01 precision
- Reserve 1200 sats of LBTC balance to save on Elements fees
- Show confidential peg-in join time limit on peg-in form
- Allow updating txid of externally funded peg-in when not found