### PR TITLE
Update PeerSwap to v5.0.0

### DIFF
--- a/peerswap/docker-compose.yml
+++ b/peerswap/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 1984
 
   web:
-    image: ghcr.io/impa10r/peerswap-web:v5.0.0@sha256:2f49f2f8d64cde33776ce3229621885fa6a5cd8352db23085f4bc49ad6cc1367
+    image: ghcr.io/impa10r/peerswap-web:v5.0.0@sha256:a7294b119fdbe2bc88833c1a36320e572ed9f4d55d398c340679d07b948a7ef7
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/peerswap/docker-compose.yml
+++ b/peerswap/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 1984
 
   web:
-    image: ghcr.io/impa10r/peerswap-web:v1.7.8@sha256:eb0d586ebac4c94b02ea84f46633c30b61d3c78b493bd7ec1063a31ff3502fb4
+    image: ghcr.io/impa10r/peerswap-web:v5.0.0@sha256:2f49f2f8d64cde33776ce3229621885fa6a5cd8352db23085f4bc49ad6cc1367
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/peerswap/umbrel-app.yml
+++ b/peerswap/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: peerswap
 category: bitcoin
 name: PeerSwap
-version: "1.7.8"
+version: "5.0.0"
 tagline: Balance your lightning channels with Liquid BTC
 description: PeerSwap enables Lightning Network nodes to balance their channels by facilitating atomic swaps with direct peers. PeerSwap enhances decentralization of the Lightning Network by enabling all nodes to be their own swap provider. No centralized coordinator, no 3rd party rent collector, and lowest cost channel balancing means small nodes can better compete with large nodes. Includes channel AutoFees, Liquid Peg-in and BTC send with coin select + fee bump functionality.
 developer: PeerSwap Project
@@ -10,6 +10,7 @@ website: https://peerswap.dev
 dependencies:
   - lightning
   - elements
+  - bitcoin
 repo: https://github.com/Impa10r/peerswap-web
 support: https://discord.com/invite/wpNv3PG8G2
 port: 1984
@@ -21,4 +22,9 @@ path: ""
 submitter: Impa10r
 submission: https://github.com/getumbrel/umbrel-apps/pull/932
 releaseNotes: >-
-  Bug fixes and improvements. Full changelog: https://github.com/Impa10r/peerswap-web/blob/main/CHANGELOG.md
+  Major bump to protocol version 5 that intoduces swap premiums. 
+  No more giving away your BTC and L-BTC coins for free! 
+  Default premiums are 1000 pps for L-BTC and 2000 pps for BTC.
+  Manage your liquidity like Boltz Pro with negative rates.
+  Ask all your current peers to update to stay compatible.
+  Full changelog: https://github.com/Impa10r/peerswap-web/blob/main/CHANGELOG.md

--- a/peerswap/umbrel-app.yml
+++ b/peerswap/umbrel-app.yml
@@ -22,9 +22,6 @@ path: ""
 submitter: Impa10r
 submission: https://github.com/getumbrel/umbrel-apps/pull/932
 releaseNotes: >-
-  Major bump to protocol version 5 that intoduces swap premiums. 
-  No more giving away your BTC and L-BTC coins for free! 
-  Default premiums are 1000 pps for L-BTC and 2000 pps for BTC.
-  Manage your liquidity like Boltz Pro with negative rates.
-  Ask all your current peers to update to stay compatible.
+  Major bump to protocol version 5 that introduces swap premiums. 
+  Default premiums are 1000 pps for L-BTC and 2000 pps for BTC swap-outs.
   Full changelog: https://github.com/Impa10r/peerswap-web/blob/main/CHANGELOG.md

--- a/peerswap/umbrel-app.yml
+++ b/peerswap/umbrel-app.yml
@@ -22,6 +22,9 @@ path: ""
 submitter: Impa10r
 submission: https://github.com/getumbrel/umbrel-apps/pull/932
 releaseNotes: >-
-  Major bump to protocol version 5 that introduces swap premiums. 
+  Major bump to protocol version 5 that introduces swap premiums.
+
   Default premiums are 1000 ppm for L-BTC and 2000 ppm for BTC swap-outs.
+
+
   Full changelog: https://github.com/Impa10r/peerswap-web/blob/main/CHANGELOG.md

--- a/peerswap/umbrel-app.yml
+++ b/peerswap/umbrel-app.yml
@@ -23,5 +23,5 @@ submitter: Impa10r
 submission: https://github.com/getumbrel/umbrel-apps/pull/932
 releaseNotes: >-
   Major bump to protocol version 5 that introduces swap premiums. 
-  Default premiums are 1000 pps for L-BTC and 2000 pps for BTC swap-outs.
+  Default premiums are 1000 ppm for L-BTC and 2000 ppm for BTC swap-outs.
   Full changelog: https://github.com/Impa10r/peerswap-web/blob/main/CHANGELOG.md


### PR DESCRIPTION
Major bump to protocol version 5 that introduces swap premiums. 

Full changelog: https://github.com/Impa10r/peerswap-web/blob/main/CHANGELOG.md