### PR TITLE
Downgrade Tailscale to v1.78.3

### DIFF
--- a/tailscale/docker-compose.yml
+++ b/tailscale/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   web:
     network_mode: "host" # TODO: We can remove this later with some iptables magic
-    image: tailscale/tailscale:v1.80.0@sha256:27b6a3dc30d89e94113b0d481dae05f08934cf80bdce860041727a2a60959921
+    image: tailscale/tailscale:v1.78.3@sha256:9d4c17a8451e2d1282c22aee1f08d28dc106979c39c7b5a35ec6313d4682a43e
     restart: on-failure
     stop_grace_period: 1m
     command: "sh -c 'tailscale web --listen 0.0.0.0:8240 & exec tailscaled --tun=userspace-networking'"

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: tailscale
 category: networking
 name: Tailscale
-version: "v1.80.0"
+version: "v1.78.3"
 tagline: Zero config VPN to access your Umbrel from anywhere
 description: >-
   Tailscale is zero config VPN that creates a secure network between
@@ -28,14 +28,10 @@ path: ""
 deterministicPassword: false
 torOnly: false
 releaseNotes: >-
-  This update introduces improvements and fixes to enhance your Tailscale experience.
+  ⚠️ This update reverts Tailscale to the previous stable version to resolve a sign-in issue introduced in 1.80.0. If you were affected, simply update to restore access.
 
 
-  Notable Changes
-    - Added system policy for overriding device hostnames
-    - Improved login UI with clearer button labeling
-    - Better error messaging for Funnel configuration issues
-    - Fixed custom coordination server connections when using non-standard ports
+  Version 1.78.3 introduces client metrics, system policy management improvements and multiple fixes.
 
 
   Full release notes are available at https://tailscale.com/changelog


### PR DESCRIPTION
This update reverts Tailscale to the previous stable version to resolve a [sign-in issue introduced in 1.80.0](https://github.com/tailscale/tailscale/issues/14872). If you were affected, simply update to restore access.

Tested fresh install, app update, and downgrade from 1.80.0 (including sign-out/sign-in)