### PR TITLE
Alby Hub v1.15.0

### DIFF
--- a/albyhub/docker-compose.yml
+++ b/albyhub/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_PORT: 8080
       PROXY_AUTH_ADD: "false"
   server:
-    image: ghcr.io/getalby/hub:v1.14.3@sha256:33fef6845f4aa6961ad86cbf9ac4b9b34b4489c51fe3f3353c2560a638182a6c
+    image: ghcr.io/getalby/hub:v1.15.0@sha256:ec60fed7bf4f440b4ae0415a9cd43247ce5fabc35ddecb61677e7d71e36c1cc9
     user: 1000:1000
     volumes:
       - ${APP_DATA_DIR}/data:/data

--- a/albyhub/umbrel-app.yml
+++ b/albyhub/umbrel-app.yml
@@ -3,7 +3,7 @@ id: albyhub
 name: Alby Hub ✨
 tagline: Self-custodial Lightning wallet with integrated node and app connections
 category: bitcoin
-version: "1.14.3"
+version: "1.15.0"
 port: 59000
 description: >-
   Alby Hub is an open-source, self-custodial Bitcoin Lightning wallet, with the easiest-to-use Lightning Network node for everyone.
@@ -32,10 +32,9 @@ gallery:
 releaseNotes: >-
   Highlights:
 
-    - Integrated onchain <> lightning swaps
-    - New home screen widgets (messageboard, stats for nerds, recently used apps, app of the day)
-    - More apps in the Hub's app store (BTCPay, Nostter, Coracle, LNBits, PTUJ.ai, Nostrcheck Server)
-    - Currency switcher, health indicator, NIP-44 encryption and many minor improvements
+    - Prepare one-click app connection setup
+    - App connection cleanup to easily remove unused connections
+    - Bug fix for an issue that caused a relay connection to get disconnected
 
   Full release notes are found at https://github.com/getAlby/hub/releases
 dependencies:


### PR DESCRIPTION
Updates to Alby Hub v1.15.0

Which contains an important bug fix for a relay connection issue. 
In some cases a relay connection fails for some app connections which is then not recovered which causes the app to fail.