### PR TITLE
Update readarr to version 0.4.16.2793

### DIFF
--- a/readarr/docker-compose.yml
+++ b/readarr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/readarr:nightly-version-0.4.15.2787@sha256:05ff6c3a66d45f8f87965bdf4eb4288f6c25e081fcd45afa5e98de1fbe34bb0c
+    image: linuxserver/readarr:develop-version-0.4.16.2793@sha256:f2f9280f1db32b6f6782d31a8c38995d604ae2f2008e7eed333bb713dd32b9af
     environment:
       - PUID=1000
       - PGID=1000

--- a/readarr/umbrel-app.yml
+++ b/readarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: readarr
 category: media
 name: Readarr
-version: "0.4.15.2787"
+version: "0.4.16.2793"
 tagline: Your book collection manager
 description: >-
   ⚠️ Readarr is currently in beta testing and is generally still a work in progress. Features may be broken, incomplete, or cause spontaneous combustion.
@@ -38,15 +38,7 @@ permissions:
 submitter: Choff3
 submission: https://github.com/getumbrel/umbrel-apps/pull/712
 releaseNotes: >-
-  This update includes several improvements and bug fixes:
-    - Improved logging with template messages and NLog integration
-    - Fixed UI issues including disabled options and missing posters or author folder hints
-    - Enhanced author addition flow and validation messages
-    - Updated translations and automated API documentation
-    - Improved error handling for missing media covers and loading issues
-    - Added indexer info in download failure details
-    - UI improvements for author status and folder deletion behavior
-    - Multiple dependency updates and minor fixes 
+  This update includes several improvements and bug fixes.
 
 
   Full release notes are found at https://github.com/Readarr/Readarr/releases


### PR DESCRIPTION
Tested update on Umbrel Home and dev instance.