### PR TITLE
Update Lightning Node to v0.19.2-beta

### DIFF
--- a/lightning/docker-compose.yml
+++ b/lightning/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
   lnd:
     hostname: "${DEVICE_DOMAIN_NAME}" # Needed so LND can generate a valid cert
-    image: lightninglabs/lnd:v0.19.1-beta@sha256:00143ec1b19ee8be186948e75517a4111bcba8cfc6bf2c4a89732fa4efd998a5
+    image: lightninglabs/lnd:v0.19.1-beta@sha256:dd113dff920c309bf5c4af6a37d912f379dc24c51f266a2c878c12d20501798b
     command: "${APP_LIGHTNING_COMMAND}"
     user: 1000:1000
     restart: unless-stopped

--- a/lightning/docker-compose.yml
+++ b/lightning/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
   lnd:
     hostname: "${DEVICE_DOMAIN_NAME}" # Needed so LND can generate a valid cert
-    image: lightninglabs/lnd:v0.19.1-beta@sha256:dd113dff920c309bf5c4af6a37d912f379dc24c51f266a2c878c12d20501798b
+    image: lightninglabs/lnd:v0.19.2-beta@sha256:dd113dff920c309bf5c4af6a37d912f379dc24c51f266a2c878c12d20501798b
     command: "${APP_LIGHTNING_COMMAND}"
     user: 1000:1000
     restart: unless-stopped

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: lightning
 category: bitcoin
 name: Lightning Node
-version: "0.19.1-beta"
+version: "0.19.2-beta"
 tagline: Run your personal Lightning Network node
 description: >-
   Run your personal Lightning Network node, and join the future of Bitcoin today.
@@ -22,12 +22,10 @@ description: >-
 
   An official app from Umbrel.
 releaseNotes: >-
-  This release updates the underlying Lightning Network Daemon (LND) that powers this app to v0.19.1-beta. The update includes new feature additions, important bug fixes, stability enhancements, and performance improvements for LND.
-  In addition, Testnet4 support has been added.
-
-
-  🚨 There are no breaking changes to the Umbrel app itself; however, if you are a power user who uses automated scripts to interact with your node via the command line,
-  there are breaking changes to the "lncli listchannels" and "lncli closedchannels" outputs that you should consult the release notes for.
+  This release updates the underlying Lightning Network Daemon (LND) that powers this app to v0.19.2-beta. The update contains important bug fixes and performance improvements for LND.
+  
+  
+  In addition, the "decayed log database" (sphinxreplay.db) is cleaned up automatically on update, which can reduce disk and memory usage for nodes.
 
 
   Full release notes can be found at https://github.com/lightningnetwork/lnd/releases


### PR DESCRIPTION
LND release notes: https://github.com/lightningnetwork/lnd/releases/tag/v0.19.2-beta

Updates the underlying Lightning Network Daemon (LND) that powers this app to v0.19.2-beta.

Garbage collection is run on the sphinx.replay.db on update.

Tested on my main LND instance:

```
2025-07-24 02:37:04.943 [INF] CHDB: Checking for optional update: name=gc_decayed_log
2025-07-24 02:37:04.943 [INF] CHDB: Performing database optional migration: gc_decayed_log
2025-07-24 02:37:04.943 [INF] CHDB: Migrating decayed log...
2025-07-24 02:37:04.944 [INF] CHDB: Decayed log migrated successfully
2025-07-24 02:37:04.947 [INF] CHDB: Successfully applied optional migration: gc_decayed_log
```

Tested and is working with other Lightning ecosystem apps.
