### PR TITLE
fix: Pihole over IPv6

### DIFF
--- a/pi-hole/docker-compose.yml
+++ b/pi-hole/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ${APP_DATA_DIR}/data/dnsmasq:/etc/dnsmasq.d/
     environment:
       - FTLCONF_webserver_api_password=${APP_PASSWORD}
-      - FTLCONF_webserver_port=8082
+      - FTLCONF_webserver_port=8082,[::]:8082
       # Listen on all interfaces, permit all origins
       - FTLCONF_dns_listeningMode=all
     cap_add:


### PR DESCRIPTION
Previously the web GUI was reachable over IPv4 and IPv6.

But recently someone updated this app to v6 and forgot to include the IPv6 port. So this corrects that issue.