### PR TITLE
Update gitea to v1.23.4

### DIFF
--- a/gitea/docker-compose.yml
+++ b/gitea/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: gitea/gitea:1.23.3-rootless@sha256:96899d07bfcc84a42bfbab2ff2cb711f0e5f25bae06dd187a3fb080c8f8233a2
+    image: gitea/gitea:1.23.4-rootless@sha256:325b856867abcbbde7ca085b81e51ceb6b304e67f99348299195ca909f043964
     user: "1000:1000"
     restart: on-failure
     ports:

--- a/gitea/umbrel-app.yml
+++ b/gitea/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: gitea
 category: developer
 name: Gitea
-version: "1.23.3"
+version: "1.23.4"
 tagline: A painless self-hosted Git service
 description: >-
   Gitea is a painless self-hosted Git service. It is similar to
@@ -52,7 +52,9 @@ releaseNotes: >
     - Improved tracked time display and sync fork behavior
     - Fixed various UI and functionality issues
 
-  As always, please review the full release notes for any changes that may affect your setup: https://github.com/go-gitea/gitea/releases
+  This release also addresses security vulnerabilities related to Actions variable and runner operations.
+
+  Full release notes are found at https://github.com/go-gitea/gitea/releases
 torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/d62e00353917143a3a10d3b376859f51b665d150

--- a/gitea/umbrel-app.yml
+++ b/gitea/umbrel-app.yml
@@ -44,17 +44,17 @@ defaultPassword: ""
 releaseNotes: >
   This update includes various enhancements and bug fixes:
 
-    - Build Gitea with Golang v1.23.6 to fix security bugs
-    - Fix a bug caused by status webhook template
-    - Improved clone button functionality
-    - Enhanced repository homepage styling
-    - Added confirmation dialog for "sync fork" action
-    - Improved tracked time display and sync fork behavior
-    - Fixed various UI and functionality issues
+    - Enhanced router protections for Actions variables and runner operations, fixed project issues list
+    - Improved loading speed for pull request comments and attachments
+    - Fixed mirror sync issues and repository health checking
+    - Improved pull request target branch dropdown functionality
+    - Fixed multiple issues including artifact ordering and assignee checks
+    - Reworked the suggestion backend system
+    - Made actions URLs absolute in commit status webhooks
+    - Added missing locale translation
+    - Fixed various context usage problems
 
-  This release also addresses security vulnerabilities related to Actions variable and runner operations.
-
-  Full release notes are found at https://github.com/go-gitea/gitea/releases
+  As always, please review the full release notes for any changes that may affect your setup: https://github.com/go-gitea/gitea/releases
 torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/d62e00353917143a3a10d3b376859f51b665d150


### PR DESCRIPTION
🤖 This is an automated summary of installation tests for gitea:

- ✅ App successfully installed in umbrel-dev instance
- ✅ App successfully listed in umbrel.yaml
- ✅ App UI successfully returns a 200 status code
- 📸 Screenshot of the app:
  ![App Screenshot](https://raw.githubusercontent.com/al-lac/app-testing-screenshots/main/screenshots/1740154859018_gitea_2025-02-21T16-20-58-844Z.png)

**This PR must still be reviewed and tested before merging.**