### PR TITLE
Update bitcoin to 1.0.4

### DIFF
--- a/bitcoin/docker-compose.yml
+++ b/bitcoin/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   app:
-    image: ghcr.io/getumbrel/umbrel-bitcoin:v1.0.3-core.v29.0@sha256:311d14cf3cb0a49fad7779310521f1abd9242dfcc2f08eb8e3cbff97ca67d6ea
+    image: ghcr.io/getumbrel/umbrel-bitcoin:v1.0.4-core.v29.1@sha256:0d80c37b9bbc52303b1eb4ea37c1cae75aa8d1a022adfbd8dfd25fed861b753f
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 15m30s
@@ -28,8 +28,9 @@ services:
       BITCOIND_EXTRA_ARGS: '-deprecatedrpc=create_bdb' # We can remove depratedrpc=create_bdb in a future update once Jam (JoinMarket) implements descriptor wallet support
 
       # BITCOIND CONF FILE SETTINGS
-      APPS_SUBNET: "${NETWORK_IP}/16" # used to whitelist local apps as both peers (whitelist) and rpc connections (rpcallowip)
+      APPS_SUBNET: "${NETWORK_IP}/16" # used for rpcallowip
       P2P_PORT: "${APP_BITCOIN_P2P_PORT}" # port, bind (also used for connect details)
+      P2P_WHITEBIND_PORT: "${APP_BITCOIN_P2P_WHITEBIND_PORT}" # Additional inbound P2P listener granting whitelisted permissions (whitebind) to this port; for trusted internal apps only; do not publish externally
       RPC_PORT: "${APP_BITCOIN_RPC_PORT}" # rpcport (also used for rpc client and connect details)
       TOR_PORT: "${APP_BITCOIN_TOR_PORT}" # bind=onion
       ZMQ_RAWBLOCK_PORT: "${APP_BITCOIN_ZMQ_RAWBLOCK_PORT}" # zmqpubrawblock

--- a/bitcoin/exports.sh
+++ b/bitcoin/exports.sh
@@ -9,6 +9,8 @@ export APP_BITCOIN_DATA_DIR="${EXPORTS_APP_DIR}/data/bitcoin"
 # PORTS
 export APP_BITCOIN_RPC_PORT="8332"
 export APP_BITCOIN_P2P_PORT="8333"
+# Additional inbound P2P listener granting whitelisted permissions (whitebind) to this port; for trusted internal apps only; do not publish externally
+export APP_BITCOIN_P2P_WHITEBIND_PORT="8335"
 # As of v28.1, the default onion listening port will now be derived to be -port + 1 instead of being set to a fixed value (8334 on mainnet)
 # We are fine because we always hardcode port to 8333 regardless of network
 export APP_BITCOIN_TOR_PORT="8334"

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -2,10 +2,10 @@ manifestVersion: 1.1
 id: bitcoin
 category: bitcoin
 name: Bitcoin Node
-version: "1.0.3"
+version: "1.0.4"
 tagline: Run your personal node powered by Bitcoin Core
 description: >-
-  Run your Bitcoin node and independently store and validate
+  Run your Bitcoin node, powered by Bitcoin Core v29.1, and independently store and validate
   every single Bitcoin transaction with it. Achieve unparalleled
   privacy by connecting your wallet directly to your node to
   ensure that your wallet company can’t spy on your transactions,
@@ -42,34 +42,7 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This update fixes a bug that could prevent Bitcoin Core from starting after upgrading from the old app if settings had been changed via the command line
-
-
-  ### In addition, here's what's new in the all-new Bitcoin Node app.
-
-
-  This update introduces a completely redesigned experience, rebuilt from the ground up, both architecturally and visually, to give you a powerful, data-rich view into every aspect of your node's operation.
-  
-  
-  From visualizing the network in real time to fine-tuning your configuration, the tools you need for ultimate sovereignty are now at your fingertips.
-  
-  
-  ### New features:
-  
-  - **Globe**: A stunning, real-time visualization of your node's global connections. See new peers connect and transactions broadcast around the world, as it happens.
-  
-  - **Blocks**: Follow along as each new block arrives, packed with transactions, and is verified by your own node.
-
-  - **Insights**: Key metrics about your node and the network are now presented in a series of clean, elegant charts.
-
-  - **Peers**: A completely new table gives you a detailed, sortable list of every peer your node is connected to.
-
-  - **Settings**: Fine-tune your node with a simplified, searcheable, and more intuitive layout for the settings. 
-
-  - **Configuration Editor**: Power users can now make custom fine-grained adjustments to their `bitcoin.conf` file directly from a new editor in the app's settings.
-
-
-  A new chapter for self-sovereignty begins.
+  This update bumps the underlying Bitcoin Core version to v29.1. Full Bitcoin Core release notes can be found at https://bitcoincore.org/en/releases/29.1/
 widgets:
   - id: "stats"
     type: "four-stats"
@@ -104,5 +77,21 @@ widgets:
       text: "83%"
       progressLabel: "In progress"
       progress: 0.83
+backupIgnore:
+  - data/bitcoin/blocks
+  - data/bitcoin/chainstate
+  - data/bitcoin/indexes
+  - data/bitcoin/testnet3/blocks
+  - data/bitcoin/testnet3/chainstate
+  - data/bitcoin/testnet3/indexes
+  - data/bitcoin/testnet4/blocks
+  - data/bitcoin/testnet4/chainstate
+  - data/bitcoin/testnet4/indexes
+  - data/bitcoin/signet/blocks
+  - data/bitcoin/signet/chainstate
+  - data/bitcoin/signet/indexes
+  - data/bitcoin/regtest/blocks
+  - data/bitcoin/regtest/chainstate
+  - data/bitcoin/regtest/indexes
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/commit/576ecd2bef8d625abceed0f67ec9c487da9b2b1b


### PR DESCRIPTION
This update bumps the underlying Bitcoin Core version to v29.1. Full Bitcoin Core release notes can be found at https://bitcoincore.org/en/releases/29.1/