### PR TITLE
ffmpeg support for Sabnzbd

### DIFF
--- a/sabnzbd/docker-compose.yml
+++ b/sabnzbd/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - ${APP_DATA_DIR}/data/config:/config
       - ${UMBREL_ROOT}/data/storage/downloads:/downloads
     environment:
+      - DOCKER_MODS=linuxserver/mods:universal-package-install
+      - INSTALL_PACKAGES=ffmpeg
       - PUID=1000
       - PGID=1000
       - TZ=Etc/UTC

--- a/sabnzbd/umbrel-app.yml
+++ b/sabnzbd/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: sabnzbd
 category: networking
 name: SABnzbd
-version: "4.5.2"
+version: "4.5.2-1"
 tagline: The automated Usenet download tool
 description: >-
   SABnzbd makes Usenet as simple and streamlined as possible by automating everything we can. All you have to do is add an .nzb.
@@ -30,7 +30,10 @@ repo: https://github.com/sabnzbd/sabnzbd
 support: https://forums.sabnzbd.org/
 port: 9876
 releaseNotes: >-
-  This release includes several improvements and bug fixes:
+  This release adds support for ffmpeg.
+
+
+  The previous update included several improvements and bug fixes:
     - Added Tab and Shift+Tab navigation to move between rename fields in queue
     - Fixed issues with invalid cookies of other services
     - Resolved Internet Bandwidth test getting stuck in infinite loop


### PR DESCRIPTION
I'm editing sabnzbd docker-compose.yml by adding environment variables to make use of docker-mods to install ffmpeg package. See https://github.com/linuxserver/docker-mods and https://github.com/linuxserver/docker-mods/tree/universal-package-install

This will also close issue #3325