### PR TITLE
Remove kollider from app store

### DIFF
--- a/kollider/umbrel-app.yml
+++ b/kollider/umbrel-app.yml
@@ -1,10 +1,13 @@
-manifestVersion: 1.1
+manifestVersion: 1.2
 id: kollider
 category: bitcoin
 name: Kollider
 version: "1.0.7"
 tagline: Lightning-fast derivative trading
 description: >-
+  ⚠️ Removal Notice: The Kollider project is no longer maintained and is not getting any more updates. For more information, see this update: https://x.com/kollider_trade/status/1720428682072772708
+
+
   Kollider lets you instantly trade perpetual contracts with low fees
   and up to 100x buying power.
 
@@ -34,3 +37,4 @@ releaseNotes: >
 torOnly: false
 submitter: Kollider
 submission: https://github.com/getumbrel/umbrel/pull/1221
+disabled: true


### PR DESCRIPTION
This removes kollider from the Umbrel App Store as the app is no longer maintained.

More information can be found here: https://x.com/kollider_trade/status/1720428682072772708

Closes #2435 