### PR TITLE
Update wger CSRF list to enable access via IPs

### DIFF
--- a/wger/docker-compose.yml
+++ b/wger/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     environment:
       SECRET_KEY: ${APP_SEED}
       SIGNING_KEY: ${APP_SEED}
-      CSRF_TRUSTED_ORIGINS: http://${DEVICE_DOMAIN_NAME}:8450
+      CSRF_TRUSTED_ORIGINS: http://${DEVICE_DOMAIN_NAME}:${APP_WGER_PORT},http://${DEVICE_HOSTNAME}:${APP_WGER_PORT},${APP_WGER_LOCAL_URLS}
       SITE_URL: http://${DEVICE_DOMAIN_NAME}:8450
     env_file:
       - ${APP_DATA_DIR}/config/prod.env

--- a/wger/exports.sh
+++ b/wger/exports.sh
@@ -1,0 +1,16 @@
+export APP_WGER_PORT="8450"
+
+local_ips=$(hostname --all-ip-addresses 2> /dev/null) || local_ips=""
+export APP_WGER_LOCAL_IPS="${local_ips}"
+
+# Build URLs with http:// and port, comma-separated
+ips_with_port=$(for ip in $local_ips; do
+  # Wrap IPv6 addresses in []
+  if [[ "$ip" == *:* ]]; then
+    echo -n "http://[$ip]:$APP_WGER_PORT,"
+  else
+    echo -n "http://$ip:$APP_WGER_PORT,"
+  fi
+done | sed 's/,$//')
+
+export APP_WGER_LOCAL_URLS="${ips_with_port}"

--- a/wger/umbrel-app.yml
+++ b/wger/umbrel-app.yml
@@ -3,7 +3,7 @@ id: wger
 name: wger
 tagline: A fitness tracker for workouts and nutrition
 category: files
-version: "2.3"
+version: "2.3-1"
 port: 8450
 description: >-
   📈 wger is a powerful and flexible open-source fitness management software designed to assist users in planning, tracking, and optimizing their workouts, nutrition, and overall fitness progress. Whether you are an individual looking to improve your training efficiency, a personal trainer managing multiple clients, or a gym owner searching for a digital solution to streamline workout programming, wger provides a feature-rich platform tailored to various fitness needs.
@@ -35,7 +35,8 @@ gallery:
   - 4.jpg
   - 5.jpg
   - 6.jpg
-releaseNotes: ""
+releaseNotes: >-
+  This update allows wger to be accessed using URLs other than the default Umbrel hostname, such as direct IP addresses.
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
This enables wger to be accessed via the local ip of umbrel or also via tailscale magic dns if the hostname is set to `umbrel` there.