### PR TITLE
Disable Nitter on pre-1.0 app stores

### DIFF
--- a/nitter/umbrel-app.yml
+++ b/nitter/umbrel-app.yml
@@ -1,4 +1,4 @@
-manifestVersion: 1
+manifestVersion: 1.2
 id: nitter
 category: social
 name: Nitter


### PR DESCRIPTION
App has been disabled on 1.0+ app store for a long time.