### PR TITLE
Change qbittorrent image to new location

### DIFF
--- a/qbittorrent/docker-compose.yml
+++ b/qbittorrent/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: hotio/qbittorrent:release-5.1.2@sha256:5a87420684fdc65daecb39283324b2a4e90e11cb748bf93a6b7d96144a9be820
+    image: ghcr.io/hotio/qbittorrent:release-5.1.2@sha256:4c731e88dd419a20f0e158cef9672e902a7e2c71acea48b8989567f00b5fb095
     environment:
       - PUID=1000
       - PGID=1000


### PR DESCRIPTION
The docker hub image of qbittorrent was deleted, the new one can be found on github.

Fixes #3239 