### PR TITLE
Update Image to 1.2.0 fixing CVE-2025-55161

### DIFF
--- a/stirling-pdf/docker-compose.yml
+++ b/stirling-pdf/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
   
   app:
-    image: stirlingtools/stirling-pdf:1.1.1@sha256:12de648818f4ec139dacad50acb90c302c6077986f70cf09708c8c38d041c285
+    image: stirlingtools/stirling-pdf:1.2.0@sha256:4b549915161efdf8a7c43bf0ad3b5d5d39f0cb0be58b7dcce1d1b62fbe8ed818
     # Stirling PDF does not work with a custom user
     #user: "1000:1000"
     restart: on-failure


### PR DESCRIPTION
https://github.com/Stirling-Tools/Stirling-PDF/security/advisories/GHSA-ff33-grr6-rmvp

https://github.com/Stirling-Tools/Stirling-PDF/commit/7d6b70871bad2a3ff810825f7382c49f55293943