### PR TITLE
[Awaiting new image] - Update Zabbix to v7.2.4

### DIFF
--- a/zabbix/docker-compose.yml
+++ b/zabbix/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       APP_PORT: 8080
 
   zabbix-frontend:
-    image: zabbix/zabbix-web-nginx-pgsql:7.2.3-alpine@sha256:9dc09565d79e5a714c468657b3429c7d22883b6741c9b73bee03b6fa598eb46b
+    image: zabbix/zabbix-web-nginx-pgsql:7.2.4-alpine@zabbix/zabbix-web-nginx-pgsql:7.2.4-alpine
     hostname: zabbix-frontend
     restart: on-failure
     environment:
@@ -36,7 +36,7 @@ services:
       - zabbix-database
 
   zabbix-agent:
-    image: zabbix/zabbix-agent2:7.2.3-alpine@sha256:e1d852e7cb9957063488bfb825c1b71b8c623b83c12831025e147798ffc28fdd
+    image: zabbix/zabbix-agent2:7.2.4-alpine@sha256:8a1ff9da1b0d36ed140e59df361ab310dcde71993bff6e943f235c8385ab2f8d
     hostname: zabbix-agent
     restart: on-failure
     init: true

--- a/zabbix/docker-compose.yml
+++ b/zabbix/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       APP_PORT: 8080
 
   zabbix-frontend:
-    image: zabbix/zabbix-web-nginx-pgsql:7.2.4-alpine@zabbix/zabbix-web-nginx-pgsql:7.2.4-alpine
+    image: zabbix/zabbix-web-nginx-pgsql:7.2.4-alpine@sha256:363e0dafc6f6009e5edec6fda66a75ec0e97618cc752ad30afb72bd56463b120
     hostname: zabbix-frontend
     restart: on-failure
     environment:

--- a/zabbix/docker-compose.yml
+++ b/zabbix/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - zabbix-database
 
   zabbix-server:
-    image: zabbix/zabbix-server-pgsql:7.2.3-alpine@sha256:d3b4308dcf91c88e925ebd936f89467dfee7a03e98cb6e494dd0a34f7754f772
+    image: zabbix/zabbix-server-pgsql:7.2.4-alpine@sha256:634e116baad3e668c8bcc96af901f4ea740a2b0ea9f0557ec0859ee842085909
     hostname: zabbix-server
     restart: on-failure
     init: true

--- a/zabbix/umbrel-app.yml
+++ b/zabbix/umbrel-app.yml
@@ -3,7 +3,7 @@ id: zabbix
 category: networking
 name: Zabbix
 tagline: The all-in-one, open-source solution that lets you monitor anything
-version: "7.2.3"
+version: "7.2.4"
 description: >-
   ⚠️ Zabbix may take a few minutes to initialize after installation. Please be patient.
   
@@ -47,12 +47,16 @@ defaultPassword: "zabbix"
 torOnly: false
 releaseNotes: >-
   This release includes several improvements and bug fixes:
-    - Improved error handling in agent plugins
-    - Enhanced UI elements including better graph rendering and form layouts
-    - Optimized VMware monitoring performance
-    - Fixed various preprocessing and macro handling issues
-    - Improved SNMP monitoring reliability
-
+    - New Features & Improvements
+      - **New Templates Added:** Support for Palo Alto PA-440, Azure SQL Managed Instance, Dell (HTTP & SNMP), and Systemd service unit discovery.
+      - **Compatibility Updates:** Now supports PHP 8.4 and TimescaleDB up to version 2.18.
+      - **Enhancements in Agent & API:** Added user parameters for Redis in Zabbix Agent 2, improved handling of service type macros, and proofread Nvidia templates.
+    - Bug Fixes
+      - **Data Integrity & Stability:** Prevented accidental deletion of key elements (hosts, triggers, services) if they are in use.
+      - **User Experience Fixes:** Restored alert visibility for users in the same group, improved UI elements (labels, dropdowns, graphs, tooltips).
+      - **Performance Enhancements:** Reduced load on history syncers, fixed excessive cache filling, and optimized maintenance and trigger handling.
+      - **Agent & Proxy Improvements:** Fixed serialization issues, incorrect exit codes, and buffer sizes in Zabbix Agent 2.
+      - **Security & Configuration Updates:** Improved DNS handling, resolved MQTT message blocking, and enhanced Modbus data interpretation.
 
   Full release notes are available at https://www.zabbix.com/release_notes.
 submitter: DavidGarciaCat


### PR DESCRIPTION
Upgrade Zabbix to version 7.2.4

At the time of creating this PR, Zabbix Server's Alpine image was not pushed yet:  
https://hub.docker.com/r/zabbix/zabbix-server-pgsql/tags?name=7.2.4-alpine

We can apply this last update as soon as the image is available, then we can merge