### PR TITLE
Update btc-rpc-explorer to v3.5.0

### DIFF
--- a/btc-rpc-explorer/docker-compose.yml
+++ b/btc-rpc-explorer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8080
 
   web:
-    image: getumbrel/btc-rpc-explorer:v3.4.0@sha256:e85a1fe80919d308b1f80de2dc7174e7b61ec79384d695304fbf259b67b53594
+    image: getumbrel/btc-rpc-explorer:v3.5.0@sha256:11b55b2efd7c6a27cd1c13474ad78e8f0b91fdac2e8a48141e40ed38c5efd186
     restart: on-failure
     stop_grace_period: 1m
     environment:

--- a/btc-rpc-explorer/umbrel-app.yml
+++ b/btc-rpc-explorer/umbrel-app.yml
@@ -20,6 +20,9 @@ releaseNotes: >-
     - Mempool total fees are now displayed on the main page
     - Improved fee estimates for the next block
 
+  
+  Note: the version shown within the app will still be 3.4.0 even though the app will be running 3.5.0. The developers of BTC RPC Explorer are aware of this cosmetic issue.
+
 
   Full release notes for BTC RPC Explorer versions are available at https://github.com/janoside/btc-rpc-explorer/releases
 developer: Dan Janosik

--- a/btc-rpc-explorer/umbrel-app.yml
+++ b/btc-rpc-explorer/umbrel-app.yml
@@ -16,6 +16,9 @@ description: >-
 
   It's time to appreciate the "fullness" of your node.
 releaseNotes: >-
+  ⚠️ It may take a few minutes for the app to be accessible after updating. Please be patient.
+
+  
   This is a minor update that fixes a few bugs and includes the following improvements:
     - Mempool total fees are now displayed on the main page
     - Improved fee estimates for the next block

--- a/btc-rpc-explorer/umbrel-app.yml
+++ b/btc-rpc-explorer/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: btc-rpc-explorer
 category: bitcoin
 name: BTC RPC Explorer
-version: "3.4.0-rpc"
+version: "3.5.0"
 tagline: Simple, database-free blockchain explorer
 description: >-
   BTC RPC Explorer is a full-featured, self-hosted explorer for the
@@ -16,10 +16,9 @@ description: >-
 
   It's time to appreciate the "fullness" of your node.
 releaseNotes: >-
-  This update brings RPC Browser and RPC Terminal features to BTC RPC Explorer on umbrelOS.
-  
-  
-  ⚠️ A username and password is now required to access the explorer due to the new RPC Browser and RPC Terminal features. You can find your unique credentials by right-clicking on the BTC RPC Explorer app icon on the umbrelOS homescreen and selecting "Show default credentials".
+  This is a minor update that fixes a few bugs and includes the following improvements:
+    - Mempool total fees are now displayed on the main page
+    - Improved fee estimates for the next block
 
 
   Full release notes for BTC RPC Explorer versions are available at https://github.com/janoside/btc-rpc-explorer/releases


### PR DESCRIPTION
~~DO NOT MERGE YET~~

Tested and working on x86 and arm64. It looks like there is a small issue where the project forgot to update the version number in their UI:

<img width="201" alt="image" src="https://github.com/user-attachments/assets/0aebca2a-7926-4714-81bd-b4fd3d196059" />

Let's wait a couple days to see if they release a fix, just so we don't release 2 updates close together with only a cosmetic version change.