### PR TITLE
Update blinko to version 0.43.4

### DIFF
--- a/blinko/docker-compose.yml
+++ b/blinko/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     restart: on-failure
 
   app:
-    image: blinkospace/blinko:0.38.6@sha256:e3779d43e987ef65429db43bf06e74da6e0f9896e1d11fb3539d2afb5e85a31b
+    image: blinkospace/blinko:0.43.4@sha256:0b610584e24a47058417d86de734225a42057f032bdaaced4ccab7dd62962bf5
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:1111"]
       interval: 30s 

--- a/blinko/umbrel-app.yml
+++ b/blinko/umbrel-app.yml
@@ -3,7 +3,7 @@ id: blinko
 name: Blinko
 tagline: An AI-powered hub for your ideas and notes
 category: files
-version: "0.38.6"
+version: "0.43.4"
 port: 1111
 description: >-
   😉 Blinko is an open-source application that combines note-taking, microblogging, pastebin functionality, task management, and AI-powered features in a self-hosted environment. The platform allows users to quickly and efficiently capture their thoughts, with full Markdown support for easy formatting.
@@ -30,7 +30,32 @@ gallery:
   - 3.jpg
   - 4.jpg
   - 5.jpg
-releaseNotes: ""
+releaseNotes: >-
+  This update of blinko brings a range of new features, enhancements, and bug fixes.
+
+
+  🎉 Highlights:
+    - Support for note history
+    - Enhanced AI capabilities with RAG, OpenRouter support, and embedding
+    - New plugin architecture with settings panel and custom toolbars
+    - Improved user authentication with login endpoints
+
+  ✨ New Features:
+    - Added note history tracking
+    - Integrated advanced AI embedding dimensions configuration
+    - Added comprehensive plugin system with Alpine.js support
+    - Enhanced RAG capabilities for better AI responses
+    - Added Voyage AI embedding support
+
+  🐛 Bug Fixes:
+    - Fixed Docker container network configuration
+    - Resolved tag content and RegExp issues
+    - Fixed various AI chat and rendering issues
+    - Improved plugin installation and error handling
+    - Updated UI components replacing NextUI with HeroUI
+    - Added RSS feed support
+
+  Full release notes are available at https://github.com/blinko-space/blinko/releases
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
Tested fresh install on Umbrel Dev instance and update on Umbrel Home. Everything working as expected.

This fixes #2297

Note, when opening this PR version 0.43.5 was already out, but there was no docker container available yet.