### PR TITLE
Update Torq to v2.2.2

### DIFF
--- a/torq/docker-compose.yml
+++ b/torq/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 7028
 
   web:
-    image: lncapital/torq:2.1.0@sha256:ae21fefde17120d414c5db69857606d52e837204d2e798bd8b9dec3b98ecb93f
+    image: lncapital/torq:2.2.2@sha256:28cfac8c81f92e7d4e021a780b2d3f2dc766a37c7ebeef68f6105f682f3b196f
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/torq/umbrel-app.yml
+++ b/torq/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: torq
 category: bitcoin
 name: Torq
-version: "v2.1.0"
+version: "v2.2.2"
 tagline: Scalable Node Management Software
 description: >-
   Operating a Lightning node requires a lot of work. You need to monitor your channels, rebalance them, keep track of your fees and much more.
@@ -48,25 +48,52 @@ gallery:
   - 4.jpg
   - 5.jpg
 releaseNotes: >-
-  Highlights:
-    - bitcoind wallet as a node type (Torq now has on-chain wallet support for CLN, LND and bitcoind)
-    - bitcoind existing on-chain address listing
-    - management of UTXO locking 
-    - improved transaction output visualizations (and backend)
-    - improve transaction output linking to channels (funding/closing transactions)
-    - LND: sweep transaction output linking to channels
-    - Torq gRPC (BETA feature):
-      - New call SubscribeBlockHeight
-      - New call PayOnChain
-      - New call DecodeInvoice
-      - New call GetInvoiceStatus
-      - We have been streamlining our names in the proto file (so breaking changes)
-    - Various small fixes
+  Release notes for 2.2.2
 
-  Note 1: There are database migrations in this release so if you want to be able to roll back, you need to create a backup before updating.
+  - Torq API node handle grouping
 
-  
-  Note 2: You get the best Torq experience if you specify bitcoind connection details in your configuration file (or command line).
+    - A possibility to make hierarchy of nodes that are used in Torq API.
+
+    - For example: primarly use Node A, but if it is unreachable, use Node B. Or: use Node A 70% of the time and Node B 30% of the time.
+
+  - Node data import downtime threshold
+
+    - Configurable threshold for when to run events and imports for node data depending on how long was Torq down for.
+
+    - For example: there is a workflow that is set to trigger on "Payment". Then a payment happened on the node while Torq was down. If Torq was down less than the threshold that was set, the workflow **is** triggered when Torq starts, and if Torq was down longer than the threshold, the workflow **is not** triggered.
+
+  - Possibility to add/remove tags via Tags -> Manage -menu
+
+  - Show tagging history on "Inspect Channel" -page
+
+  - Bug fixes and minor improvements:
+
+     - Bitcoind node status now shown in the "status modal"
+
+     - Fixed "last balance change" filter and make columns sortable by "last balance change"
+
+     - Fixed bug when updating CLN node connection details
+
+     - Ordered tags list on "Tags" page alphabetically
+
+     - Fixed bolt11 invoice not working in signet
+
+     - More accurate "unconfirmed" balance on bitcoind node
+
+     - mempool-url conf parameter now allows trailing slash
+
+     - Fixed an UI bug that created an error in UI when making an on-chain payment
+
+     - "Contact support" text in footer is now clickable and opens support chat window
+
+     - In earlier release an internal table of "payment attempt" was added that saves each attempted payment even if the node with which to make the payment is not reachable. This might bloat the database too much if there are a lot of payments. This release adds a new setting to set the amount of days that they are kept before being deleted from database (If zero, deleted after 1h).
+
+     - Fixed CLN showing doubled balance while on-chain transaction to self is unconfirmed  
+
+     - Fix a race condition in LND channel balance cache that might cause Torq to crash
+
+     - Fix bugs that caused channel balance to not be updated in some cases and channel "peer total local balance" not getting updated.
+
 path: ""
 defaultUsername: ""
 deterministicPassword: false

--- a/torq/umbrel-app.yml
+++ b/torq/umbrel-app.yml
@@ -48,51 +48,29 @@ gallery:
   - 4.jpg
   - 5.jpg
 releaseNotes: >-
-  Release notes for 2.2.2
-
-  - Torq API node handle grouping
-
-    - A possibility to make hierarchy of nodes that are used in Torq API.
-
-    - For example: primarly use Node A, but if it is unreachable, use Node B. Or: use Node A 70% of the time and Node B 30% of the time.
-
-  - Node data import downtime threshold
-
-    - Configurable threshold for when to run events and imports for node data depending on how long was Torq down for.
-
-    - For example: there is a workflow that is set to trigger on "Payment". Then a payment happened on the node while Torq was down. If Torq was down less than the threshold that was set, the workflow **is** triggered when Torq starts, and if Torq was down longer than the threshold, the workflow **is not** triggered.
-
-  - Possibility to add/remove tags via Tags -> Manage -menu
-
-  - Show tagging history on "Inspect Channel" -page
-
-  - Bug fixes and minor improvements:
-
-     - Bitcoind node status now shown in the "status modal"
-
-     - Fixed "last balance change" filter and make columns sortable by "last balance change"
-
-     - Fixed bug when updating CLN node connection details
-
-     - Ordered tags list on "Tags" page alphabetically
-
-     - Fixed bolt11 invoice not working in signet
-
-     - More accurate "unconfirmed" balance on bitcoind node
-
-     - mempool-url conf parameter now allows trailing slash
-
-     - Fixed an UI bug that created an error in UI when making an on-chain payment
-
-     - "Contact support" text in footer is now clickable and opens support chat window
-
-     - In earlier release an internal table of "payment attempt" was added that saves each attempted payment even if the node with which to make the payment is not reachable. This might bloat the database too much if there are a lot of payments. This release adds a new setting to set the amount of days that they are kept before being deleted from database (If zero, deleted after 1h).
-
-     - Fixed CLN showing doubled balance while on-chain transaction to self is unconfirmed  
-
-     - Fix a race condition in LND channel balance cache that might cause Torq to crash
-
-     - Fix bugs that caused channel balance to not be updated in some cases and channel "peer total local balance" not getting updated.
+  Highlights:
+    - Torq API node handle grouping
+      - A possibility to make hierarchy of nodes that are used in Torq API.
+      - For example: primarly use Node A, but if it is unreachable, use Node B. Or: use Node A 70% of the time and Node B 30% of the time.
+    - Node data import downtime threshold
+      - Configurable threshold for when to run events and imports for node data depending on how long was Torq down for.
+      - For example: there is a workflow that is set to trigger on "Payment". Then a payment happened on the node while Torq was down. If Torq was down less than the threshold that was set, the workflow **is** triggered when Torq starts, and if Torq was down longer than the threshold, the workflow **is not** triggered.
+    - Possibility to add/remove tags via Tags -> Manage -menu
+    - Show tagging history on "Inspect Channel" -page
+    - Bug fixes and minor improvements:
+       - Bitcoind node status now shown in the "status modal"
+       - Fixed "last balance change" filter and make columns sortable by "last balance change"
+       - Fixed bug when updating CLN node connection details
+       - Ordered tags list on "Tags" page alphabetically
+       - Fixed bolt11 invoice not working in signet
+       - More accurate "unconfirmed" balance on bitcoind node
+       - mempool-url conf parameter now allows trailing slash
+       - Fixed an UI bug that created an error in UI when making an on-chain payment
+       - "Contact support" text in footer is now clickable and opens support chat window
+       - In earlier release an internal table of "payment attempt" was added that saves each attempted payment even if the node with which to make the payment is not reachable. This might bloat the database too much if there are a lot of payments. This release adds a new setting to set the amount of days that they are kept before being deleted from database (If zero, deleted after 1h).
+       - Fixed CLN showing doubled balance while on-chain transaction to self is unconfirmed  
+       - Fix a race condition in LND channel balance cache that might cause Torq to crash
+       - Fix bugs that caused channel balance to not be updated in some cases and channel "peer total local balance" not getting updated.
 
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
  Release notes for 2.2.2
  - Torq API node handle grouping
    - A possibility to make hierarchy of nodes that are used in Torq API.
    - For example: primarly use Node A, but if it is unreachable, use Node B. Or: use Node A 70% of the time and Node B 30% of the time.
  - Node data import downtime threshold
    - Configurable threshold for when to run events and imports for node data depending on how long was Torq down for.
    - For example: there is a workflow that is set to trigger on "Payment". Then a payment happened on the node while Torq was down. If Torq was down less than the threshold that was set, the workflow **is** triggered when Torq starts, and if Torq was down longer than the threshold, the workflow **is not** triggered.
  - Possibility to add/remove tags via Tags -> Manage -menu
  - Show tagging history on "Inspect Channel" -page
  - Bug fixes and minor improvements:
     - Bitcoind node status now shown in the "status modal"
     - Fixed "last balance change" filter and make columns sortable by "last balance change"
     - Fixed bug when updating CLN node connection details
     - Ordered tags list on "Tags" page alphabetically
     - Fixed bolt11 invoice not working in signet
     - More accurate "unconfirmed" balance on bitcoind node
     - mempool-url conf parameter now allows trailing slash
     - Fixed an UI bug that created an error in UI when making an on-chain payment
     - "Contact support" text in footer is now clickable and opens support chat window
     - In earlier release an internal table of "payment attempt" was added that saves each attempted payment even if the node with which to make the payment is not reachable. This might bloat the database too much if there are a lot of payments. This release adds a new setting to set the amount of days that they are kept before being deleted from database (If zero, deleted after 1h).
     - Fixed CLN showing doubled balance while on-chain transaction to self is unconfirmed  
     - Fix a race condition in LND channel balance cache that might cause Torq to crash
     - Fix bugs that caused channel balance to not be updated in some cases and channel "peer total local balance" not getting updated.