### PR TITLE
Enable Desktop Client use for Solidtime

### DIFF
--- a/solidtime/hooks/post-start
+++ b/solidtime/hooks/post-start
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# sentinel file to check if client_id was already created
+CLIENT_SENTINEL="${APP_DATA_DIR}/desktop_cliend_id.txt"
+
+# ──────────────────────────────────────────────────────────────
+# Ensure desktop_client_id.txt exists
+# ──────────────────────────────────────────────────────────────
+if [[ ! -s "$CLIENT_SENTINEL" ]]; then
+  echo "Solidtime: generating desktop client id…"
+  "${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" \
+    run --rm scheduler php artisan passport:client --name=desktop --redirect_uri=solidtime://oauth/callback --public -n \
+  | grep 'Client ID' | awk '{print $NF}' > "$CLIENT_SENTINEL"
+fi

--- a/solidtime/hooks/pre-start
+++ b/solidtime/hooks/pre-start
@@ -19,7 +19,7 @@ SLEEP_SECS=5
 # Skip bootstrap entirely if admin already initialised
 # ──────────────────────────────────────────────────────────────
 if [[ -f "$ADMIN_SENTINEL" ]]; then
-  echo "Solidtime: admin already initialised – skipping bootstrap."
+  echo "Solidtime: admin already initialised - skipping bootstrap."
   exit 0
 fi
 
@@ -64,7 +64,7 @@ for ((try=1; try<=MAX_TRIES; try++)); do
     echo "Solidtime: admin user ready."
     break
   fi
-  echo "  Attempt $try/$MAX_TRIES failed – retrying in ${SLEEP_SECS}s…"
+  echo "  Attempt $try/$MAX_TRIES failed - retrying in ${SLEEP_SECS}s…"
   sleep "$SLEEP_SECS"
 done
 
@@ -89,5 +89,5 @@ fi
 # ──────────────────────────────────────────────────────────────
 # Bring down all containers and let umbrelOS start them fresh
 # ──────────────────────────────────────────────────────────────
-echo "Solidtime: bootstrap finished – stopping stack for clean start…"
+echo "Solidtime: bootstrap finished - stopping stack for clean start…"
 "${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" stop

--- a/solidtime/umbrel-app.yml
+++ b/solidtime/umbrel-app.yml
@@ -3,7 +3,7 @@ id: solidtime
 name: Solidtime
 tagline: A simple, secure, and private time tracking app
 category: files
-version: "0.8.0"
+version: "0.8.0-1"
 port: 8770
 description: >-
   🕒 Solidtime is a simple, secure, and private time tracking app that helps you keep track of your time and stay productive. It's designed to be easy to use and respects your privacy by storing your data locally.
@@ -18,6 +18,11 @@ description: >-
   ⚠️ New users can only be created via the terminal for now. Example:
 
   `sudo docker exec -i solidtime_scheduler_1 bash -c "echo '<password' | php artisan admin:user:create '<username>' '<email>' --ask-for-password --verify-email"`
+
+
+  💻 To be able to use the Desktop Client, a Client ID is needed. 
+    - Use the Umbrel Files App and navigate to **Apps/Solidtime**
+    - A file called `desktop_cliend_id.txt` can be found there that contains the ID that you need to get started
 
 
   The application takes a few minutes until it becomes available after installation. Please be patient.
@@ -37,7 +42,13 @@ deterministicPassword: true
 defaultPassword: ""
 dependencies: []
 releaseNotes: >-
-  This release includes new features and improvements:
+  This update creates an ID so you can use the Desktop Client.
+
+
+  You can find the Client ID via the Files App here: **Apps/Solidtime/desktop_client_id.txt**
+
+
+  Version 0.8.0 includes new features and improvements:
 
     - New formatting options for numbers, currency, date, time, and intervals
     - New date range picker


### PR DESCRIPTION
This update generates a `client_id` that can be used to login to the solidtime Desktop App.

Fixes #3090 