### PR TITLE
update bitwatch to 1.6

### DIFF
--- a/bitwatch/docker-compose.yml
+++ b/bitwatch/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3117
 
   web:
-    image: ghcr.io/zapomatic/bitwatch:v1.5.6@sha256:4b2cc7a30793c3bda20e13099f1573aafecfe00efd3d49e5ad6be503ac332908
+    image: ghcr.io/zapomatic/bitwatch:v1.6.13@sha256:3ff18cbab4cc9ff74a3de0bcb564fa405f5d18e7bb58ba133ec98d9d1a3edbec
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/bitwatch/umbrel-app.yml
+++ b/bitwatch/umbrel-app.yml
@@ -29,14 +29,10 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  This release adds support for extended public keys and descriptors, cleans up UI and fixes several bugs, and adds a complete e2e testing suite.
+  This release adds support for taproot extended keys and descriptors.
 
-    - Adds support for extended keys: xpub/ypub/zpub/vpub addresses as a sub-collection
+    - Adds support for taproot extended keys (vpub)
     - Adds support for descriptors (e.g. multiSig: wsh(multi(2,xpub...,...))
-    - extended keys and descriptors can be configured with an initial number of addresses to watch, a gap limit of empty addresses to keep updating on the list, and a skip count to jump over already spent addresses.
-    - adds better public mempool.space API rate limiting and a new apiDelay config for being nicer to the API
-    - new defaults in config for public mempool.space API usage to better align with rate limits
-    - UI impprovements to unify styles, cleanup modules and make buttons cleaner
     - Allows saving default monitor settings
     - Refresh buttons on addresses and descriptor/extended key sets
     - fix bug in reloading on sub-pages

--- a/bitwatch/umbrel-app.yml
+++ b/bitwatch/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bitwatch
 category: bitcoin
 name: Bitwatch
-version: "1.5.6"
+version: "1.6.13"
 tagline: Monitor Bitcoin addresses in real-time
 description: >-
   Monitor Bitcoin addresses in the mempool and on-chain using the mempool.space API and websocket.
@@ -29,13 +29,16 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  This release adds support for extended public key address watching, cleans up UI and fixes several minor bugs.
+  This release adds support for extended public keys and descriptors, cleans up UI and fixes several bugs, and adds a complete e2e testing suite.
 
-    - Add support for xpub/ypub/zpub addresses as a sub-collection
-    - extended keys can be configured with an initial number of addresses to watch, a gap limit of empty addresses to keep updating on the list, and a skip count to jump over already spent addresses.
+    - Adds support for extended keys: xpub/ypub/zpub/vpub addresses as a sub-collection
+    - Adds support for descriptors (e.g. multiSig: wsh(multi(2,xpub...,...))
+    - extended keys and descriptors can be configured with an initial number of addresses to watch, a gap limit of empty addresses to keep updating on the list, and a skip count to jump over already spent addresses.
     - adds better public mempool.space API rate limiting and a new apiDelay config for being nicer to the API
     - new defaults in config for public mempool.space API usage to better align with rate limits
     - UI impprovements to unify styles, cleanup modules and make buttons cleaner
+    - Allows saving default monitor settings
+    - Refresh buttons on addresses and descriptor/extended key sets
     - fix bug in reloading on sub-pages
 
 website: https://github.com/zapomatic/bitwatch


### PR DESCRIPTION
This release adds support for taproot extended keys and descriptors.

    - Adds support for taproot extended keys (vpub)
    - Adds support for descriptors (e.g. multiSig: wsh(multi(2,xpub...,...))
    - Allows saving default monitor settings
    - Refresh buttons on addresses and descriptor/extended key sets
    - fix bug in reloading on sub-pages

New gallery images (if you want to update them):

![](https://github.com/zapomatic/bitwatch/blob/main/client/public/app.png?raw=true)
![](https://github.com/zapomatic/bitwatch/blob/main/client/public/app_1.png?raw=true)
![](https://github.com/zapomatic/bitwatch/blob/main/client/public/app_2.png?raw=true)
![](https://github.com/zapomatic/bitwatch/blob/main/client/public/app_3.png?raw=true)
![](https://github.com/zapomatic/bitwatch/blob/main/client/public/app_4.png?raw=true)
![](https://github.com/zapomatic/bitwatch/blob/main/client/public/app_5.png?raw=true)