### PR TITLE
Update Open-webUI to v0.5.20

### DIFF
--- a/open-webui/docker-compose.yml
+++ b/open-webui/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   web:
-    image: ghcr.io/open-webui/open-webui:v0.5.18@sha256:e774a5e695890b990ec2aa2f83ff52ff41d1f3fa33df11207d2418a2bc89ac63
+    image: ghcr.io/open-webui/open-webui:v0.5.20@sha256:92b238e6c27dc6dacda7769062444044ed71b78628e0a9810ba5cea25e0e1ba0
     volumes:
       - ${APP_DATA_DIR}/data/open-webui:/app/backend/data
     environment:

--- a/open-webui/umbrel-app.yml
+++ b/open-webui/umbrel-app.yml
@@ -3,7 +3,7 @@ id: open-webui
 name: Open WebUI
 tagline: Chat with Ollama models like DeepSeek-R1 and LLama, or use an OpenAI API key
 category: ai
-version: "0.5.18"
+version: "0.5.20"
 port: 2876
 description: >-
   Open WebUI lets you chat with advanced AI models running locally on your own device or connect to online models using an API key.
@@ -39,12 +39,16 @@ dependencies:
 releaseNotes: >-
   ⚠️ If you encounter errors when chatting with your existing ollama models after this update, please clear your browser cache to resolve.
   This is a known issue with ollama and open-webui that may occur after updating.
-
-
-  Highlights:
-    - 🌐 Open WebUI Now Works Over LAN in Insecure Context: Resolved an issue preventing Open WebUI from functioning when accessed over a local network in an insecure context, ensuring seamless connectivity.
-    - 🔄 UI Now Reflects Deleted Connections Instantly: Fixed an issue where deleting a connection did not update the UI in real time, ensuring accurate system state visibility.
-    - 🛠️ Models Now Display Correctly with ENABLE_FORWARD_USER_INFO_HEADERS: Addressed a bug where models were not visible when ENABLE_FORWARD_USER_INFO_HEADERS was set, restoring proper model listing.
+  
+  
+  **Added**
+    - ⚡ Toggle Code Execution On/Off: You can now enable or disable code execution, providing more control over security, ensuring a safer and more customizable experience.
+  
+  **Fixed**
+    - 📜 Pinyin Keyboard Enter Key Now Works Properly: Resolved an issue where the Enter key for Pinyin keyboards was not functioning as expected, ensuring seamless input for Chinese users.
+    - 🖼️ Web Manifest Loading Issue Fixed: Addressed inconsistencies with 'site.webmanifest', guaranteeing proper loading and representation of the app across different browsers and devices.
+    - 📦 Non-Root Container Issue Resolved: Fixed a critical issue where the UI failed to load correctly in non-root containers, ensuring reliable deployment in various environments.
 
   Full release notes can be found at https://github.com/open-webui/open-webui/releases
 path: ""
+

--- a/open-webui/umbrel-app.yml
+++ b/open-webui/umbrel-app.yml
@@ -43,11 +43,21 @@ releaseNotes: >-
   
   **Added**
     - ⚡ Toggle Code Execution On/Off: You can now enable or disable code execution, providing more control over security, ensuring a safer and more customizable experience.
+    - 📊 Logit Bias Parameter Support: Fine-tune conversation dynamics by adjusting the Logit Bias parameter directly in chat settings, giving you more control over model responses.
+    - ⌨️ Customizable Enter Behavior: You can now configure Enter to send messages only when combined with Ctrl (Ctrl+Enter) via Settings > Interface, preventing accidental message sends.
+    - 📝 Collapsible Code Blocks: Easily collapse long code blocks to declutter your chat, making it easier to focus on important details.
+    - 🏷️ Tag Selector in Model Selector: Quickly find and categorize models with the new tag filtering system in the Model Selector, streamlining model discovery.
+    - 📈 Experimental Elasticsearch Vector DB Support: Now supports Elasticsearch as a vector database, offering more flexibility for data retrieval in Retrieval-Augmented Generation (RAG) workflows.
+    - ⚙️ General Reliability Enhancements: Various stability improvements across the WebUI, ensuring a smoother, more consistent experience.
+    - 🌍 Updated Translations: Refined multilingual support for better localization and accuracy across various languages.
   
   **Fixed**
     - 📜 Pinyin Keyboard Enter Key Now Works Properly: Resolved an issue where the Enter key for Pinyin keyboards was not functioning as expected, ensuring seamless input for Chinese users.
     - 🖼️ Web Manifest Loading Issue Fixed: Addressed inconsistencies with 'site.webmanifest', guaranteeing proper loading and representation of the app across different browsers and devices.
     - 📦 Non-Root Container Issue Resolved: Fixed a critical issue where the UI failed to load correctly in non-root containers, ensuring reliable deployment in various environments.
+    - 🔄 "Stream" Hook Activation: Fixed an issue where the "Stream" hook only worked when globally enabled, ensuring reliable real-time filtering.
+    - 📧 LDAP Email Case Sensitivity: Resolved an issue where LDAP login failed due to email case sensitivity mismatches, improving authentication reliability.
+    - 💬 WebSocket Chat Event Registration: Fixed a bug preventing chat event listeners from being registered upon sign-in, ensuring real-time updates work properly.
 
   Full release notes can be found at https://github.com/open-webui/open-webui/releases
 path: ""


### PR DESCRIPTION
Tested by updating app-store files on Umbrel OS 1.4, and causing update to trigger:

  - `open-webui/docker-compose.yml`
  - `open-webui/umbrel-app.yml`

Update was successful without issues and existing data persists.