### PR TITLE
Remove docker compose options that were not compatible with older umbrel versions

### DIFF
--- a/romm/docker-compose.yml
+++ b/romm/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-        restart: true
     environment:
       - DB_HOST=romm_db_1
       - DB_NAME=romm
@@ -47,7 +46,6 @@ services:
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       start_period: 30s
-      start_interval: 10s
       interval: 10s
       timeout: 5s
       retries: 5

--- a/romm/umbrel-app.yml
+++ b/romm/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: romm
 category: media
 name: RomM
-version: "3.7.3"
+version: "3.7.3-1"
 tagline: A beautiful, powerful, self-hosted rom manager
 description: >-
   👾 RomM (ROM Manager) allows you to scan, enrich, browse and play your game collection with a clean and responsive interface.
@@ -35,4 +35,5 @@ dependencies: []
 path: ""
 defaultUsername: ""
 defaultPassword: ""
-releaseNotes: ""
+releaseNotes: >-
+  This update fixes a bug that prevented the app from working on older umbrel versions.


### PR DESCRIPTION
This update removes newer docker compose options that prevent the app from being installed on older umbrel versions like 0.5.4. 

Fixes #2228