### PR TITLE
Update Bitcoin Node to v28.1

### DIFF
--- a/bitcoin/docker-compose.yml
+++ b/bitcoin/docker-compose.yml
@@ -40,7 +40,7 @@ services:
         ipv4_address: $APP_BITCOIN_IP
 
   bitcoind:
-    image: getumbrel/bitcoind:v28.0@sha256:95c5eb9778fc0050e185b22700061fb7e7d71a0c27860067461bed2afcfbe5c4
+    image: getumbrel/bitcoind:v28.1@sha256:c565266ea302c9ab2fc490f04ff14e584210cde3d0d991b8309157e5dfae9e8d
     user: "1000:1000"
     command: "${APP_BITCOIN_COMMAND}"
     restart: unless-stopped

--- a/bitcoin/exports.sh
+++ b/bitcoin/exports.sh
@@ -121,8 +121,10 @@ BIN_ARGS+=( "-zmqpubsequence=tcp://0.0.0.0:${APP_BITCOIN_ZMQ_SEQUENCE_PORT}" )
 # BIN_ARGS+=( "-rpcworkqueue=128" )
 # We can remove depratedrpc=create_bdb in a future update once Jam (JoinMarket) implements descriptor wallet support
 BIN_ARGS+=( "-deprecatedrpc=create_bdb" )
+
 # Required for LND compatibility. We can remove deprecatedrpc=warnings in a future update once LND releases a version with this fix: https://github.com/btcsuite/btcd/pull/2245
-BIN_ARGS+=( "-deprecatedrpc=warnings" )
+# No longer required as of LND v0.18.4
+# BIN_ARGS+=( "-deprecatedrpc=warnings" )
 
 export APP_BITCOIN_COMMAND=$(IFS=" "; echo "${BIN_ARGS[@]}")
 

--- a/bitcoin/exports.sh
+++ b/bitcoin/exports.sh
@@ -102,6 +102,7 @@ BIN_ARGS=()
 # BIN_ARGS+=( "-port=${APP_BITCOIN_P2P_PORT}" )
 # BIN_ARGS+=( "-rpcport=${APP_BITCOIN_RPC_PORT}" )
 # We hardcode the ports p2p and rpc ports to always be the same for all networks
+# As of v28.1, the default onion listening port will now be derived to be -port + 1 instead of being set to a fixed value (8334 on mainnet)
 BIN_ARGS+=( "-port=8333" )
 BIN_ARGS+=( "-rpcport=8332" )
 BIN_ARGS+=( "-rpcbind=${APP_BITCOIN_NODE_IP}" )

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -42,6 +42,9 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
+  ⚠️ If you are running the Lightning Node app (LND) connected to your Bitcoin Node app, please update Lightning Node to the latest version available in the app store to ensure compatibility.
+
+
   Bitcoin Core has been updated to v28.1. See the full Bitcoin Core release notes at https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-28.1.md
 widgets:
   - id: "stats"

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bitcoin
 category: bitcoin
 name: Bitcoin Node
-version: "28.0"
+version: "28.1"
 tagline: Run your personal node powered by Bitcoin Core
 description: >-
   Run your Bitcoin node and independently store and validate
@@ -42,10 +42,7 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  Highlights:
-    - Bitcoin Core Update: Bitcoin Core has been updated to v28.0, which includes new features, bug fixes, and performance improvements. See the full Bitcoin Core release notes at https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-28.0.md
-    - Testnet4 Availability: Testnet4 is now accessible via Advanced Settings. Testnet3 remains available but is expected to be removed in a future Bitcoin Core release.
-    - Configuration Update: The mempoolfullrbf setting is now enabled by default for new installs. If you're upgrading from a previous version, your current mempoolfullrbf setting will not be changed. This can be adjusted in Advanced Settings.
+  Bitcoin Core has been updated to v28.1. See the full Bitcoin Core release notes at https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-28.1.md
 widgets:
   - id: "stats"
     type: "four-stats"


### PR DESCRIPTION
Pending compatibility testing with major apps in the ecosystem.

TODO: check if `-deprecatedrpc=warnings` can be removed for new LND update https://github.com/lightningnetwork/lnd/blob/0-18-4-branch/docs/release-notes/release-notes-0.18.4.md#functional-enhancements