### PR TITLE
Update sha256 to get Jellyseerr to version 2.5.2

### DIFF
--- a/jellyseerr/docker-compose.yml
+++ b/jellyseerr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: fallenbagel/jellyseerr:2.5.2@sha256:52ca0b18c58ec4e769b8acae9beaae37a520a365c7ead52b7fc3ba1c3352d1f0
+    image: fallenbagel/jellyseerr:2.5.2@sha256:2a611369ad1d0d501c2d051fc89b6246ff081fb4a30879fdc75642cf6a37b1a6
     volumes:
       - ${APP_DATA_DIR}/data/config:/app/config
     restart: on-failure

--- a/jellyseerr/umbrel-app.yml
+++ b/jellyseerr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jellyseerr
 category: media
 name: Jellyseerr
-version: "2.5.2"
+version: "2.5.2-1"
 tagline: Beautiful media discovery for Jellyfin users
 description: >-
   Jellyseerr is a request management and media discovery tool built to work with your existing Jellyfin ecosystem.
@@ -30,6 +30,9 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
+  Fixed version mismatch issue so that the Jellyseerr can be updated to version 2.5.2
+
+
   Key highlights in this release:
     - Fixed Bitwarden autofill for local/Jellyfin login
     - Resolved issues with "Remove from *arr" button


### PR DESCRIPTION
Jellyseerr was not really updated to version 2.5.2 before.

Tested on Umbrel Home.