### PR TITLE
Disable chromium

### DIFF
--- a/chromium/umbrel-app.yml
+++ b/chromium/umbrel-app.yml
@@ -1,4 +1,4 @@
-manifestVersion: 1
+manifestVersion: 1.2
 id: chromium
 name: Chromium
 tagline: The open-source browser project
@@ -6,6 +6,9 @@ category: networking
 version: "8d3cb5f1"
 port: 30099
 description: >-
+  ⚠️ Removal Notice: The Chromium app has been disabled as there are no more updates that work without HTTPS.
+
+
   Chromium is an open-source web browser project initiated and primarily maintained by Google. Serving as the foundation for many browsers, including Google Chrome, Microsoft Edge, and Opera, Chromium aims to build a safer, faster, and more stable way for all users to experience the web.
 developer: The Chromium Project
 website: https://www.chromium.org/Home/
@@ -27,3 +30,4 @@ releaseNotes: >-
 
 
   Full release notes can be found at https://developer.chrome.com/release-notes
+disabled: true


### PR DESCRIPTION
Will be re-enabled once HTTP support is back or Umbrel HTTPS support is available.