### PR TITLE
Update Monero daemon to v0.18.4.2

### DIFF
--- a/monero/docker-compose.yml
+++ b/monero/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     restart: unless-stopped
     stop_grace_period: 15m
     command: "${APP_MONERO_COMMAND}"
-    image: ghcr.io/sethforprivacy/simple-monerod:v0.18.4.1@sha256:11810da93d3a92721421e7aa5f6e1763e12752d5398b84659d864cccc3ebe989
+    image: ghcr.io/sethforprivacy/simple-monerod:v0.18.4.2@sha256:4ddb2eef5b367639a106f449c47992709a55953e30ea269788cdd736ca45a98b
     ports:
       - "${APP_MONERO_P2P_PORT}:${APP_MONERO_P2P_PORT}"
       - "${APP_MONERO_RPC_PORT}:${APP_MONERO_RPC_PORT}"

--- a/monero/umbrel-app.yml
+++ b/monero/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: monero
 category: finance
 name: Monero Node
-version: "0.18.4.1"
+version: "0.18.4.2"
 tagline: Run a monero node
 description: >-
   Run your monero node and independently store and validate every single Monero transaction with it.
@@ -23,15 +23,13 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This release contains bug fixes related to the wallet, the daemon, the RPC, and more.
+  This release contains bug fixes related to the wallet, the daemon, and more.
 
 
 
   Some highlights of this release are:
-    - add new dynamic fees to ZMQ
-    - add set_subaddresss_lookahead endpoint
-    - improve logic when connecting to a peer
-    - fix edge case causing unresponsive wallet
-    - add safeguard for rare exception in TCP accept handler
+    - Wallet: fix privacy leak with malicious remote node
+    - Daemon: more accurate connection count
+    - Minor bug fixes and improvements
 
-  Further details can be found at https://www.getmonero.org/2025/07/25/monero-0.18.4.1-released.html
+  Further details can be found at https://www.getmonero.org/2025/08/26/monero-0.18.4.2-released.html


### PR DESCRIPTION
Monero 0.18.4.2 (Fluorine Fermi) has been released, so we upgrade the daemon in the corresponding Umbrel app accordingly.