### PR TITLE
Wikijs repo fix

### DIFF
--- a/wikijs/docker-compose.yml
+++ b/wikijs/docker-compose.yml
@@ -8,11 +8,10 @@ services:
       PROXY_AUTH_ADD: "false"
   
   server:
+    user: "1000:1000"
     image: linuxserver/wikijs:2.5.306@sha256:4868253594b2511b7c6054aa83695332bf3e77257b667c84e276e62668e36b62
     restart: on-failure
-    environment:
-      - PUID=1000
-      - PGID=1000
     volumes:
       - ${APP_DATA_DIR}/data:/data
+      - ${APP_DATA_DIR}/repo:/app/wiki/data/repo
       - ${APP_DATA_DIR}/config:/config

--- a/wikijs/hooks/pre-start
+++ b/wikijs/hooks/pre-start
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DATA_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)/data"
+APP_CONFIG_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)/config"
+APP_REPO_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)/repo"
+
+# Create directories if they do not exist
+[ ! -d "${APP_DATA_DIR}" ] && mkdir -p "${APP_DATA_DIR}"
+[ ! -d "${APP_CONFIG_DIR}" ] && mkdir -p "${APP_CONFIG_DIR}"
+[ ! -d "${APP_REPO_DIR}" ] && mkdir -p "${APP_REPO_DIR}"
+
+# Recursively set ownership of all files and directories under APP_DATA_DIR to 1000:1000
+chown -R 1000:1000 "${APP_DATA_DIR}"
+chown -R 1000:1000 "${APP_CONFIG_DIR}"
+chown -R 1000:1000 "${APP_REPO_DIR}"

--- a/wikijs/hooks/pre-start
+++ b/wikijs/hooks/pre-start
@@ -5,12 +5,11 @@ APP_DATA_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)/data"
 APP_CONFIG_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)/config"
 APP_REPO_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)/repo"
 
-# Create directories if they do not exist
-[ ! -d "${APP_DATA_DIR}" ] && mkdir -p "${APP_DATA_DIR}"
-[ ! -d "${APP_CONFIG_DIR}" ] && mkdir -p "${APP_CONFIG_DIR}"
+# Create repo directory if it does not exist. This was not included for pre-2.5.306-1 installs
 [ ! -d "${APP_REPO_DIR}" ] && mkdir -p "${APP_REPO_DIR}"
 
-# Recursively set ownership of all files and directories under APP_DATA_DIR to 1000:1000
+# Recursively set ownership of all bind mounts to 1000:1000. wikijs was running as root for pre-2.5.306-1 installs
+# even though it was using "correct" PUID/PGID env vars for linuxserver.io images.
 chown -R 1000:1000 "${APP_DATA_DIR}"
 chown -R 1000:1000 "${APP_CONFIG_DIR}"
 chown -R 1000:1000 "${APP_REPO_DIR}"

--- a/wikijs/umbrel-app.yml
+++ b/wikijs/umbrel-app.yml
@@ -1,8 +1,8 @@
-manifestVersion: 1
+manifestVersion: 1.1
 id: wikijs
 category: developer
 name: WikiJS
-version: "2.5.306"
+version: "2.5.306-repo"
 tagline: Make documentation a joy to write
 description: >-
   The most powerful and extensible open source Wiki software.

--- a/wikijs/umbrel-app.yml
+++ b/wikijs/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: wikijs
 category: developer
 name: WikiJS
-version: "2.5.306-repo"
+version: "2.5.306-1"
 tagline: Make documentation a joy to write
 description: >-
   The most powerful and extensible open source Wiki software.
@@ -30,7 +30,10 @@ defaultUsername: ""
 defaultPassword: ""
 torOnly: false
 releaseNotes: >-
-  This update includes the following changes:
+  This update includes a bug fix that prevented access to the repo folder for syncing with git.
+
+
+  Version 2.5.306 includes the following changes:
     - Added a git always namespace option
     - Fixed an issue with HA mode activation
     - Improved compatibility with Elasticsearch


### PR DESCRIPTION
This update adds the repo folder to wikijs to fix permissions errors when using the git sync feature.

Fixes #2176.

Maybe you can test and take a look at the new hook @nmfretz. 