### PR TITLE
Update n8n to version 1.80.3

### DIFF
--- a/n8n/docker-compose.yml
+++ b/n8n/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       PROXY_AUTH_WHITELIST: "/webhook-test/*,/webhook/*"
 
   server:
-    image: n8nio/n8n:1.78.1@sha256:89f13a316252535fe20623f82960256bc277bbcead897bd2be381f456f8d5c81
+    image: n8nio/n8n:1.80.3@sha256:76997d169566a957f9304027c2f7e4304bc684ddf7ec7120602dc2a0b66e42ce
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/home/node/.n8n

--- a/n8n/umbrel-app.yml
+++ b/n8n/umbrel-app.yml
@@ -4,7 +4,8 @@ category: automation
 name: n8n
 version: "1.80.3"
 releaseNotes: >-
-  This is a small bugfix release.
+  This update fixes multiple bugs and adds pagination to the workflow list.
+
 
   Full release notes are found at https://github.com/n8n-io/n8n/releases
 tagline: Build complex workflows, really fast

--- a/n8n/umbrel-app.yml
+++ b/n8n/umbrel-app.yml
@@ -2,10 +2,9 @@ manifestVersion: 1
 id: n8n
 category: automation
 name: n8n
-version: "1.78.1"
+version: "1.80.3"
 releaseNotes: >-
   This is a small bugfix release.
-
 
   Full release notes are found at https://github.com/n8n-io/n8n/releases
 tagline: Build complex workflows, really fast


### PR DESCRIPTION
🤖 This is an automated summary of installation tests for n8n:

- ✅ App successfully installed in umbrel-dev instance
- ✅ App successfully listed in umbrel.yaml
- ✅ App UI successfully returns a 200 status code
- 📸 Screenshot of the app:
  ![App Screenshot](https://raw.githubusercontent.com/al-lac/app-testing-screenshots/main/screenshots/1740594800033_n8n_2025-02-26T18-33-19-851Z.png)

Tested on Umbrel Home and Dev instance.