### PR TITLE
Update the mempool app to v3.2.1

### DIFF
--- a/mempool/docker-compose.yml
+++ b/mempool/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_MEMPOOL_PORT
       PROXY_AUTH_ADD: "false"
   web:
-    image: mempool/frontend:v3.2.0@sha256:99f6d7fa2370a96bd05f370e4e72d6e4a27ea083183edc21f164cc047644a707
+    image: mempool/frontend:v3.2.1@sha256:dd126cf383bd425ad46710925697c6a7925675a535c1026c206f2c092231e106
     user: "1000:1000"
     init: true
     restart: on-failure
@@ -23,7 +23,7 @@ services:
       default:
         ipv4_address: $APP_MEMPOOL_IP
   api:
-    image: mempool/backend:v3.2.0@sha256:dae3ee56782ded9f90317bf66ce7f51a228936049f75cec688cb1cbf5dba0042
+    image: mempool/backend:v3.2.1@sha256:d3531090e3bdd9a3dd38151349c5027768c3b7132438db267df8d8f026e15e61
     user: "1000:1000"
     init: true
     restart: on-failure

--- a/mempool/umbrel-app.yml
+++ b/mempool/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: mempool
 category: bitcoin
 name: mempool
-version: "3.2.0"
+version: "3.2.1"
 tagline: Be your own explorer
 description: >-
   Run your own instance of The Mempool Open Source Project and trust no one.
@@ -13,10 +13,10 @@ description: >-
 
   This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com
 releaseNotes: >-
-  This update brings the mempool app to version 3.2.0, which includes a number of new features and bug fixes.
+  This update brings the mempool app to version 3.2.1, which includes a hotfix for a potential crash loop if the list of mining pools fails to get updated from our GitHub repo.
 
 
-  Highlights:
+  Highlights from version 3.2.0:
     - Support for v3 transactions
     - Support for anchor outputs
     - New UTXO bubble chart on the address page


### PR DESCRIPTION
Updating the mempool app to v3.2.1 - this is a hotfix for a potential crash if the list of mining pools could not be updated.

Official release notes available at https://github.com/mempool/mempool/releases