### PR TITLE
LND conf: enable bLIP-50: LSP Spec Transport Layer

### DIFF
--- a/lightning/exports.sh
+++ b/lightning/exports.sh
@@ -43,6 +43,9 @@ BIN_ARGS+=( "--tor.socks=${TOR_PROXY_IP}:${TOR_PROXY_PORT}" )
 BIN_ARGS+=( "--tor.targetipaddress=${APP_LIGHTNING_NODE_IP}" )
 BIN_ARGS+=( "--tor.password=${TOR_PASSWORD}" )
 
+# [protocol]
+BIN_ARGS+=( "--protocol.custom-message=37913" )
+
 export APP_LIGHTNING_COMMAND=$(IFS=" "; echo "${BIN_ARGS[@]}")
 
 # echo "${APP_LIGHTNING_COMMAND}"


### PR DESCRIPTION
LSPS0/bLIP-50 has recently been [merged into the bLIP spec](https://github.com/lightning/blips/blob/master/blip-0050.md). This is a communication protocol over Lightning's p2p messaging layer called BOLT8, and is used for clients to communicate with Lightning Service Providers and vice versa.

At present, LND doesn't allow applications to communicate over BOLT8 with message types higher than 32768, without building with the `dev` tag or modifying the LND configuration. LSPS0/bLIP-50 uses type 37913.

This configuration change will allow Umbrel users to interface with LSP spec-compliant services, such as ZEUS' Olympus.