### PR TITLE
Update ord to v0.22.2

### DIFF
--- a/ordinals/docker-compose.yml
+++ b/ordinals/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   ord:
-    image: nmfretz/ord:0.20.0@sha256:33c61d57680178463288483975b2ccc9530f98528362d80158a866e41fe9f365
+    image: nmfretz/ord:0.22.2@sha256:95c64da92c51f0d4c4b810b5fb067a3119cc8040cbb9ae976d33c85d257450b3
     # This needs to run as root
     # user: "1000:1000"
     restart: on-failure

--- a/ordinals/hooks/pre-start
+++ b/ordinals/hooks/pre-start
@@ -29,7 +29,7 @@ fi
 # for fresh installs this file will be harmlessly created 
 if [[ ! -f "${APP_DATA_DIR}/AT_LEAST_0-22-2" ]]; then
     # delete index db for all bitcoin networks
-    for file in "${ORDINALS_DATA_DIR}/index.redb" "${ORDINALS_DATA_DIR}/testnet3/index.redb" "${ORDINALS_DATA_DIR}/regtest/index.redb" "${ORDINALS_DATA_DIR}/signet/index.redb"; do
+    for file in "${ORDINALS_DATA_DIR}/index.redb" "${ORDINALS_DATA_DIR}/testnet3/index.redb" "${ORDINALS_DATA_DIR}/testnet4/index.redb" "${ORDINALS_DATA_DIR}/regtest/index.redb" "${ORDINALS_DATA_DIR}/signet/index.redb"; do
         if [[ -f "${file}" ]]; then
             rm -f "${file}"
         fi

--- a/ordinals/hooks/pre-start
+++ b/ordinals/hooks/pre-start
@@ -27,7 +27,7 @@ fi
 
 # re-index ord on major version upgrades (so far in ord's history, this has been required on every major version update)
 # for fresh installs this file will be harmlessly created 
-if [[ ! -f "${APP_DATA_DIR}/AT_LEAST_0-20-0" ]]; then
+if [[ ! -f "${APP_DATA_DIR}/AT_LEAST_0-22-2" ]]; then
     # delete index db for all bitcoin networks
     for file in "${ORDINALS_DATA_DIR}/index.redb" "${ORDINALS_DATA_DIR}/testnet3/index.redb" "${ORDINALS_DATA_DIR}/regtest/index.redb" "${ORDINALS_DATA_DIR}/signet/index.redb"; do
         if [[ -f "${file}" ]]; then

--- a/ordinals/hooks/pre-start
+++ b/ordinals/hooks/pre-start
@@ -34,7 +34,7 @@ if [[ ! -f "${APP_DATA_DIR}/AT_LEAST_0-22-2" ]]; then
             rm -f "${file}"
         fi
     done
-    touch "${APP_DATA_DIR}/AT_LEAST_0-20-0"
+    touch "${APP_DATA_DIR}/AT_LEAST_0-22-2"
 fi
 
 # migrate all wallet database files to ord/wallets, ord/testnet3/wallets, ord/regtest/wallets, and ord/signet/wallets for pre-0.18.2 versions: https://github.com/ordinals/ord/releases/tag/0.18.2

--- a/ordinals/umbrel-app.yml
+++ b/ordinals/umbrel-app.yml
@@ -22,7 +22,7 @@ releaseNotes: >-
   ⏳ If ord is currently indexing, it may take a few minutes to safely shut down before updating. Please be patient during this process.
 
 
-  This release fixes a compatibility issue with Bitcoin Core v28.1.
+  This release fixes an issue where ord's cli was unable to connect to recent versions of Bitcoin Core.
 
 
   Full release notes can be found at https://github.com/ordinals/ord/releases

--- a/ordinals/umbrel-app.yml
+++ b/ordinals/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ordinals
 category: bitcoin
 name: Ordinals
-version: "0.20.0"
+version: "0.22.2"
 tagline: Run your own index, block explorer, and command-line wallet for Ordinals
 description: >
   Run your own index, block explorer, and command-line wallet for Ordinals. The app automatically connects to your Bitcoin node on umbrelOS for trustless operation. Simply install the app and wait for Ordinals to index inscriptions and runes.
@@ -20,24 +20,6 @@ releaseNotes: >-
 
 
   ⏳ If ord is currently indexing, it may take a few minutes to safely shut down before updating. Please be patient during this process.
-
-
-  Fixed
-    - Improve indexing performance
-    - Make index settings harder to misuse
-    - Fix rune links for runes with no symbol
-
-  Added
-    - Add inscriptions and runes details to address API endpoint
-    - Add address field to /r/inscription/:id
-    - Add sat_balance to address API
-    - List all Bitcoin Core wallets
-
-  Changed
-    - Remove inscription content type counts from /status page
-    - Suppress printing sat_ranges by default
-    
-  And more!
 
 
   Full release notes can be found at https://github.com/ordinals/ord/releases

--- a/ordinals/umbrel-app.yml
+++ b/ordinals/umbrel-app.yml
@@ -22,6 +22,9 @@ releaseNotes: >-
   ⏳ If ord is currently indexing, it may take a few minutes to safely shut down before updating. Please be patient during this process.
 
 
+  This release fixes a compatibility issue with Bitcoin Core v28.1.
+
+
   Full release notes can be found at https://github.com/ordinals/ord/releases
 developer: Casey Rodarmor
 website: https://ordinals.com/


### PR DESCRIPTION
🚨 As usual, major version updates require ord to re-index from scratch. This process will happen automatically when you update the app. 

⏳ If ord is currently indexing, it may take a few minutes to safely shut down before updating. Please be patient during this process.

- Tested on arm64 and x86. 
- Tested fresh install and app update from previous major version
- Tested ord cli commands to ensure compatibility with Core v28.0+