### PR TITLE
Umami: Ensure Umami Receives Real User IP

### DIFF
--- a/umami/docker-compose.yml
+++ b/umami/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       APP_HOST: umami_app_1
       APP_PORT: 3000
       PROXY_AUTH_ADD: "false"
+      PROXY_TRUST_UPSTREAM: "true"
   
   app:
     image: ghcr.io/umami-software/umami:postgresql-v2.17.0@sha256:837eb91c54200f6f087e5c21d5f050ceb3b659eed49af91402dac04dd53bbac1


### PR DESCRIPTION
I encountered an issue where Umami was not receiving users' region information in analytics. This was caused by the proxy in front of Umami, which was preventing it from seeing the real client IP.  

#### **Issue**  
- The proxy is modifying or stripping `X-Forwarded-For`, leading to Umami not being able to resolve user locations correctly.  
- Since authentication is already disabled for Umami, the purpose of the proxy in this case is unclear.  

#### **Proposed Fix**  
- Either **remove the proxy entirely** for Umami if it is not needed.  
- Or **set `PROXY_TRUST_UPSTREAM: "true"`** to ensure Umami receives the correct `X-Forwarded-For` header.  

This change will allow Umami to correctly resolve user locations while maintaining the existing proxy structure if needed.  