### PR TITLE
Update Lightning Node to 0.18.5-beta

### DIFF
--- a/lightning/docker-compose.yml
+++ b/lightning/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
   lnd:
     hostname: "${DEVICE_DOMAIN_NAME}" # Needed so LND can generate a valid cert
-    image: lightninglabs/lnd:v0.18.3-beta@sha256:f86bbec4dfb370436384db5d67732bbd627bf6b7f574bde3d5eed32242132287
+    image: lightninglabs/lnd:v0.18.5-beta@sha256:2b560c9beb559c57ab2f2da1dfed80d286cf11a6dc6e4354cab84aafba79b6f6
     command: "${APP_LIGHTNING_COMMAND}"
     user: 1000:1000
     restart: unless-stopped

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: lightning
 category: bitcoin
 name: Lightning Node
-version: "0.18.3-beta"
+version: "0.18.5-beta"
 tagline: Run your personal Lightning Network node
 description: >-
   Run your personal Lightning Network node, and join the future of Bitcoin today.
@@ -22,7 +22,8 @@ description: >-
 
   An official app from Umbrel.
 releaseNotes: >-
-  This release updates the underlying Lightning Network Daemon (LND) to v0.18.3-beta, which includes bug fixes and stability improvements, as well as support for sending and receiving blinded paths using BOLT 11 invoices.
+  This release updates the underlying Lightning Network Daemon (LND) to v0.18.5-beta, which includes the features required for building custom channels, alongside important bug fixes, stability enhancements, and performance improvements.
+  Notable highlights include an optimization for payment requests (invoices) that removes unnecessary size expansion, critical bug fixes for AMP invoices and erroneous invoice state transitions, and improvements for fee bump transactions.
 
 
   Full release notes can be found at https://github.com/lightningnetwork/lnd/releases


### PR DESCRIPTION
Pending compatibility testing with major apps in the ecosystem.

TODO: check if `-deprecatedrpc=warnings` can be now be removed from the Bitcoin Node app
https://github.com/lightningnetwork/lnd/blob/0-18-4-branch/docs/release-notes/release-notes-0.18.4.md#functional-enhancements

This update is holding up https://github.com/getumbrel/umbrel-apps/pull/2184