### PR TITLE
Change name of bitcoin app

### DIFF
--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -1,7 +1,7 @@
 manifestVersion: 1.1
 id: bitcoin
 category: bitcoin
-name: Bitcoin Node
+name: Bitcoin Core
 version: "29.0"
 tagline: Run your personal node powered by Bitcoin Core
 description: >-


### PR DESCRIPTION
Hi, given that bitcoin core is actually taking (IMO) bad decisions to protect the network I want to reopen #2692 

A lot if users just see "bitcoin node" while opening the umbrel web page for the first time and just click without knowing what is running under.