### PR TITLE
Re-enable readarr to fix discover page

### DIFF
--- a/readarr/umbrel-app.yml
+++ b/readarr/umbrel-app.yml
@@ -49,4 +49,4 @@ releaseNotes: >-
 
 
   Full release notes are found at https://github.com/Readarr/Readarr/releases
-disabled: true
+#disabled: true


### PR DESCRIPTION
Will be disabled after it has been removed from the app store discover page.