### PR TITLE
Update Sonarr to v4.0.13

### DIFF
--- a/sonarr/docker-compose.yml
+++ b/sonarr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/sonarr:4.0.12@sha256:23f6911b2b81cb69aa03166b53c15081d5c3a5ed58f5b183c5900c2d8fc9759a
+    image: linuxserver/sonarr:4.0.13@sha256:28d9dcbc846aed74bd47dc90305e016183443ddc3dfa3e8bcac268fc653a6e5e
     environment:
       - PUID=1000
       - PGID=1000

--- a/sonarr/umbrel-app.yml
+++ b/sonarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: sonarr
 category: media
 name: Sonarr
-version: "4.0.12.2823"
+version: "4.0.13.2932"
 tagline: Smart PVR for newsgroup and bittorrent users
 description: >-
   Sonarr is a PVR for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.

--- a/sonarr/umbrel-app.yml
+++ b/sonarr/umbrel-app.yml
@@ -30,16 +30,31 @@ path: ""
 releaseNotes: >-
   This update includes several improvements and new features:
 
-    - Added ability to change root folder when editing series
-    - Added new language fields in webhook notifications
-    - Added series genres for search results
-    - Added reactive search button on Wanted pages
-    - Added option to append instance name to Telegram notifications
-    - Improved handling of file imports and downloads
-    - Enhanced calendar functionality and UI
-    - Fixed various issues with Custom Format scoring
-    - Fixed issues with series tags and download clients
-    - Improved synchronization for import lists
+    - Fix: adjust qBittorrent ratio limit check accounting for float.
+    - remove 0.0.0.0 validation for bind host.
+    - Translations update from Servarr Weblate.
+    - Fixed: Tooltips for detailed error messages.
+    - Additional logging for custom format score by.
+    - Remote image links for Discord's manual interaction needed.
+    - New: show release source in history grab popup.
+    - Additional logging for delay profile decisions.
+    - update translation widget.
+    - Fixed: Series added via other IDs unmonitored/tagged unexpectedly.
+    - New: Parse releases with year and season number in brackets.
+    - Translations update from Servarr Weblate.
+    - dd reflink support for ZFS.
+    - Fix translation key for RSS in History Details.
+    - Fixed: Map covers to local for Series Editor.
+    - Fixed: Parsing of AKA release titles.
+    - Fixed: Augmenting languages for releases with MULTI and other languages.
+    - Translations update from Servarr Weblate.
+    - Prevent page crash on console.error being used with non-string values.
+    - Fix: respect MonitoredOnly for search for specials.
+    - add .scr to dangerousExtensions.
+    - Fix: Fail downloads for dangerous.
+    - Translations update from Servarr Weblate.
+    - Fixed: Drop downs flickering in some cases.
+    - Translations update from Servarr Weblate.
 
 
   Full release notes for Sonarr can be found at https://github.com/Sonarr/Sonarr/releases


### PR DESCRIPTION
Update Sonarr to version 4.0.13

This update includes several improvements and new features:

    - Fix: adjust qBittorrent ratio limit check accounting for float.
    - remove 0.0.0.0 validation for bind host.
    - Translations update from Servarr Weblate.
    - Fixed: Tooltips for detailed error messages.
    - Additional logging for custom format score by.
    - Remote image links for Discord's manual interaction needed.
    - New: show release source in history grab popup.
    - Additional logging for delay profile decisions.
    - update translation widget.
    - Fixed: Series added via other IDs unmonitored/tagged unexpectedly.
    - New: Parse releases with year and season number in brackets.
    - Translations update from Servarr Weblate.
    - dd reflink support for ZFS.
    - Fix translation key for RSS in History Details.
    - Fixed: Map covers to local for Series Editor.
    - Fixed: Parsing of AKA release titles.
    - Fixed: Augmenting languages for releases with MULTI and other languages.
    - Translations update from Servarr Weblate.
    - Prevent page crash on console.error being used with non-string values.
    - Fix: respect MonitoredOnly for search for specials.
    - add .scr to dangerousExtensions.
    - Fix: Fail downloads for dangerous.
    - Translations update from Servarr Weblate.
    - Fixed: Drop downs flickering in some cases.
    - Translations update from Servarr Weblate.