### PR TITLE
Update Jam to v0.4.0

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   web:
-    image: ghcr.io/joinmarket-webui/jam-standalone:v0.3.0-clientserver-v0.9.11@sha256:5047d29a59d5892f2eb77d5c9a7f9ad15105ccaae44e6b3deb5a04bc4e76de6f
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.4.0-clientserver-v0.9.11@sha256:3742e15734b91ea520ae7b78c2e6b82aed715bdcda5a786c92efe77ffd89ecc7
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: jam
 category: bitcoin
 name: Jam
-version: "0.3.0"
+version: "0.4.0"
 tagline: Your sats. Your privacy. Your profit.
 description: >-
   Jam is a user-interface for JoinMarket with focus on
@@ -13,15 +13,15 @@ description: >-
 
   The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 releaseNotes: >-
-  - Send: Quickly freeze/unfreeze UTXOs
+  - Fidelity Bond: Ability to select destination jar when unlocking fidelity bond
 
-  - Send: Review eligible or selected UTXOs
+  - Send: Color-coded checkboxes for UTXO states
 
-  - Feature: Ability to trigger a rescan of the timechain
+  - Rescan: Show progress during timechain rescan
 
-  - Orderbook: Display fidelity bond value and locktime data
+  - Orderbook: Ability to reload and/or hard refresh
 
-  - Earn: Display simple stats on earn report
+  - Theme: Fast theme toggle in navbar
 
   - UI: Various UI improvements and bugfixes
 


### PR DESCRIPTION
This version includes:
- Jam: [v0.4.0](https://github.com/joinmarket-webui/jam/releases/tag/v0.4.0)
- joinmarket-clientserver: [v0.9.11](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.11)

All notable changes of the UI can be seen in the [Jam v0.4.0 changelog](https://github.com/joinmarket-webui/jam/blob/v0.4.0/CHANGELOG.md)