### PR TITLE
Change name of bitcoin app

### DIFF
--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bitcoin
 category: bitcoin
 name: Bitcoin Core
-version: "28.1"
+version: "29.0"
 tagline: Run your personal node powered by Bitcoin Core
 description: >-
   Run your Bitcoin node and independently store and validate

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -1,7 +1,7 @@
 manifestVersion: 1.1
 id: bitcoin
 category: bitcoin
-name: Bitcoin Node
+name: Bitcoin Core
 version: "28.1"
 tagline: Run your personal node powered by Bitcoin Core
 description: >-


### PR DESCRIPTION
Given the current issues surrounding OP_Return etc users should be clearly able to choose between core and Knots.

If the name remains 'Bitcoin Node' this would seem more ''supported'' and would be umbrel choosing sides and favouring Core.

To keep umbrel neutral the name should be changed to Bitcoin Core