### PR TITLE
Disable LibreTranslate on pre-1.0 app stores

### DIFF
--- a/libretranslate/umbrel-app.yml
+++ b/libretranslate/umbrel-app.yml
@@ -1,4 +1,4 @@
-manifestVersion: 1.1
+manifestVersion: 1.2
 id: libretranslate
 category: ai
 name: LibreTranslate


### PR DESCRIPTION
Related to https://github.com/getumbrel/umbrel-apps/pull/2528
Also disables on the app store for pre-1.0 umbrelOS installs