### PR TITLE
lightning-terminal: update to `v0.14.1-alpha`

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.14.0-alpha@sha256:1fec11bdf96a1c628f29b8f6f106decebc68d03b1bf240779d419290a003aa95
+    image: lightninglabs/lightning-terminal:v0.14.1-alpha@sha256:b9eb42c626eae23ad0d0bf1937c4b620498f2e92ed5f477f1d09a0e94b497fae
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -5,9 +5,6 @@ name: Lightning Terminal
 version: "0.14.1-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
-  ⚠️ Please update your Lightning Node app to the latest version available in the app store to ensure compatibility with Lightning Terminal.
-
-
   Lightning Terminal is the easiest way to manage inbound and
   outbound liquidity on the Lightning Network. Keep your channels open and the
   funds flowing. It provides a visual interface for interacting with your
@@ -59,6 +56,9 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
+  ⚠️ Please update your Lightning Node app to the latest version available in the app store to ensure compatibility with Lightning Terminal.
+
+
   This release of Lightning Terminal (LiT) ships the first update to the non-experimental version of Taproot Asset
   Channels, which comes with bug fixes for Taproot Assets Channels! It also updates the integrated LND and Faraday daemons.
 

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.14.0-alpha"
+version: "0.14.1-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -56,8 +56,8 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  This release of Lightning Terminal (LiT) ships the first non-experimental version of Taproot Asset Channels! It also
-  updates the integrated LND and Loop daemons.
+  This release of Lightning Terminal (LiT) ships the first update to the non-experimental version of Taproot Asset
+  Channels, which comes with bug fixes for Taproot Assets Channels! It also updates the integrated LND and Faraday daemons.
 
 
   IMPORTANT NOTE: To avoid loss of funds, it's imperative that you read the
@@ -95,7 +95,7 @@ releaseNotes: >-
   feedback from the community.
 
 
-  This release packages LND v0.18.4-beta, Taproot Assets Daemon v0.5.0-alpha,
-  Loop v0.29.0-beta, Pool v0.6.4-beta and Faraday v0.2.13-alpha.
+  This release packages LND v0.18.5-beta, Taproot Assets Daemon v0.5.1-alpha,
+  Loop v0.29.0-beta, Pool v0.6.4-beta and Faraday v0.2.14-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -5,6 +5,9 @@ name: Lightning Terminal
 version: "0.14.1-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
+  ⚠️ Please update your Lightning Node app to the latest version available in the app store to ensure compatibility with Lightning Terminal.
+
+
   Lightning Terminal is the easiest way to manage inbound and
   outbound liquidity on the Lightning Network. Keep your channels open and the
   funds flowing. It provides a visual interface for interacting with your


### PR DESCRIPTION
In this PR we bump Litd to v0.14.1-alpha. 

See the release notes here: https://github.com/lightninglabs/lightning-terminal/blob/master/docs/release-notes/release-notes-0.14.1.md

Happy to address any feedback if needed :)!