### PR TITLE
lightning-terminal: update to v0.15.0-alpha

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.14.1-alpha@sha256:b9eb42c626eae23ad0d0bf1937c4b620498f2e92ed5f477f1d09a0e94b497fae
+    image: lightninglabs/lightning-terminal:v0.15.0-alpha@sha256:0a56e4cb34dd76265c568835c88501b626065a8d78d41ace757ccdbebdd8b205
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.14.1-alpha"
+version: "0.15.0-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -59,8 +59,8 @@ releaseNotes: >-
   ⚠️ Please update your Lightning Node app to the latest version available in the app store to ensure compatibility with Lightning Terminal.
 
 
-  This release of Lightning Terminal (LiT) ships the first update to the non-experimental version of Taproot Asset
-  Channels, which comes with bug fixes for Taproot Assets Channels! It also updates the integrated LND and Faraday daemons.
+  This release of Lightning Terminal (LiT) ships with `lnd v0.19.1-beta`, `loop v0.31.2-beta`, `faraday v0.2.16-alpha`,
+  `pool v0.6.6-beta` and `tapd v0.6.0`, which comes with full group key support for Taproot Assets Channels!
 
 
   IMPORTANT NOTE: To avoid loss of funds, it's imperative that you read the
@@ -98,7 +98,7 @@ releaseNotes: >-
   feedback from the community.
 
 
-  This release packages LND v0.18.5-beta, Taproot Assets Daemon v0.5.1-alpha,
-  Loop v0.29.0-beta, Pool v0.6.4-beta and Faraday v0.2.14-alpha.
+  This release packages LND v0.19.1-beta, Taproot Assets Daemon v0.6.0-alpha,
+  Loop v0.31.2-beta, Pool v0.6.6-beta and Faraday v0.2.16-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
In this PR we bump Litd to v0.15.0-alpha.

See the release notes here: https://github.com/lightninglabs/lightning-terminal/blob/master/docs/release-notes/release-notes-0.15.0.md

Happy to address any feedback if needed :)!