### PR TITLE
App Submission: RustDesk Server

### DIFF
--- a/rustdesk/docker-compose.yml
+++ b/rustdesk/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.7'
+
+services:
+  hbbs:
+    container_name: hbbs
+    image: rustdesk/rustdesk-server@sha256:680f8ba5accafc264d15076f33a6fdb9cb6f4d963a0fc92e01023ca0e919cc83
+    command: hbbs
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+
+    depends_on:
+      - hbbr
+    restart: unless-stopped
+
+  hbbr:
+    container_name: hbbr
+    image: rustdesk/rustdesk-server@sha256:680f8ba5accafc264d15076f33a6fdb9cb6f4d963a0fc92e01023ca0e919cc83
+    command: hbbr
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+    restart: unless-stopped

--- a/rustdesk/umbrel-app.yml
+++ b/rustdesk/umbrel-app.yml
@@ -1,0 +1,33 @@
+manifestVersion: 1
+id: rustdesk
+name: RustDesk
+tagline: Open Source Remote Desktop Software
+category: utilities
+version: "1.1.14"
+port: 21115
+description: >-
+  RustDesk is a secure and efficient remote desktop software that works out of the box.
+  No configuration required. You have full control of your data, with no concerns
+  about security. You can use our relay server, or set up your own.
+
+  **Features:**
+  - Cross-platform support
+  - Direct connection through ID/password
+  - Secure end-to-end encryption
+  - File transfer capabilities
+  - Multi-monitor support
+developer: RustDesk Team
+website: https://rustdesk.com
+submitter: Knufle
+submission: https://github.com/getumbrel/umbrel-apps/pull/xxx
+repo: https://github.com/rustdesk/rustdesk-server
+support: https://github.com/rustdesk/rustdesk/issues
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+defaultUsername: ""
+defaultPassword: ""
+dependencies: []
+releaseNotes: "Initial release of RustDesk server for Umbrel"
+path: ""


### PR DESCRIPTION
# App Submission
RustDesk Server

This PR adds RustDesk server to Umbrel. RustDesk is an open-source remote desktop software that allows secure remote connections.

The server consists of two components:
- hbbs (ID/Rendezvous server)
- hbbr (Relay server)

Both components are required for proper functionality and are included in this deployment.

### 256x256 SVG icon

https://limewire.com/d/ceee5ca3-4cfd-4d82-ba71-a0af37693c14#yLGrXJICd91f3YfXMUzWZgJR8tmMIhcXtc0DZn75uLk

### Gallery images

There's no image to be shown here since it's all server

### I have tested my app on:
- [ ] umbrelOS on a Raspberry Pi
- [ ] umbrelOS on an Umbrel Home
- [ ] umbrelOS on Linux VM