### PR TITLE
Update twenty to v0.55.6

### DIFF
--- a/twenty/docker-compose.yml
+++ b/twenty/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
   
   server:
-    image: twentycrm/twenty:v0.54.4@sha256:6a6e5a34426867e746f43ef000989cae3afc44f2e1cedf8bcefa447f6988187a
+    image: twentycrm/twenty:v0.55.6@sha256:b8caf7fd4d28230b7158bba784d32e0df949b39df616fc54a161a52998429e82
     user: "1000:1000"
     volumes:
       - ${APP_DATA_DIR}/data/server-local-data:/app/packages/twenty-server/.local-storage
@@ -30,7 +30,7 @@ services:
     restart: on-failure
 
   worker:
-    image: twentycrm/twenty:v0.54.4@sha256:6a6e5a34426867e746f43ef000989cae3afc44f2e1cedf8bcefa447f6988187a
+    image: twentycrm/twenty:v0.55.6@sha256:b8caf7fd4d28230b7158bba784d32e0df949b39df616fc54a161a52998429e82
     user: "1000:1000"
     volumes:
       - ${APP_DATA_DIR}/data/server-local-data:/app/packages/twenty-server/.local-storage

--- a/twenty/umbrel-app.yml
+++ b/twenty/umbrel-app.yml
@@ -3,7 +3,7 @@ id: twenty
 name: Twenty
 tagline: An adaptable CRM solution for seamless team collaboration and growth
 category: files
-version: "0.54.4"
+version: "0.55.6"
 port: 2020
 description: >-
   Twenty is the leading open-source CRM, built by a community of hundreds of contributors to meet the unique needs of your business. Designed for flexibility, it helps businesses of all sizes efficiently manage customer relationships and streamline workflows.
@@ -19,6 +19,12 @@ description: >-
 
 
   Benefits of using Twenty include improved organization, streamlined communication, better data management, and enhanced collaboration within your team. The flexibility and customization options also ensure that Twenty can adapt as your business grows and changes.
+
+
+  ⚠️ The Twenty CRM app does not come with preconfigured email or calendar providers. To use services like Gmail or Microsoft Outlook, you need to create your own OAuth credentials and add them in the Settings under **Other / Admin Panel / Config Variables**. Providers will only appear in the interface once valid credentials are set.
+  
+  
+  You can find detailed setup instructions here: https://twenty.com/developers/section/self-hosting/setup#for-gmail-and-google-calendar
 developer: Twenty.com PBC
 website: https://twenty.com/
 submitter: dennysubke
@@ -31,11 +37,14 @@ gallery:
   - 3.jpg
   - 4.jpg
 releaseNotes: >-
-  This release includes various improvements and bug fixes:
-    - Enhanced filtering capabilities for LINKS and EMAILS sub-fields
-    - Improved workflow management and custom field handling
-    - Refined user interface and experience enhancements
-    - Various performance optimizations and bug fixes
+  This release includes multiple new features, improvements and bug fixes:
+    - **UI/UX Enhancements**: Numerous dropdown, table, modal, and layout fixes to improve interface stability and consistency.
+    - **Admin Panel**: Added support for setting custom variables.
+    - **Permissions Overhaul**: Continued rollout of Permissions V2 with refined access control, error handling, and test coverage.
+    - **Workflow Upgrades**: Better execution handling, restored workflow runs, diagram fixes, and dynamic config support.
+    - **Search & Filters**: Added advanced filters including TS vector support, day-first/year-first date parsing, and record search filters.
+    - **Developer Experience**: Dependency updates, improved logging, removed deprecated code, and upgraded to Node.js 22.
+    - **Internationalization**: Ongoing i18n updates and translation additions.
 
 
   For a complete list of changes, please visit https://github.com/twentyhq/twenty/releases


### PR DESCRIPTION
This updates twenty to version 0.55.6.

This release comes with a new feature that gives users the option to configure environment variables via the twenty admin panel in the settings. This fixes #2594.

Also closes #2625 as the workaround with the environment files is not needed anymore then.

Tested on Umbrel dev instance.