### PR TITLE
update bitwatch to 1.5

### DIFF
--- a/bitwatch/docker-compose.yml
+++ b/bitwatch/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3117
 
   web:
-    image: ghcr.io/zapomatic/bitwatch:v1.5.5@sha256:eb43e0a8d767a5e2ea2980e5e45b9da76115799fb51af17134c44a52a3a6da3e
+    image: ghcr.io/zapomatic/bitwatch:v1.5.6@sha256:4b2cc7a30793c3bda20e13099f1573aafecfe00efd3d49e5ad6be503ac332908
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/bitwatch/docker-compose.yml
+++ b/bitwatch/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3117
 
   web:
-    image: ghcr.io/zapomatic/bitwatch:v1.5.3@sha256:1a88c9ed1962ccc2d58e81ce474398fd62315750948430bcf67d097144210ebf
+    image: ghcr.io/zapomatic/bitwatch:v1.5.4@sha256:9a8f1cda8f032f4d58b094a26826231a0393d30d97c29b3ee8edd5e59ac0cd13
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/bitwatch/docker-compose.yml
+++ b/bitwatch/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3117
 
   web:
-    image: ghcr.io/zapomatic/bitwatch:v1.5.4@sha256:9a8f1cda8f032f4d58b094a26826231a0393d30d97c29b3ee8edd5e59ac0cd13
+    image: ghcr.io/zapomatic/bitwatch:v1.5.5@sha256:eb43e0a8d767a5e2ea2980e5e45b9da76115799fb51af17134c44a52a3a6da3e
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/bitwatch/docker-compose.yml
+++ b/bitwatch/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3117
 
   web:
-    image: ghcr.io/zapomatic/bitwatch:v1.4.4@sha256:12e8326db0e5027a24dec723fb849178e4687464705351d7e6d7d42068ca96eb
+    image: ghcr.io/zapomatic/bitwatch:v1.5.3@sha256:1a88c9ed1962ccc2d58e81ce474398fd62315750948430bcf67d097144210ebf
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/bitwatch/umbrel-app.yml
+++ b/bitwatch/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bitwatch
 category: bitcoin
 name: Bitwatch
-version: "1.5.3"
+version: "1.5.4"
 tagline: Monitor Bitcoin addresses in real-time
 description: >-
   Monitor Bitcoin addresses in the mempool and on-chain using the mempool.space API and websocket.

--- a/bitwatch/umbrel-app.yml
+++ b/bitwatch/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bitwatch
 category: bitcoin
 name: Bitwatch
-version: "1.5.4"
+version: "1.5.5"
 tagline: Monitor Bitcoin addresses in real-time
 description: >-
   Monitor Bitcoin addresses in the mempool and on-chain using the mempool.space API and websocket.
@@ -36,6 +36,7 @@ releaseNotes: >-
     - adds better public mempool.space API rate limiting and a new apiDelay config for being nicer to the API
     - new defaults in config for public mempool.space API usage to better align with rate limits
     - UI impprovements to unify styles, cleanup modules and make buttons cleaner
+    - fix bug in reloading on sub-pages
 
 website: https://github.com/zapomatic/bitwatch
 repo: https://github.com/zapomatic/bitwatch

--- a/bitwatch/umbrel-app.yml
+++ b/bitwatch/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bitwatch
 category: bitcoin
 name: Bitwatch
-version: "1.4.4"
+version: "1.5.3"
 tagline: Monitor Bitcoin addresses in real-time
 description: >-
   Monitor Bitcoin addresses in the mempool and on-chain using the mempool.space API and websocket.
@@ -28,7 +28,15 @@ gallery:
   - 1.jpg
   - 2.jpg
   - 3.jpg
-releaseNotes: ""
+releaseNotes: >-
+  This release adds support for extended public key address watching, cleans up UI and fixes several minor bugs.
+
+    - Add support for xpub/ypub/zpub addresses as a sub-collection
+    - extended keys can be configured with an initial number of addresses to watch, a gap limit of empty addresses to keep updating on the list, and a skip count to jump over already spent addresses.
+    - adds better public mempool.space API rate limiting and a new apiDelay config for being nicer to the API
+    - new defaults in config for public mempool.space API usage to better align with rate limits
+    - UI impprovements to unify styles, cleanup modules and make buttons cleaner
+
 website: https://github.com/zapomatic/bitwatch
 repo: https://github.com/zapomatic/bitwatch
 support: https://github.com/zapomatic/bitwatch/issues

--- a/bitwatch/umbrel-app.yml
+++ b/bitwatch/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bitwatch
 category: bitcoin
 name: Bitwatch
-version: "1.5.5"
+version: "1.5.6"
 tagline: Monitor Bitcoin addresses in real-time
 description: >-
   Monitor Bitcoin addresses in the mempool and on-chain using the mempool.space API and websocket.


### PR DESCRIPTION
This release adds support for extended public key address watching, cleans up UI and fixes several minor bugs.

- Add support for xpub/ypub/zpub addresses as a sub-collection
- extended keys can be configured with an initial number of addresses to watch, a gap limit of empty addresses to keep updating on the list, and a skip count to jump over already spent addresses.
- adds better public mempool.space API rate limiting and a new apiDelay config for being nicer to the API
- new defaults in config for public mempool.space API usage to better align with rate limits
- UI impprovements to unify styles, cleanup modules and make buttons cleaner

New gallery images (if you want to update them):

![](https://github.com/zapomatic/bitwatch/blob/main/client/public/app.png?raw=true)
![](https://github.com/zapomatic/bitwatch/blob/main/client/public/app_1.png?raw=true)
![](https://github.com/zapomatic/bitwatch/blob/main/client/public/app_2.png?raw=true)
![](https://github.com/zapomatic/bitwatch/blob/main/client/public/app_3.png?raw=true)
![](https://github.com/zapomatic/bitwatch/blob/main/client/public/app_4.png?raw=true)
![](https://github.com/zapomatic/bitwatch/blob/main/client/public/app_5.png?raw=true)