### PR TITLE
Update Jam to v0.4.1

### DIFF
--- a/jam/docker-compose.yml
+++ b/jam/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   web:
-    image: ghcr.io/joinmarket-webui/jam-standalone:v0.4.0-clientserver-v0.9.11@sha256:3742e15734b91ea520ae7b78c2e6b82aed715bdcda5a786c92efe77ffd89ecc7
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.4.1-clientserver-v0.9.11@sha256:1b2491b6795bd56b5c7ff01a365c92c9699ad6c0456047bc4e9a30078d5cce6c
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/jam/umbrel-app.yml
+++ b/jam/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: jam
 category: bitcoin
 name: Jam
-version: "0.4.0"
+version: "0.4.1"
 tagline: Your sats. Your privacy. Your profit.
 description: >-
   Jam is a user-interface for JoinMarket with focus on
@@ -13,15 +13,9 @@ description: >-
 
   The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 releaseNotes: >-
-  - Fidelity Bond: Ability to select destination jar when unlocking fidelity bond
+  - Fix: Total balance inconsistency
 
-  - Send: Color-coded checkboxes for UTXO states
-
-  - Rescan: Show progress during timechain rescan
-
-  - Orderbook: Ability to reload and/or hard refresh
-
-  - Theme: Fast theme toggle in navbar
+  - Config: Include new directory nodes in default config
 
   - UI: Various UI improvements and bugfixes
 


### PR DESCRIPTION
This version includes:
- Jam: [v0.4.1](https://github.com/joinmarket-webui/jam/releases/tag/v0.4.1)
- joinmarket-clientserver: [v0.9.11](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.11)

All notable changes of the UI can be seen in the [Jam v0.4.1 changelog](https://github.com/joinmarket-webui/jam/blob/v0.4.1/CHANGELOG.md)