### PR TITLE
Fulcrum database corruption mitigation

### DIFF
--- a/fulcrum/docker-compose.yml
+++ b/fulcrum/docker-compose.yml
@@ -29,7 +29,8 @@ services:
   fulcrum:
     image: cculianu/fulcrum:v1.12.0.1@sha256:ee6a67224a766448507eddc0efba8649b5598f1ea3def39673e2a08210ae4921
     init: true
-    stop_grace_period: 1m
+    stop_signal: SIGINT
+    stop_grace_period: 5m
     restart: on-failure
     user: "1000:1000"
     environment:
@@ -40,7 +41,8 @@ services:
       RPCPASSWORD: ${APP_BITCOIN_RPC_PASS}
       PEERING: "false"
       ANNOUNCE: "false"
-    command: sh -c 'Fulcrum -D /data _ENV_ 2>&1 | tee /logs/fulcrum.log'
+      DATA_DIR: /data
+    command: 'Fulcrum _ENV_ 2>&1 | tee /logs/fulcrum.log'
     volumes:
       - "${APP_DATA_DIR}/data/fulcrum:/data"
       - "${APP_DATA_DIR}/data/fulcrum-logs:/logs"

--- a/fulcrum/umbrel-app.yml
+++ b/fulcrum/umbrel-app.yml
@@ -31,8 +31,10 @@ path: ""
 defaultPassword: ""
 releaseNotes: >-
   This release add a graceful shutdown method to mitigate any database corruption issues.
-  
-  **Previous release notes:**
+
+
+  **Previous release notes below.**
+
 
   Key highlights:
     - Added support for UPnP

--- a/fulcrum/umbrel-app.yml
+++ b/fulcrum/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - electrs
 category: bitcoin
 name: Fulcrum
-version: "1.12.0"
+version: "1.12.0-graceful-shutdown"
 tagline: A fast and nimble Electrum Server
 description: >-
   Run your personal Electrum server and connect your Electrum-compatible wallet,
@@ -30,8 +30,9 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This release includes several bug fixes and improvements.
-
+  This release add a graceful shutdown method to mitigate any database corruption issues.
+  
+  **Previous release notes:**
 
   Key highlights:
     - Added support for UPnP


### PR DESCRIPTION
Fulcrum is very susceptible to database corruption. Even a mere shutdown/restart of Umbrel can cause database corruption. 

This PR attempts to mitigate the issue by changing docker's default stop signal to `SIGINT` as per the [recommendation ](https://github.com/cculianu/Fulcrum/issues/115#issuecomment-1140124624) from Fulcrum's developer.

`stop_grace_period` has also been increased to make sure Fulcrum finished writing the block and complete the cleanup on slower machines/ HDDs