### PR TITLE
Update fulcrum to v2.0

### DIFF
--- a/fulcrum/docker-compose.yml
+++ b/fulcrum/docker-compose.yml
@@ -29,7 +29,9 @@ services:
   fulcrum:
     image: cculianu/fulcrum:v2.0.0@sha256:cb1c006d0cff104696f4791d0f1516699b2c163120165461385e4de206271943
     init: true
-    stop_grace_period: 1m
+    # Rely on Docker's default SIGTERM; Fulcrum treats SIGTERM/SIGINT/SIGQUIT as graceful
+    # Generous grace period prevents SIGKILL during checkpoint/flush on exit
+    stop_grace_period: 5m
     restart: on-failure
     user: "1000:1000"
     environment:
@@ -41,7 +43,12 @@ services:
       PEERING: "false"
       ANNOUNCE: "false"
       DATA_DIR: /data
-    command: sh -c 'Fulcrum -D /data _ENV_ 2>&1 | tee /logs/fulcrum.log'
+    # Exec Fulcrum as PID1 so it receives SIGTERM directly; FIFO+tee mirrors output to docker logs and /logs/fulcrum.log
+    # rm -f makes FIFO creation idempotent across restarts/crash loops
+    command: >
+      sh -c 'rm -f /tmp/fulcrum.pipe; mkfifo /tmp/fulcrum.pipe;
+      tee -a /logs/fulcrum.log < /tmp/fulcrum.pipe &
+      exec Fulcrum -D /data _ENV_ > /tmp/fulcrum.pipe 2>&1'
     volumes:
       - "${APP_DATA_DIR}/data/fulcrum:/data"
       - "${APP_DATA_DIR}/data/fulcrum-logs:/logs"

--- a/fulcrum/docker-compose.yml
+++ b/fulcrum/docker-compose.yml
@@ -29,8 +29,7 @@ services:
   fulcrum:
     image: cculianu/fulcrum:v1.12.0.1@sha256:ee6a67224a766448507eddc0efba8649b5598f1ea3def39673e2a08210ae4921
     init: true
-    stop_signal: SIGINT
-    stop_grace_period: 5m
+    stop_grace_period: 1m
     restart: on-failure
     user: "1000:1000"
     environment:
@@ -42,7 +41,7 @@ services:
       PEERING: "false"
       ANNOUNCE: "false"
       DATA_DIR: /data
-    command: 'Fulcrum _ENV_ 2>&1 | tee /logs/fulcrum.log'
+    command: sh -c 'Fulcrum -D /data _ENV_ 2>&1 | tee /logs/fulcrum.log'
     volumes:
       - "${APP_DATA_DIR}/data/fulcrum:/data"
       - "${APP_DATA_DIR}/data/fulcrum-logs:/logs"

--- a/fulcrum/docker-compose.yml
+++ b/fulcrum/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         ipv4_address: $APP_FULCRUM_IP
 
   fulcrum:
-    image: cculianu/fulcrum:v1.12.0.1@sha256:ee6a67224a766448507eddc0efba8649b5598f1ea3def39673e2a08210ae4921
+    image: cculianu/fulcrum:v2.0.0@sha256:cb1c006d0cff104696f4791d0f1516699b2c163120165461385e4de206271943
     init: true
     stop_grace_period: 1m
     restart: on-failure

--- a/fulcrum/hooks/post-update
+++ b/fulcrum/hooks/post-update
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-# restart app so that new port number for the UI (2109) is sourced correctly
-"${UMBREL_ROOT}/scripts/app" restart "${APP_ID}" &

--- a/fulcrum/hooks/pre-start
+++ b/fulcrum/hooks/pre-start
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Remove legacy post-update hook if present
-POST_UPDATE_HOOK="$(readlink -f $(dirname "${BASH_SOURCE[0]}") )/post-update"
+POST_UPDATE_HOOK="${APP_DATA_DIR}/hooks/post-update"
 if [[ -e "${POST_UPDATE_HOOK}" ]]; then
   echo "App: ${APP_ID} - Removing '${POST_UPDATE_HOOK}'"
   rm -f -- "${POST_UPDATE_HOOK}" || echo "App: ${APP_ID} - Warning: failed to remove '${POST_UPDATE_HOOK}'"
@@ -11,6 +11,30 @@ fi
 if [[ ! -d "${APP_DATA_DIR}/data/fulcrum-logs" ]]; then
   mkdir -p "${APP_DATA_DIR}/data/fulcrum-logs"
   chown 1000:1000 "${APP_DATA_DIR}/data/fulcrum-logs"
+fi
+
+# We do a one-time re-sync for pre-2.0 users by clearing the old fulcrum data if present
+# Why we delete instead of attempting a one-time on-start `--db-upgrade`:
+# - Fulcrum 2.0 uses a new, incompatible DB format; 1.x requires `--db-upgrade` to convert
+# - The 1.x -> 2.0 upgrade is irreversible and unsafe to interrupt; a restart during upgrade
+#   can destroy both the old and new DBs (see Fulcrum 2.0 release notes)
+# - We cannot guarantee users won't restart the app mid-upgrade, which can take several hours on mainnet.
+#   and users would get no feedback from the app at all during that time.
+# - A flagged one-time delete followed by a fresh sync is deterministic, idempotent, and avoids
+#   partial migrations or bricked states if users restart at the wrong time
+FULCRUM_DATA_DIR="${APP_DATA_DIR}/data/fulcrum"
+POST_2_0_FLAG="${APP_DATA_DIR}/POST_2_0_VERSION"
+
+mkdir -p "${FULCRUM_DATA_DIR}"
+
+if [[ ! -f "${POST_2_0_FLAG}" ]]; then
+  # Check if directory has any entries (files or dirs), including dotfiles
+  if [[ -n "$(find "${FULCRUM_DATA_DIR}" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+    echo "App: ${APP_ID} - Pre-2.0 data detected, clearing '${FULCRUM_DATA_DIR}' once"
+    # Remove all entries safely (handles dotfiles and names with spaces)
+    find "${FULCRUM_DATA_DIR}" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+  fi
+  touch "${POST_2_0_FLAG}"
 fi
 
 # Delay booting Fulcrum until the RPC Tor Hidden Service is ready

--- a/fulcrum/hooks/pre-start
+++ b/fulcrum/hooks/pre-start
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# Remove legacy post-update hook if present
+POST_UPDATE_HOOK="$(readlink -f $(dirname "${BASH_SOURCE[0]}") )/post-update"
+if [[ -e "${POST_UPDATE_HOOK}" ]]; then
+  echo "App: ${APP_ID} - Removing '${POST_UPDATE_HOOK}'"
+  rm -f -- "${POST_UPDATE_HOOK}" || echo "App: ${APP_ID} - Warning: failed to remove '${POST_UPDATE_HOOK}'"
+fi
+
 # If ${APP_DATA_DIR}/data/fulcrum-logs doesn't exist, we create it and set 1000:1000 ownership
 if [[ ! -d "${APP_DATA_DIR}/data/fulcrum-logs" ]]; then
   mkdir -p "${APP_DATA_DIR}/data/fulcrum-logs"

--- a/fulcrum/umbrel-app.yml
+++ b/fulcrum/umbrel-app.yml
@@ -30,7 +30,14 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This update adds support for Backups in umbrelOS 1.5.
+  🚨 This update will automatically trigger a full re-sync of your Fulcrum index. During the
+  re-sync, wallets connected to Fulcrum won't be able to connect.
+
+
+  Fulcrum is now far more resilient to restarts, shutdowns, and power loss, avoiding the database corruption issues that notoriously plagued previous versions.
+
+
+  Full Fulcrum release notes are available at https://github.com/cculianu/Fulcrum/releases/tag/v2.0.0
 backupIgnore:
   - data/fulcrum/scripthash_history
   - data/fulcrum/utxoset

--- a/fulcrum/umbrel-app.yml
+++ b/fulcrum/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - electrs
 category: bitcoin
 name: Fulcrum
-version: "1.12.0-patch.2"
+version: "2.0.0"
 tagline: A fast and nimble Electrum Server
 description: >-
   Run your personal Electrum server and connect your Electrum-compatible wallet,

--- a/fulcrum/umbrel-app.yml
+++ b/fulcrum/umbrel-app.yml
@@ -39,11 +39,4 @@ releaseNotes: >-
 
   Full Fulcrum release notes are available at https://github.com/cculianu/Fulcrum/releases/tag/v2.0.0
 backupIgnore:
-  - data/fulcrum/scripthash_history
-  - data/fulcrum/utxoset
-  - data/fulcrum/scripthash_unspent
-  - data/fulcrum/txhash2txnum
-  - data/fulcrum/blkinfo
-  - data/fulcrum/meta
-  - data/fulcrum/undo
-  - data/fulcrum/rpa
+  - data/fulcrum/fulc2_db


### PR DESCRIPTION
https://github.com/cculianu/Fulcrum/releases/tag/v2.0.0

From Fulcrum's official release notes:
>#### Upgrade Instructions
>Fulcrum 2.0 has a different database format than the 1.x series. As such, you have two options for upgrading:
>
>Create a blank new datadir and just re-synch from block 0 (slow, but 100% reliable)
Upgrade your existing 1.x datadir (faster, but irreversible and destructice)
To upgade your existing database, be sure to pass the one-time --db-upgrade flag to Fulcrum. It will refuse to start up if it detects that your datadir is in the old format and you did not pass this flag. This ensures that admins know what they are getting into.
>
>Note: The upgrade process takes seconds to minutes on BCH and BTC testnet(s), maybe ~15 minutes on BCH mainnet, and around an hour or more (depending on hardware) on BTC mainnet.

>#### Critical Note On Upgrading the DB from 1.x -> 2.0
>Let it run to completion!
>
>While Fulcrum 2.0 is 100% reliable and may be killed at any time during its operation -- there is one exception to this rule: the upgrade process that converts 1.x databases -> 2.0. As such please let the upgrade process run to completion and do not kill, stop, molest, or otherwise abuse the Fulcrum process while it's upgrading the DB!!. If you do, the old 1.x database will be lost and your 2.0 database will also be corrupted.
>
>You have been warned!

I don't think there is a simple and reliable way for us to go the database upgrade route for users. This would involve a one-time container startup with `--db-upgrade`, then allow migration to run fully with no user feedback other than the app stuck in "starting...", and then bringing up the app normally after migration is complete. The migration on mainnet can take hours, AND during that time if the user restarted the app or their Umbrel for any reason they would fully brick their Fulcrum app (would lose 1.x database and corrupt 2.0 database) requiring a re-install and full re-sync.

So the simplest, bomb-proof route for us here is to delete index data for pre-2.0 installs which will automatically force a re-index which apparently won't be corrupted during start/stop even during index anymore due to 2.0 db changes.

I've done this super simply with a flag file we set for new installs (empty fulcrum data dir) and for existing installs one-time after deleting the contents of the fulcrum data dir.

Other changes:
- reverted https://github.com/getumbrel/umbrel-apps/pull/2894 changes that resulted in a broken UI (no fulcrum.log)
- removed legacy post-update script
- updated the backupIgnore filepaths to take into account Fulcrum 2.0 structure:

<img width="1131" height="438" alt="image" src="https://github.com/user-attachments/assets/eaef552c-306f-41c0-81fb-829ed753d4ed" />

