### PR TITLE
Update wger media url

### DIFF
--- a/wger/docker-compose.yml
+++ b/wger/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       SIGNING_KEY: ${APP_SEED}
       CSRF_TRUSTED_ORIGINS: http://${DEVICE_DOMAIN_NAME}:${APP_WGER_PORT},http://${DEVICE_HOSTNAME}:${APP_WGER_PORT},${APP_WGER_LOCAL_URLS}
       SITE_URL: http://${DEVICE_DOMAIN_NAME}:8450
+      MEDIA_URL: http://${DEVICE_DOMAIN_NAME}:8450/media/
     env_file:
       - ${APP_DATA_DIR}/config/prod.env
     volumes:

--- a/wger/umbrel-app.yml
+++ b/wger/umbrel-app.yml
@@ -3,7 +3,7 @@ id: wger
 name: wger
 tagline: A fitness tracker for workouts and nutrition
 category: files
-version: "2.3-1"
+version: "2.3-2"
 port: 8450
 description: >-
   📈 wger is a powerful and flexible open-source fitness management software designed to assist users in planning, tracking, and optimizing their workouts, nutrition, and overall fitness progress. Whether you are an individual looking to improve your training efficiency, a personal trainer managing multiple clients, or a gym owner searching for a digital solution to streamline workout programming, wger provides a feature-rich platform tailored to various fitness needs.
@@ -36,7 +36,7 @@ gallery:
   - 5.jpg
   - 6.jpg
 releaseNotes: >-
-  This update allows wger to be accessed using URLs other than the default Umbrel hostname, such as direct IP addresses.
+  This update fixes the media url so images can be loaded.
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
This updates the media url of wger so images can be displayed properly.

Usually this command needs to be executed so the default images are downloaded, we could consider to add this to a pre-start script in the future: `docker exec -it wger_web_1 python3 manage.py download-exercise-images`