### PR TITLE
Update trilium-notes to v0.95.0

### DIFF
--- a/trilium-notes/docker-compose.yml
+++ b/trilium-notes/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: zadam/trilium:0.63.7@sha256:a0b5a6a5fd7a64391ae6039bbcd5493151a77a1d5470ef5911923c64d0c232c0
+    image: triliumnext/notes:v0.95.0@sha256:611a430016585d35b170eb9a0fa300ce76318f04a8ec0067549c4c52561b0c36
     restart: on-failure
     environment:
       - TRILIUM_DATA_DIR=/data

--- a/trilium-notes/umbrel-app.yml
+++ b/trilium-notes/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: trilium-notes
 category: files
 name: Trilium Notes
-version: "0.63.7"
+version: "v0.95.0"
 tagline: Build your personal knowledge base with Trilium Notes
 description: >-
   Features
@@ -43,11 +43,11 @@ description: >-
   - Evernote and Markdown import & export
 
   - Web Clipper for easy saving of web content
-developer: ZAdam
-website: https://github.com/zadam/trilium
+developer: TriliumNext
+website: https://github.com/TriliumNext
 dependencies: []
-repo: https://github.com/zadam/trilium
-support: https://github.com/zadam/trilium/wiki
+repo: https://github.com/TriliumNext/Trilium
+support: https://github.com/TriliumNext/Trilium/wiki
 port: 3779
 gallery:
   - 1.jpg
@@ -61,8 +61,19 @@ torOnly: false
 submitter: Pranshu Agrawal
 submission: https://github.com/getumbrel/umbrel-apps/pull/199
 releaseNotes: >-
-  Changes:
+  ⚠️ This release brings a big version jump with lots of new features and improvements. Consider taking a backup before upgrading.
 
-    - Backported Excalidraw upgrade to 0.17.3
 
-  Full release notes are available at https://github.com/zadam/trilium/releases
+  Key Highlights:
+    - New default theme "Trilium.Rocks" with refreshed UI and icons
+    - Full TypeScript rewrite of the codebase for better stability and maintainability
+    - Built-in syntax highlighting for code blocks and math rendering support (LaTeX-style)
+    - Enhanced calendar with start/end times, week/year/list views
+    - Zen Mode improvements and keyboard shortcut for formatting (F9)
+    - Mermaid diagrams and mind maps can now be exported as PNG
+    - Markdown export improvements (better formatting, HTML tables support)
+    - Improved mobile and tablet layout
+    - Numerous bug fixes and dependency upgrades
+
+
+  Full release notes are available at https://github.com/TriliumNext/Trilium/releases


### PR DESCRIPTION
Tested update on Umbrel dev instance and fresh install on Umbrel Home.