### PR TITLE
Disable firefox

### DIFF
--- a/firefox/umbrel-app.yml
+++ b/firefox/umbrel-app.yml
@@ -5,7 +5,7 @@ name: Firefox
 version: "139.0.4"
 tagline: Firefox is a free and open-source web browser
 description: >-
-  ⚠️ Removal Notice: The Firefox app has been disabled as there are not more updates that work without HTTPS.
+  ⚠️ Removal Notice: The Firefox app has been disabled as there are no more updates that work without HTTPS.
 
 
   Get the browser that protects what is important.

--- a/firefox/umbrel-app.yml
+++ b/firefox/umbrel-app.yml
@@ -1,10 +1,13 @@
-manifestVersion: 1
+manifestVersion: 1.2
 id: firefox
 category: networking
 name: Firefox
 version: "139.0.4"
 tagline: Firefox is a free and open-source web browser
 description: >-
+  ⚠️ Removal Notice: The Firefox app has been disabled as there are not more updates that work without HTTPS.
+
+
   Get the browser that protects what is important.
 
 
@@ -45,3 +48,4 @@ deterministicPassword: false
 torOnly: false
 submitter: Pranshu Agrawal
 submission: https://github.com/getumbrel/umbrel-apps/pull/253
+disabled: true


### PR DESCRIPTION
Will be re-enabled once HTTP support is back or Umbrel HTTPS support is available.