### PR TITLE
Update the mempool app to v3.2.0

### DIFF
--- a/mempool/docker-compose.yml
+++ b/mempool/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_MEMPOOL_PORT
       PROXY_AUTH_ADD: "false"
   web:
-    image: mempool/frontend:v3.0.1@sha256:f3a74d2ca47dfa679f8da5a2b22bd714164794dc2fd088ef8779a79b21d4e742
+    image: mempool/frontend:v3.2.0@sha256:99f6d7fa2370a96bd05f370e4e72d6e4a27ea083183edc21f164cc047644a707
     user: "1000:1000"
     init: true
     restart: on-failure
@@ -23,7 +23,7 @@ services:
       default:
         ipv4_address: $APP_MEMPOOL_IP
   api:
-    image: mempool/backend:v3.0.1@sha256:4daa540727d3a830e71fb9f1ae281d1393be5077177c7d714066d450fb8f5bbf
+    image: mempool/backend:v3.2.0@sha256:dae3ee56782ded9f90317bf66ce7f51a228936049f75cec688cb1cbf5dba0042
     user: "1000:1000"
     init: true
     restart: on-failure

--- a/mempool/umbrel-app.yml
+++ b/mempool/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: mempool
 category: bitcoin
 name: mempool
-version: "3.0.1-hotfix"
+version: "3.2.0"
 tagline: Be your own explorer
 description: >-
   Run your own instance of The Mempool Open Source Project and trust no one.
@@ -13,10 +13,27 @@ description: >-
 
   This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com
 releaseNotes: >-
-  This update fixes an issue where users on umbrelOS 1.3 were unable to use optional LND functionality in the mempool app.
+  Support for v3 transactions
 
+  Support for anchor outputs
 
-  Full release notes for the previous major update to version 3.0.0 are found at https://github.com/mempool/mempool/releases
+  New UTXO bubble chart on the address page
+
+  DATUM miner tags
+
+  Tags to identify runestone messages and inscriptions
+
+  Package broadcast
+
+  Stratum job data visualizations
+
+  Taproot multisig labels
+
+  Transaction & PSBT preview feature
+
+  Address poisoning detection
+
+  Full release notes for version 3.2.0 are found at https://github.com/mempool/mempool/releases
 developer: Mempool Space K.K.
 website: https://mempool.space/about
 dependencies:

--- a/mempool/umbrel-app.yml
+++ b/mempool/umbrel-app.yml
@@ -13,27 +13,23 @@ description: >-
 
   This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com
 releaseNotes: >-
-  Support for v3 transactions
+  This update brings the mempool app to version 3.2.0, which includes a number of new features and bug fixes.
 
-  Support for anchor outputs
 
-  New UTXO bubble chart on the address page
+  Highlights:
+    - Support for v3 transactions
+    - Support for anchor outputs
+    - New UTXO bubble chart on the address page
+    - DATUM miner tags
+    - Tags to identify runestone messages and inscriptions
+    - Package broadcast
+    - Stratum job data visualizations
+    - Taproot multisig labels
+    - Transaction & PSBT preview feature
+    - Address poisoning detection
 
-  DATUM miner tags
 
-  Tags to identify runestone messages and inscriptions
-
-  Package broadcast
-
-  Stratum job data visualizations
-
-  Taproot multisig labels
-
-  Transaction & PSBT preview feature
-
-  Address poisoning detection
-
-  Full release notes for version 3.2.0 are found at https://github.com/mempool/mempool/releases
+  Full release notes are found at https://github.com/mempool/mempool/releases
 developer: Mempool Space K.K.
 website: https://mempool.space/about
 dependencies:


### PR DESCRIPTION
Updating the mempool app to v3.2.0

Full changelog available at https://github.com/mempool/mempool/releases/tag/v3.2.0

Note to Umbrel folks: this release includes changes to the Docker images, which are now using newer base OS images and Node/Rust versions.