### PR TITLE
chore(alby-nostr-wallet-connect): deprecate old NWC app

### DIFF
--- a/alby-nostr-wallet-connect/umbrel-app.yml
+++ b/alby-nostr-wallet-connect/umbrel-app.yml
@@ -4,6 +4,7 @@ name: Nostr Wallet Connect
 tagline: The power of the zaps at the tip of your fingers
 category: bitcoin
 version: "0.4.2"
+disabled: true
 port: 58000
 description: >-
   ⚠️ Deprecation notice: This app has been deprecated by the project developers and therefore will no longer receive any app updates.


### PR DESCRIPTION
This PR deprecates the old Nostr Wallet Connect (Alby) app by adding disabled: true to its umbrel-app.yml.
The app is no longer maintained and users should install Alby Hub instead.