### PR TITLE
Update Cloudflare Tunnel daemon to 2025.6.1

### DIFF
--- a/cloudflared/docker-compose.yml
+++ b/cloudflared/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       CLOUDFLARED_TOKEN_FILE: "/app/data/token"
 
   connector:
-    image: ghcr.io/radiokot/umbrel-cloudflared-connector:1.0.0-cf.2025.2.0@sha256:9a126ccfd01e93e447a98f246cc948b55b4822455beb7dda995dfb216c1b3eab
+    image: ghcr.io/radiokot/umbrel-cloudflared-connector:1.0.0-cf.2025.6.1@sha256:29b93b8705051446ad86b1b5b69fd099c9c7ba7c6c084e91b7e052c28220b07c
     hostname: cloudflared-connector
     restart: on-failure
     stop_grace_period: 5s

--- a/cloudflared/umbrel-app.yml
+++ b/cloudflared/umbrel-app.yml
@@ -3,7 +3,7 @@ id: cloudflared
 name: Cloudflare Tunnel
 tagline: Access your Umbrel apps from the Internet using Cloudflare network
 category: networking
-version: "2025.2.0"
+version: "2025.6.1"
 port: 4499
 description: >-
   Start a secure tunnel to access your Umbrel apps from the Internet using the Cloudflare network. 
@@ -34,7 +34,7 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  The tunneling daemon (cloudflared) has been updated to 2025.2.0
+  The tunneling daemon (cloudflared) has been updated to 2025.6.1
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
This PR updates the cloudflared daemon of the Cloudflare Tunnel app to [2025.6.1](https://github.com/cloudflare/cloudflared/blob/9ca8b41cf79fa08ec58c0209eef940851df9157b/RELEASE_NOTES).
There are no user-facing changes in this update.