### PR TITLE
Alby Hub: lnd dependency replaced by dynamic backend detection getalby#1349

### DIFF
--- a/albyhub/docker-compose.yml
+++ b/albyhub/docker-compose.yml
@@ -10,12 +10,13 @@ services:
     user: 1000:1000
     volumes:
       - ${APP_DATA_DIR}/data:/data
-      - ${APP_LIGHTNING_NODE_DATA_DIR}:/lnd:ro
+      # Using UMBREL_ROOT here to ensure exports.sh can read mounted LND certs/macaroons properly
+      - ${UMBREL_ROOT}/app-data/lightning/data/lnd:/lnd:ro
     environment:
-      LN_BACKEND_TYPE: "LND"
-      LND_ADDRESS: $APP_LIGHTNING_NODE_IP:$APP_LIGHTNING_NODE_GRPC_PORT
-      LND_CERT_FILE: "/lnd/tls.cert"
-      LND_MACAROON_FILE: "/lnd/data/chain/bitcoin/$APP_BITCOIN_NETWORK/admin.macaroon"
+      LN_BACKEND_TYPE: ${APP_ALBYHUB_LN_BACKEND:-LDK}
+      LND_ADDRESS: ${APP_ALBYHUB_LND_ADDRESS:-}
+      LND_CERT_FILE: ${APP_ALBYHUB_LND_CERT_FILE:-}
+      LND_MACAROON_FILE: ${APP_ALBYHUB_LND_MACAROON_FILE:-}
       WORK_DIR: "/data/albyhub"
       COOKIE_SECRET: ${APP_SEED}
       LOG_EVENTS: "true"

--- a/albyhub/exports.sh
+++ b/albyhub/exports.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+
+export APP_ALBYHUB_LN_BACKEND="LDK"
+export APP_ALBYHUB_LND_ADDRESS=""
+
+# Check if Lightning Node app is installed and export required variables if so
+installed_apps=$("${UMBREL_ROOT}/scripts/app" ls-installed)
+
+if echo "$installed_apps" | grep --quiet 'lightning'; then
+  export APP_ALBYHUB_LN_BACKEND="LND"
+  export APP_ALBYHUB_LND_ADDRESS="10.21.21.9:10009"
+  export APP_ALBYHUB_LND_CERT_FILE="/lnd/tls.cert"
+  export APP_ALBYHUB_LND_MACAROON_FILE="/lnd/data/chain/bitcoin/mainnet/admin.macaroon"
+fi

--- a/albyhub/umbrel-app.yml
+++ b/albyhub/umbrel-app.yml
@@ -39,11 +39,11 @@ releaseNotes: >-
     - Addressed password change authorization bug
     - Added migration button for isolated connections to sub-wallets
     - Included Wave.space in the app store
+    - Removed lightning(LND) dependency: LND + LDK backend auto-detection.
 
 
   Full release notes are found at https://github.com/getAlby/hub/releases
-dependencies:
-  - lightning
+
 path: ""
 defaultUsername: ""
 defaultPassword: ""


### PR DESCRIPTION
This PR allows users to install Alby Hub with an LDK backend directly without having the dependency of the LND (lightning) app. In case the LND is indeed installed, then the Alby Hub will install automatically using the LND as the backend.

Dynamic backend detection implemented in the `exports.sh` file, similar to mempool's app implementation.
- If the LND app (`lightning`) is installed, Alby Hub will be configured to use **LND**.
- If not, it will fallback to **LDK** as default.

Addresses [issue#1349](https://github.com/getAlby/hub/issues/1349)
