### PR TITLE
Add Public Pool widget

### DIFF
--- a/public-pool/docker-compose.yml
+++ b/public-pool/docker-compose.yml
@@ -45,3 +45,10 @@ services:
       - web
       - server
     restart: on-failure
+
+  widget-server:
+    image: ghcr.io/getumbrel/umbrel-public-pool-widget:v1.0.0@sha256:b8861a5b79471377f1bfbf6733f11350970b482103d4ef4185f372350ffff6b3
+    user: "1000:1000"
+    environment:
+      - PUBLIC_POOL_API_URL=http://public-pool_proxy_1/api/pool
+    restart: on-failure

--- a/public-pool/umbrel-app.yml
+++ b/public-pool/umbrel-app.yml
@@ -7,9 +7,12 @@ tagline: Fully Open Source Solo Bitcoin Mining Pool
 description: >-
   Run your own Bitcoin Solo Mining Pool with no fees.
 
+
   Connected to your Bitcoin node, and only your node. Contribute to furthering bitcoin mining decentralisation.
 
+
   Allows you to pool together any and all mining hardware, with mining rewards going directly to your chosen bitcoin address. 
+  
 
   Track total hashrate and your individual works with ease.
 developer: Benjamin Wilson

--- a/public-pool/umbrel-app.yml
+++ b/public-pool/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: public-pool
 category: bitcoin
 name: Public Pool
-version: "9c14003"
+version: "9c14003-w"
 tagline: Fully Open Source Solo Bitcoin Mining Pool
 description: >-
   Run your own Bitcoin Solo Mining Pool with no fees.
@@ -25,10 +25,29 @@ gallery:
   - 3.jpg
 path: ""
 releaseNotes: >-
-  This update brings Bitcoin Core v28 compatibility to Public Pool, along with a number of other improvements.
+  This update brings a brand new Public Pool widget, allowing you to see your pool stats at a glance right from your umbrelOS home screen!
 
 
-  If you have already updated your Bitcoin Node app to v28.0 and Public Pool is not working, this update will fix it.
+  To add this widget, right-click on your home screen and select "Edit widgets", or click on Widgets in the Dock.
 defaultPassword: ""
+widgets:
+  - id: "stats"
+    type: "four-stats"
+    refresh: "5s"
+    endpoint: "widget-server:3000/widgets/pool"
+    link: ""
+    example:
+      type: "four-stats"
+      link: ""
+      items:
+        - title: "Hash Rate"
+          text: "968"
+          subtext: "GH/s"
+        - title: "Miners"
+          text: "1"
+        - title: "Blocks Found"
+          text: "1"
+        - title: "Block Height"
+          text: "883453"
 submitter: smolgrrr
 submission: https://github.com/getumbrel/umbrel-apps/pull/915

--- a/public-pool/umbrel-app.yml
+++ b/public-pool/umbrel-app.yml
@@ -5,16 +5,16 @@ name: Public Pool
 version: "9c14003-w"
 tagline: Fully Open Source Solo Bitcoin Mining Pool
 description: >-
-  Run your own Bitcoin Solo Mining Pool with no fees.
-
-
-  Connected to your Bitcoin node, and only your node. Contribute to furthering bitcoin mining decentralisation.
-
-
-  Allows you to pool together any and all mining hardware, with mining rewards going directly to your chosen bitcoin address. 
+  Public Pool is an open-source, solo Bitcoin mining application that lets you run your own pool using your own node.
+  Instead of relying on centralized pools, Public Pool enables your mining hardware to submit work to your personal setup, ensuring that you have full control over your mining operation.
+  If you successfully mine a block, you receive the entire block reward. No splitting with other miners. No fees. No middleman.
   
-
-  Track total hashrate and your individual works with ease.
+  
+  On umbrelOS, Public Pool is automatically configured to work with your Bitcoin node—no extra setup required. Simply install the app, and it's ready to go.
+  
+  
+  To start mining, just point your mining hardware to your Public Pool instance using the stratum details provided in the app.
+  Monitor your total hashrate, track individual miners, and receive rewards directly to your chosen Bitcoin address. Mine independently and help strengthen Bitcoin's decentralization.
 developer: Benjamin Wilson
 website: https://web.public-pool.io/#/
 dependencies:


### PR DESCRIPTION
This update brings a brand new Public Pool widget, allowing you to see your pool stats at a glance right from your umbrelOS home screen!

To add this widget, right-click on your home screen and select "Edit widgets", or click on Widgets in the Dock.

<img width="320" alt="image" src="https://github.com/user-attachments/assets/74d7f8fd-b2f2-469a-b941-1a805fd4a288" />
