### PR TITLE
Update Cloudflared to 2025.2.0

### DIFF
--- a/cloudflared/docker-compose.yml
+++ b/cloudflared/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       CLOUDFLARED_TOKEN_FILE: "/app/data/token"
 
   connector:
-    image: ghcr.io/radiokot/umbrel-cloudflared-connector:1.0.0-cf.2024.6.1@sha256:6f008e93af8c1230ad3d13df853aa182344eca5577725bf0ce80376de029a809
+    image: ghcr.io/radiokot/umbrel-cloudflared-connector:1.0.0-cf.2025.2.0@sha256:9a126ccfd01e93e447a98f246cc948b55b4822455beb7dda995dfb216c1b3eab
     hostname: cloudflared-connector
     restart: on-failure
     stop_grace_period: 5s

--- a/cloudflared/umbrel-app.yml
+++ b/cloudflared/umbrel-app.yml
@@ -34,7 +34,7 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  The tunneling daemon (cloudflared) has been updated to 2024.6.1
+  The tunneling daemon (cloudflared) has been updated to 2025.2.0
 dependencies: []
 path: ""
 defaultUsername: ""

--- a/cloudflared/umbrel-app.yml
+++ b/cloudflared/umbrel-app.yml
@@ -3,7 +3,7 @@ id: cloudflared
 name: Cloudflare Tunnel
 tagline: Access your Umbrel apps from the Internet using Cloudflare network
 category: networking
-version: "2024.6.1 (web 1.0.2)"
+version: "2025.2.0"
 port: 4499
 description: >-
   Start a secure tunnel to access your Umbrel apps from the Internet using the Cloudflare network. 


### PR DESCRIPTION
The tunneling daemon (cloudflared) has been updated to 2025.2.0. This update includes security patches, performance improvements, and bug fixes. There are no visible changes in this update.