### PR TITLE
Update btcpay-server to version 2.0.8

### DIFF
--- a/btcpay-server/docker-compose.yml
+++ b/btcpay-server/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.5.17@sha256:d3a882a32df61d7de3ac802c65f47718b1e9ddea09bf29d7a108871eb815b43c
+    image: nicolasdorier/nbxplorer:2.5.23@sha256:9eee0f974ed5e56756f5d75fbc7ac4008e07a768cc5f51a33e01e55a8f9a8936
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       NBXPLORER_BTCHASTXINDEX: 1
 
   web:
-    image: btcpayserver/btcpayserver:2.0.5@sha256:14dc2f6ca638d126f17d53d7bfa89c798b82f241b9307c113a84b29df8481ab6
+    image: btcpayserver/btcpayserver:2.0.8@sha256:00f9612ec99843ba926a4aa27261272c6ec366f7099f6209e7296013d1cd3e7d
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/btcpay-server/umbrel-app.yml
+++ b/btcpay-server/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: btcpay-server
 category: bitcoin
 name: BTCPay Server
-version: "2.0.5"
+version: "2.0.8"
 tagline: Accept Bitcoin payments with 0 fees & no 3rd party
 description: >-
   BTCPay Server is a payment processor that allows you to receive
@@ -35,13 +35,16 @@ defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
   Highlights:
-    - Added QR Code support for store invitation emails.
-    - Introduced rate providers for Norwegian exchanges (Bitmynt and Bare Bitcoin).
-    - Improved store user management with enhanced API functionality and documentation.
-    - Admins can now view users’ invoices.
-    - Added a “Copy Link” button for pull payment actions.
-    - Enhanced UI consistency and plugin customization options.
-    - Various bug fixes.
+    - Added previews for fiat amounts in transactions  
+    - Allowed setting a custom email server through the API  
+    - Improved form handling and invoice display  
+    - Made archived invoices private for better security  
+    - Fixed an issue with duplicate payouts for certain payments  
+    - Added options to customize page titles and language settings  
+    - Fixed issues when upgrading from very old versions  
+    - Improved display of small Lightning balances  
+    - Notified users about the old Shopify integration being replaced
+    - Fixed a crash when upgrading from older versions  
 
   Full release notes can be found at https://github.com/btcpayserver/btcpayserver/releases.
 submitter: Umbrel


### PR DESCRIPTION
Tested on Umbrel Home, maybe you can also take a look @nmfretz @sharknoon.