### PR TITLE
Update wordpress to version 6.8.1

### DIFF
--- a/wordpress/docker-compose.yml
+++ b/wordpress/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   app:
-    image: wordpress:6.8.0@sha256:7dc16274adb1ab8cd381901ac4968e864a4938f49fec96778e2078f150b64ea1
+    image: wordpress:6.8.1@sha256:626ea197cb3f17747b24de6ba8f52a5a841efbb68a11167a115a6401ccb6cd3c
     user: "1000:1000"
     environment:
       - WORDPRESS_DB_HOST=wordpress_db_1

--- a/wordpress/umbrel-app.yml
+++ b/wordpress/umbrel-app.yml
@@ -3,7 +3,7 @@ id: wordpress
 name: WordPress
 tagline: The open source publishing platform of choice for millions of websites worldwide
 category: social
-version: "6.8.0"
+version: "6.8.1"
 port: 8567
 description: >-
   📚 **Empower Your Digital Voice** - The open-source publishing platform trusted by millions. From personal blogs to enterprise portals, WordPress gives everyone the tools to share their stories.
@@ -38,7 +38,10 @@ defaultUsername: ""
 defaultPassword: ""
 dependencies: []
 releaseNotes: >-
-  WordPress 6.8, code-named “Cecil,” refines your creative workflow with a streamlined Style Book, now available in select Classic themes. Enjoy faster navigation via speculative loading, stronger security with bcrypt password hashing, and over 100 accessibility improvements. With thoughtful editor upgrades and behind-the-scenes performance boosts, 6.8 delivers polish, power, and precision.
+  ⚠️ To fully update your Wordpress instance, you need to go to the admin interface and update from there as well.
+
+
+  This minor release includes fixes for 15 bugs throughout Core and the Block Editor addressing issues affecting multiple areas of WordPress including the block editor, multisite, and REST API.
 
 
   Full release notes can be found at https://wordpress.org/news/category/releases/


### PR DESCRIPTION
Tested on Umbrel Home and dev instance.

Added note that the actual update needs to be done via the admin interface.