### PR TITLE
Ensure Bitcoin testnet3 compatibility for dependent apps

### DIFF
--- a/bitcoin/exports.sh
+++ b/bitcoin/exports.sh
@@ -24,7 +24,7 @@ BITCOIN_ENV_FILE="${EXPORTS_APP_DIR}/.env"
 			"main")
 				BITCOIN_NETWORK="mainnet";;
 			"test")
-				BITCOIN_NETWORK="testnet3";;
+				BITCOIN_NETWORK="testnet";;
 			"testnet4")
 				BITCOIN_NETWORK="testnet4";;
 			"signet")
@@ -66,7 +66,7 @@ fi
 
 if [[ "${APP_BITCOIN_NETWORK}" == "mainnet" ]]; then
 	BITCOIN_CHAIN="main"
-elif [[ "${APP_BITCOIN_NETWORK}" == "testnet3" ]]; then
+elif [[ "${APP_BITCOIN_NETWORK}" == "testnet" ]]; then
 	BITCOIN_CHAIN="test"
 	# export APP_BITCOIN_RPC_PORT="18332"
 	# export APP_BITCOIN_P2P_PORT="18333"

--- a/libre-relay/exports.sh
+++ b/libre-relay/exports.sh
@@ -25,7 +25,7 @@ BITCOIN_ENV_FILE="${EXPORTS_APP_DIR}/.env"
 			"main")
 				BITCOIN_NETWORK="mainnet";;
 			"test")
-				BITCOIN_NETWORK="testnet3";;
+				BITCOIN_NETWORK="testnet";;
 			"testnet4")
 				BITCOIN_NETWORK="testnet4";;
 			"signet")
@@ -67,7 +67,7 @@ fi
 
 if [[ "${APP_LIBRE_RELAY_NETWORK}" == "mainnet" ]]; then
 	BITCOIN_CHAIN="main"
-elif [[ "${APP_LIBRE_RELAY_NETWORK}" == "testnet3" ]]; then
+elif [[ "${APP_LIBRE_RELAY_NETWORK}" == "testnet" ]]; then
 	BITCOIN_CHAIN="test"
 	# export APP_LIBRE_RELAY_RPC_PORT="18332"
 	# export APP_LIBRE_RELAY_P2P_PORT="18333"


### PR DESCRIPTION
Exports `APP_BITCOIN_NETWORK` as `testnet` when running on testnet3.

@Impa10r can you please check to see if this simple change in the Bitcoin Node app works for your purposes?

If it solves your issue, are you okay if we include this fix with the [Core 29.0 release](https://github.com/bitcoin/bitcoin/releases/tag/v29.0)? I need to set aside some time next week to build the bitcoind image because with 29.0 the build system has migrated from Autotools to CMake.

related: https://github.com/getumbrel/umbrel-apps/pull/2353