### PR TITLE
Remove libretranslate from 1.x app store

### DIFF
--- a/libretranslate/umbrel-app.yml
+++ b/libretranslate/umbrel-app.yml
@@ -5,6 +5,8 @@ name: LibreTranslate
 version: "1.6.5"
 tagline: Free and Open Source machine translation API
 description: >-
+  ⚠️ Removal Notice: The LibreTranslate app has been disabled over trademark issues.
+
   ⚠️ This app may take up to 10 minutes or more to become accessible after installation, depending on your hardware and internet connection. LibreTranslate must first download around 10 GB of translation models in the background before the UI becomes available. Please be patient.
 
 
@@ -36,3 +38,4 @@ releaseNotes: >-
 
 
   Full release notes are found at https://github.com/LibreTranslate/LibreTranslate/releases
+disabled: true


### PR DESCRIPTION
This PR removes the LibreTranslate from the app store for now over trademark issues.