### PR TITLE
Bump kokoro version to 0.2.3

### DIFF
--- a/kokoro/umbrel-app.yml
+++ b/kokoro/umbrel-app.yml
@@ -3,7 +3,7 @@ id: kokoro
 name: Kokoro
 tagline: An intelligent, high-quality TTS solution
 category: ai
-version: "0.2.2"
+version: "0.2.3"
 port: 8877
 description: >-
   Kokoro is an advanced Text-to-Speech (TTS) model that delivers impressive speech quality with only 82 million parameters, making it competitive with much larger and more resource-intensive models. Despite its relatively compact architecture, Kokoro effectively transforms text into clear, natural-sounding speech, making it an excellent choice for applications relying on speech synthesis. The model has been specifically designed to ensure high efficiency and fast processing, making it suitable for both resource-constrained environments and production systems. In comparison to traditional TTS models, which often require substantial computational resources, Kokoro offers a more cost-effective and faster alternative without compromising the quality of speech output.
@@ -26,7 +26,8 @@ gallery:
   - 1.jpg
   - 2.jpg
   - 3.jpg
-releaseNotes: ""
+releaseNotes: >-
+  Bump version to match the one that is actually being installed.
 dependencies: []
 path: "/web"
 defaultUsername: ""


### PR DESCRIPTION
Tested on Umbrel Home.

This update just aligns the version to what is actually being installed.