### PR TITLE
Update adguard-home to v0.107.57

### DIFF
--- a/adguard-home/docker-compose.yml
+++ b/adguard-home/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   server:
-    image: adguard/adguardhome:v0.107.56@sha256:c64a0b37f7b9f7e065089f34686c1232a4dd5401a199a1b20b074d90b955eebd
+    image: adguard/adguardhome:v0.107.57@sha256:5c536c1e25f76693ae7ee5e64e8a029893e0f3f1778c8d2a9581383e60cfa9b9
     # override the default command to set the web address to port 8095 to avoid conflict with Thunderhub
     # command from Dockerfile: https://github.com/AdguardTeam/AdGuardHome/blob/master/docker/Dockerfile
     command: ["--no-check-update", "-c", "/opt/adguardhome/conf/AdGuardHome.yaml", "-w", "/opt/adguardhome/work", "--web-addr", "0.0.0.0:8095"]

--- a/adguard-home/umbrel-app.yml
+++ b/adguard-home/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: adguard-home
 category: networking
 name: AdGuard Home
-version: "0.107.56"
+version: "0.107.57"
 tagline: Network-wide software for blocking ads and tracking
 description: >-
   ⚠️ See below for important set-up instructions.
@@ -22,10 +22,9 @@ releaseNotes: >-
   This release includes security improvements and bug fixes:
 
     - Updated core components to address security vulnerabilities
-    - Improved formatting of large numbers on the dashboard
-    - Enhanced client request tracking functionality
-    - Fixed various performance and stability issues
-
+    - Fixed an issue where hostnames of DHCP clients were not being shown in the Top clients table on the dashboard
+    - Fixed formatting of large numbers in the upstream table and query log
+    - Added the ability to specify the upstream timeout in the Web UI
 
   Full release notes can be found at https://github.com/AdguardTeam/AdGuardHome/releases
 developer: Adguard


### PR DESCRIPTION
🤖 This is an automated summary of installation tests for adguard-home:

- ✅ App successfully installed in umbrel-dev instance
- ✅ App successfully listed in umbrel.yaml
- ✅ App UI successfully returns a 200 status code
- 📸 Screenshot of the app:
  ![App Screenshot](https://raw.githubusercontent.com/al-lac/app-testing-screenshots/main/screenshots/1740154446115_adguard-home_2025-02-21T16-14-05-956Z.png)

**This PR must still be reviewed and tested before merging.**