### PR TITLE
Allow Jellyfin to access Videos folder

### DIFF
--- a/jellyfin/docker-compose.yml
+++ b/jellyfin/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
       - ${UMBREL_ROOT}/data/storage/downloads:/downloads
-      - ${UMBREL_ROOT}/data/storage/videos:/videos
+      - ${UMBREL_ROOT}/home/Videos:/videos
     ports:
       # Service auto-discovery
       - 7359:7359/udp


### PR DESCRIPTION
Jellyfin being a an app made to host video files, it would make sense to be able to put my video files directly inside UmbrelOS's video folder, instead of somewhere in the app data files.

Note: i don't know if `${UMBREL_ROOT}/data/storage/videos:/videos` is the correct thing to point to the videos folder, so please correct it if its wrong.