### PR TITLE
Bump influxdb to version 1.11.8

### DIFF
--- a/influxdb/docker-compose.yml
+++ b/influxdb/docker-compose.yml
@@ -1,14 +1,14 @@
 version: "3.7"
 
 services:
-  
+
   app_proxy:
     environment:
       APP_HOST: influxdb_chronograf_1
       APP_PORT: 8888
-      
+
   influxdb:
-    image: influxdb:1.11.8@sha256:7a7c698866b3c4098f70a6f9b5e55a10ae622e9cb02eaf48cf75c2f034877a8e
+    image: influxdb:1.11.8@sha256:a69e60fd29edb02921947605fd25fd252a0082ce811bff552d407896262e48a7
     user: 1000:1000
     restart: on-failure
     stop_grace_period: 1m

--- a/influxdb/umbrel-app.yml
+++ b/influxdb/umbrel-app.yml
@@ -3,7 +3,7 @@ id: influxdb
 name: InfluxDB
 tagline: High performance time series database
 category: developer
-version: "1.11.7"
+version: "1.11.8"
 port: 8888
 description: >-
   InfluxDB is an open-source, high-performance time series database packaged with Chronograf, the official web-based visualization tool.
@@ -35,7 +35,7 @@ description: >-
   InfluxDB automatically compacts data to minimize your storage space.
   In addition, you can easily downsample the data; keeping high-precision raw data for a limited time and storing the lower-precision, summarized data for much longer or until the end of time.
 
-  
+
   **📊 Integrated Visualization with Chronograf**
 
   Chronograf is the administrative user interface and visualization engine of the stack. It makes it easy to setup and maintain the monitoring and alerting for your infrastructure.
@@ -48,7 +48,8 @@ gallery:
   - 1.jpg
   - 2.jpg
   - 3.jpg
-releaseNotes: ""
+releaseNotes: >-
+  This update bumps InfluxDB to version 1.11.8 to match the version already used in the container.
 dependencies: []
 path: ""
 defaultUsername: "admin"


### PR DESCRIPTION
Tested on Umbrel Home.

This update just bumps influxdb to a newer sha tag and aligns the version with the one already used for the container.