### PR TITLE
Update pi-hole to v2025.02.6-ipv6

### DIFF
--- a/pi-hole/umbrel-app.yml
+++ b/pi-hole/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: pi-hole
 category: networking
 name: Pi-hole
-version: "2025.02.6"
+version: "2025.02.6-ipv6"
 tagline: Block ads on your entire network
 description: >-
   Instead of browser plugins or other software on each computer,
@@ -34,6 +34,12 @@ torOnly: false
 releaseNotes: >-
   ⚠️ If you have set up your router to use Pi-hole as its only DNS server, umbrelOS may be unable to resolve domain names during the update, preventing it from downloading the update files.
   To avoid issues, temporarily set a backup DNS server (e.g., 1.1.1.1) on your router before updating— or configure a permanent fallback DNS to prevent future issues.
+
+
+  This is a small fix that allows umbrelOS users to access the Pi-hole web interface via an IPv6 address.
+
+
+  **Previous 2025.02.6 release notes:**
 
 
   This release comes with Pi-hole version 6 and adds a lot of new features.


### PR DESCRIPTION
Updates app manifest for https://github.com/getumbrel/umbrel-apps/pull/2288

Context: https://github.com/getumbrel/umbrel-apps/pull/2288#issuecomment-2709475716