### PR TITLE
Update Thunderhub to v.0.13.32

### DIFF
--- a/thunderhub/docker-compose.yml
+++ b/thunderhub/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: apotdevin/thunderhub:v0.13.31@sha256:8c2e54dbc09cb7924def149c4be3ae0bd7fc7080b7d6db6daed9c17f829f8dcc
+    image: apotdevin/thunderhub:v0.13.32@sha256:a1db59155b4e6f9af027e7ac722aed7b186d3406648d08add753f3dc7d44086a
     # We now have to run as root to avoid schema.gql permission errors
     # user: "1000:1000"
     restart: on-failure

--- a/thunderhub/umbrel-app.yml
+++ b/thunderhub/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: thunderhub
 category: bitcoin
 name: ThunderHub
-version: "0.13.31"
+version: "0.13.32"
 tagline: Take full control of your Lightning node
 description: >-
   ThunderHub allows you to take full control of your Lightning node
@@ -28,9 +28,9 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 releaseNotes: >-
-  This release upgrades Boltz Swaps to Taproot for cheaper and more private swaps. The upgrade is backwards compatible, so existing swaps that are pending before the upgrade will complete without issue.
+  This release fixes issues when fetching multiple Boltz swap statuses.
 
   
-  Full release notes can be found at https://github.com/apotdevin/thunderhub/releases/tag/v0.13.31
+  Full release notes can be found at https://github.com/apotdevin/thunderhub/releases/tag/v0.13.32
 submitter: Anthony Potdevin
 submission: https://github.com/getumbrel/umbrel/pull/343


### PR DESCRIPTION
Fixes issues when fetching multiple Boltz swap statuses.