### PR TITLE
Update nbxplorer image to version 2.5.26

### DIFF
--- a/btcpay-server/docker-compose.yml
+++ b/btcpay-server/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.5.25@sha256:7f730fac6a968823aa10f039597ae8f729487f225e81bd9b99f65eba12db8c95
+    image: nicolasdorier/nbxplorer:2.5.26@sha256:d75e224e2d03ccded2a927d77a5ddb311a6f77b219ac755b14ef4c9fe37f443e
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/btcpay-server/umbrel-app.yml
+++ b/btcpay-server/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: btcpay-server
 category: bitcoin
 name: BTCPay Server
-version: "2.1.1"
+version: "2.1.1-patch.1"
 tagline: Accept Bitcoin payments with 0 fees & no 3rd party
 description: >-
   BTCPay Server is a payment processor that allows you to receive
@@ -34,6 +34,9 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
+  This patch release of BTCPay Server fixes a critical bug that prevented syncing block 896727. You can see the release notes for BTCPay Server 2.1.1 below:
+
+
   This update of BTCPay Server includes new features, improvements and bug fixes.
 
 


### PR DESCRIPTION
This PR bumps the version of nbxplorer to resolve an issue processing block 896727

More information: 
https://github.com/dgarage/NBXplorer/issues/518 