### PR TITLE
Update pi-hole to version 2025.02.6

### DIFF
--- a/pi-hole/docker-compose.yml
+++ b/pi-hole/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   server:
-    image: pihole/pihole:2024.07.0@sha256:0def896a596e8d45780b6359dbf82fc8c75ef05b97e095452e67a0a4ccc95377
+    image: pihole/pihole:2025.02.6@sha256:bcf79fe65348067d17b7b14fd7e2cb8177bbb4e972e1880a905169334e69c1a2
     # Pi-hole doesn't currently support running as non-root
     # https://github.com/pi-hole/docker-pi-hole/issues/685
     # user: "1000:1000"

--- a/pi-hole/docker-compose.yml
+++ b/pi-hole/docker-compose.yml
@@ -12,10 +12,9 @@ services:
       - ${APP_DATA_DIR}/data/pihole:/etc/pihole/
       - ${APP_DATA_DIR}/data/dnsmasq:/etc/dnsmasq.d/
     environment:
-      - VIRTUAL_HOST=${APP_DOMAIN}
-      - WEBPASSWORD=${APP_PASSWORD}
-      - WEB_PORT=8082
+      - FTLCONF_webserver_api_password=${APP_PASSWORD}
+      - FTLCONF_webserver_port=8082
       # Listen on all interfaces, permit all origins
-      - DNSMASQ_LISTENING=all
+      - FTLCONF_dns_listeningMode=all
     cap_add:
       - NET_ADMIN

--- a/pi-hole/umbrel-app.yml
+++ b/pi-hole/umbrel-app.yml
@@ -34,6 +34,7 @@ torOnly: false
 releaseNotes: >-
   This release comes with Pi-hole version 6 and adds a lot of new features.
 
+
   Highlights:
     - Redesigned User Interface
     - Embedded Web Server and REST API

--- a/pi-hole/umbrel-app.yml
+++ b/pi-hole/umbrel-app.yml
@@ -32,9 +32,16 @@ defaultUsername: ""
 deterministicPassword: true
 torOnly: false
 releaseNotes: >-
-  This release includes an update to PADD v4.0.0.
+  This release comes with Pi-hole version 6 and adds a lot of new features.
 
+  Highlights:
+    - Redesigned User Interface
+    - Embedded Web Server and REST API
+    - Advanced Filtering and Allowlists
+    - Consolidated Configuration Files
+    - HTTPS Support
+    - Alpine based Docker image
 
-  Full release notes are found at https://github.com/pi-hole/PADD/compare/v3.11.1...v4.0.0
+  Full release notes can be found at https://pi-hole.net/blog/2025/02/18/introducing-pi-hole-v6/
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/9ca55a25e043dcd50d5cb92c6ec756d368bb4794

--- a/pi-hole/umbrel-app.yml
+++ b/pi-hole/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: pi-hole
 category: networking
 name: Pi-hole
-version: "2024.07.0"
+version: "2025.02.6"
 tagline: Block ads on your entire network
 description: >-
   Instead of browser plugins or other software on each computer,
@@ -32,9 +32,9 @@ defaultUsername: ""
 deterministicPassword: true
 torOnly: false
 releaseNotes: >-
-  🚨 This release fixes a vulnerability that was recently discovered in Pi-hole's gravity script that could allow an authenticated user to read system files through the web interface. Please update immediately. 
+  This release includes an update to PADD v4.0.0.
 
 
-  More information can be found at https://github.com/pi-hole/pi-hole/security/advisories/GHSA-95g6-7q26-mp9x
+  Full release notes are found at https://github.com/pi-hole/PADD/compare/v3.11.1...v4.0.0
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/9ca55a25e043dcd50d5cb92c6ec756d368bb4794


### PR DESCRIPTION
Tested fresh install on dev instance and update on Umbrel Home. 

Some more testing would be needed still.