### PR TITLE
Update duplicati to version v2.1.0.4_stable_2025-01-31

### DIFF
--- a/duplicati/docker-compose.yml
+++ b/duplicati/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
   
   duplicati:
-    image: duplicati/duplicati:2.1.0.2@sha256:5cfae82b909212e29fbcfe6f597d73bd68ea202e54333135e05193b99974f69b
+    image: duplicati/duplicati:2.1.0.4@sha256:c6a2efddd86bdaf7c6927ea5c807986df7c0395581d061595db4884db2783ac5
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -20,4 +20,3 @@ services:
       DUPLICATI__WEBSERVICE_INTERFACE: "any"
       DUPLICATI__WEBSERVICE_PASSWORD: "${APP_PASSWORD}"
       DUPLICATI__WEBSERVICE_ALLOWED_HOSTNAMES: "*"
-

--- a/duplicati/umbrel-app.yml
+++ b/duplicati/umbrel-app.yml
@@ -3,7 +3,7 @@ id: duplicati
 name: Duplicati
 tagline: Store securely encrypted backups in the cloud
 category: files
-version: "2.1.0.2_beta_2024-11-29"
+version: "2.1.0.4_stable_2025-01-31"
 port: 38476
 description: >-
   Pick your own backend and store encrypted backups of your umbrel files anywhere!
@@ -38,13 +38,17 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  Highlights:
-    - Added support for encrypting specific database fields.
-    - Introduced an experimental new UI.
-    - Added Telegram as a reporting destination.
-    - Improved IPv6 support and remote control capabilities.
-    - Updated WebDAV and FTP backends for better reliability.
-    - Removed legacy features like 7z compression and RC4 database encryption.
+  🚨 Important: This update requires a mandatory password and uses a new authentication scheme for the server. Automatic updating is not supported.
+
+
+  Some of the key highlights in this release include:
+    - Updated to .NET8 with OS specific builds
+    - Using Kestrel as the API/UI server
+    - Updated the authentication system
+    - Added support for encrypting database fields
+    - Fixed a number of stability issues
+    - Added support for remote control
+
 
   Full release notes can be found at https://github.com/duplicati/duplicati/releases
 dependencies: []

--- a/duplicati/umbrel-app.yml
+++ b/duplicati/umbrel-app.yml
@@ -38,10 +38,10 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  🚨 Important: This update requires a mandatory password and uses a new authentication scheme for the server. Automatic updating is not supported.
+  This is the first stable release of the Duplicati 2.x codebase.
 
 
-  Some of the key highlights in this release include:
+  Some of the key highlights:
     - Updated to .NET8 with OS specific builds
     - Using Kestrel as the API/UI server
     - Updated the authentication system


### PR DESCRIPTION
🤖 This is an automated summary of installation tests for duplicati:

- ✅ App successfully installed in umbrel-dev instance
- ✅ App successfully listed in umbrel.yaml
- ✅ App UI successfully returns a 200 status code
- 📸 Screenshot of the app:
  ![App Screenshot](https://raw.githubusercontent.com/al-lac/app-testing-screenshots/main/screenshots/1740610276386_duplicati_2025-02-26T22-51-16-239Z.png)

Tested fresh install on dev instance and update on Umbrel Home.