### PR TITLE
Update to the latest simple-monerod image

### DIFF
--- a/monero/docker-compose.yml
+++ b/monero/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     restart: unless-stopped
     stop_grace_period: 15m
     command: "${APP_MONERO_COMMAND}"
-    image: ghcr.io/sethforprivacy/simple-monerod:v0.18.3.4@sha256:26535f28aba4e8404a8a9a362b27beadfa48e25e23b73c20886cdbe342013690 
+    image: ghcr.io/sethforprivacy/simple-monerod:v0.18.3.4@sha256:7f5a3fde6720aa0d35bfc454af4117d24230235f5310fabdf74d634003d2994c
     ports:
       - "${APP_MONERO_P2P_PORT}:${APP_MONERO_P2P_PORT}"
       - "${APP_MONERO_RPC_PORT}:${APP_MONERO_RPC_PORT}"

--- a/monero/umbrel-app.yml
+++ b/monero/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: monero
 category: finance
 name: Monero Node
-version: "0.18.3.4"
+version: "0.18.3.4-1"
 tagline: Run a monero node
 description: >-
   Run your monero node and independently store and validate every single Monero transaction with it.
@@ -23,11 +23,7 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  Highlights:
-    - Support for locked transfers has been removed.
-    - The daemon now skips privacy networks that lack outgoing connections.
-    - Improvements to the daemon include preventing duplicate transactions in the fluff queue and fixing unintended disconnections.
-    - Resolved bugs in the daemon’s ZMQ DaemonInfo functionality.
-    - Fixed an issue with the stagenet wallet restore height estimate.
-    - Added support for Ledger Flex in the wallet.
-    - Resolved a bug in the log rotation mechanism.
+  This update keeps monerod on version 0.18.3.4, but enables a ban list of suspected spy node IP addresses, as recommended by Monero Reesearch Lab.
+
+
+  Further details can be found at https://github.com/monero-project/meta/issues/1124


### PR DESCRIPTION
This image includes the ban list of suspected spy node IP addresses, provided by the Monero Research Lab.

References:

- https://github.com/monero-project/meta/issues/1124

- https://github.com/sethforprivacy/simple-monerod-docker/commit/cea9d8c83738f8164f8d8e09648c916c571c1571