### PR TITLE
Mount Umbrel's home directory in the docker container in Portainer.

### DIFF
--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     volumes:
       - ${APP_DATA_DIR}/entrypoint.sh:/entrypoint.sh
       - ${APP_DATA_DIR}/data/docker:/data
+      - ${UMBREL_ROOT}/home:/umbrel
 
   portainer:
     image: portainer/portainer-ce:2.27.1@sha256:99c3047d44991af08f2a34df16e69ae2654bee43444b2e9857aa6b5864c4f602

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -20,12 +20,14 @@ description: >-
   modify containers, networks, volumes, and images. You can also deploy multi-container applications using Docker Compose
   with ease.
 
+  Note: Umbrel's home directory is mounted at /umbrel.
+
 
   🛠️ Portainer on Umbrel is for power users, follow these best practices to avoid issues:
 
 
   1. Data persistence: Make sure to only used named Docker volumes for your stacks and containers. Data in bind-mounted
-  volumes will be lost when the Portainer app is restarted or updated.
+  volumes will be lost when the Portainer app is restarted or updated unless you are binding a directory under /umbrel.
 
 
   2. Port management: Watch out for potential port conflicts between your custom containers and umbrelOS' service containers,


### PR DESCRIPTION
The `${UMBREL_ROOT}/home` directory is now mounted at `/umbrel` in the container.