### PR TITLE
Update Monero daemon to v0.18.4.0

### DIFF
--- a/monero/docker-compose.yml
+++ b/monero/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     restart: unless-stopped
     stop_grace_period: 15m
     command: "${APP_MONERO_COMMAND}"
-    image: ghcr.io/sethforprivacy/simple-monerod:v0.18.3.4@sha256:7f5a3fde6720aa0d35bfc454af4117d24230235f5310fabdf74d634003d2994c
+    image: ghcr.io/sethforprivacy/simple-monerod:v0.18.4.0@sha256:eb143b50b427348f74b94d9342aaa6c9a1b4e74310cf1bfb1aa8623361ec20a1
     ports:
       - "${APP_MONERO_P2P_PORT}:${APP_MONERO_P2P_PORT}"
       - "${APP_MONERO_RPC_PORT}:${APP_MONERO_RPC_PORT}"

--- a/monero/docker-compose.yml
+++ b/monero/docker-compose.yml
@@ -40,6 +40,7 @@ services:
 
   monerod:
     user: "1000:1000"
+    # "unless-stopped" ensures monerod restarts via UI-triggered daemon restarts, not just on failure
     restart: unless-stopped
     stop_grace_period: 15m
     command: "${APP_MONERO_COMMAND}"

--- a/monero/umbrel-app.yml
+++ b/monero/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: monero
 category: finance
 name: Monero Node
-version: "0.18.3.4-1"
+version: "0.18.4.0"
 tagline: Run a monero node
 description: >-
   Run your monero node and independently store and validate every single Monero transaction with it.
@@ -23,7 +23,15 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This update keeps monerod on version 0.18.3.4, but enables a ban list of suspected spy node IP addresses, as recommended by Monero Reesearch Lab.
+  This is a recommended release that fixes multiple daemon-related (monerod) network vulnerabilities.
 
+  Some highlights of this release are:
 
-  Further details can be found at https://github.com/monero-project/meta/issues/1124
+  - reduce disk writes from 2 to 1 per transaction
+  - fix temp fails causing alt blocks to be permanently invalid
+  - fix daemon connection speed throttling incorrectly
+  - fix --anonymous-inbound data leak
+  - update seed nodes
+  - minor bug fixes and improvements
+
+  Further details can be found at https://www.getmonero.org/2025/04/05/monero-0.18.4.0-released.html

--- a/monero/umbrel-app.yml
+++ b/monero/umbrel-app.yml
@@ -25,13 +25,13 @@ defaultPassword: ""
 releaseNotes: >-
   This is a recommended release that fixes multiple daemon-related (monerod) network vulnerabilities.
 
-  Some highlights of this release are:
 
-  - reduce disk writes from 2 to 1 per transaction
-  - fix temp fails causing alt blocks to be permanently invalid
-  - fix daemon connection speed throttling incorrectly
-  - fix --anonymous-inbound data leak
-  - update seed nodes
-  - minor bug fixes and improvements
+  Some highlights of this release are:
+    - reduce disk writes from 2 to 1 per transaction
+    - fix temp fails causing alt blocks to be permanently invalid
+    - fix daemon connection speed throttling incorrectly
+    - fix --anonymous-inbound data leak
+    - update seed nodes
+    - minor bug fixes and improvements
 
   Further details can be found at https://www.getmonero.org/2025/04/05/monero-0.18.4.0-released.html


### PR DESCRIPTION
This is the v0.18.4.0 release of the Monero software. It is a recommended release that fixes multiple daemon-related network vulnerabilities.