### PR TITLE
umbrelOS 1.5 GPU acceleration support

### DIFF
--- a/emby/umbrel-app.yml
+++ b/emby/umbrel-app.yml
@@ -3,7 +3,7 @@ id: emby
 name: Emby
 tagline: A personal media server
 category: media
-version: "4.9.1"
+version: "4.9.1-gpu"
 port: 8097
 description: >-
   ▶️ Emby is a powerful media server software designed to help users manage, stream, and enjoy their personal collection of movies, TV shows, music, photos, and home videos across a wide range of devices. It acts as a central hub for all your digital media, automatically organizing content and enriching it with metadata like cover art, descriptions, and ratings. Emby provides a clean and intuitive interface that allows users to easily browse and play their media, whether they are at home or on the go.
@@ -51,7 +51,12 @@ releaseNotes: >-
     - Various fixes for sorting, scanning, and metadata management
 
   For a complete list of changes, please visit https://github.com/MediaBrowser/Emby.Releases/releases
+
+  This update also adds support for GPU passthrough in umbrelOS 1.5.
 dependencies: []
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+permissions:
+  - STORAGE_DOWNLOADS
+  - GPU

--- a/frigate/docker-compose.yml
+++ b/frigate/docker-compose.yml
@@ -12,8 +12,6 @@ services:
     restart: on-failure
     image: ghcr.io/blakeblackshear/frigate:0.16.1@sha256:cb6624b9075f76ece626139eedca7e728cab1456a5f8c351afbf877320826bc1
     shm_size: "128mb" # update for your cameras based on calculation above
-    devices:
-     - /dev:/dev
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${APP_DATA_DIR}/data/config:/config

--- a/frigate/umbrel-app.yml
+++ b/frigate/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: frigate
 category: automation
 name: Frigate
-version: "0.16.1"
+version: "0.16.1-gpu"
 tagline: A complete and local NVR
 description: >-
   A complete and local NVR designed for Home Assistant with AI object detection. 
@@ -19,10 +19,10 @@ description: >-
 releaseNotes: >-
   ⚠️ As usual, Frigate will attempt to update its configuration automatically. It is still recommended to back up your current config and database before upgrading.
 
+  This update adds support for GPU passthrough in umbrelOS 1.5.
 
-  This is a maintenance release for Frigate 0.16 that includes bugfixes and minor changes. Some key highlights include:
 
-
+  The release notes of the previous version included the following changes:
     - Improved recording playback startup time on slow connections
     - Fixed various UI issues and layout problems
     - Improved audio support for go2rtc streams
@@ -44,5 +44,7 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 dependencies: []
+permissions:
+  - GPU
 submitter: ~dibref-labter
 submission: https://github.com/getumbrel/umbrel-apps/pull/843

--- a/immich/umbrel-app.yml
+++ b/immich/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: immich
 category: files
 name: Immich
-version: "v2.0.1"
+version: "v2.0.1-gpu"
 tagline: High-performance photo and video backup solution
 description: >-
   An open-source and high-performance self-hosted backup solution for the videos and photos on your mobile device
@@ -48,8 +48,10 @@ releaseNotes: >-
   ⚠️ As usual, please check that your mobile app is compatible with this release of Immich.
 
 
+  This update adds support for GPU passthrough in umbrelOS 1.5.
 
-  This patch release primarily addresses several bugs in the mobile app:
+
+  The release notes of the previous version included the following changes:
     - Fixed asset deletion on share
     - Fixed activity display in shared albums
     - Fixed compass button overlapping status bar
@@ -74,5 +76,7 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+permissions:
+  - GPU
 submitter: levma
 submission: https://github.com/getumbrel/umbrel-apps/pull/239

--- a/jellyfin/umbrel-app.yml
+++ b/jellyfin/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jellyfin
 category: media
 name: Jellyfin
-version: "10.10.7"
+version: "10.10.7-gpu"
 tagline: The Free Software Media System
 description: >-
   Jellyfin is the volunteer-built media solution that puts you in control of your media. Stream to any device from your own server, with no strings attached. Your media, your server, your way.
@@ -32,7 +32,10 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  This minor release brings several bugfixes and security fixes to improve your Jellyfin experience.
+  This update adds support for GPU passthrough in umbrelOS 1.5.
+
+
+  The release notes of the previous version included the following changes.
 
 
   ⚠️ If you're using a reverse proxy, ensure you have explicitly configured trusted proxies before upgrading. See the Jellyfin documentation for more information.
@@ -50,5 +53,6 @@ releaseNotes: >-
 torOnly: false
 permissions:
   - STORAGE_DOWNLOADS
+  - GPU
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/commit/60878f278d544b204d8e7c96240c797f43a9b319

--- a/plex/umbrel-app.yml
+++ b/plex/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: plex
 category: media
 name: Plex
-version: "1.42.1.10054"
+version: "1.42.1.10054-gpu"
 tagline: Stream Movies & TV Shows
 description: >-
   Stream movies and TV shows, plus 300+ channels of live TV, instantly, without a subscription. Watch live TV and movies anywhere, from any device, with Plex.
@@ -28,11 +28,12 @@ defaultPassword: ""
 torOnly: false
 permissions:
   - STORAGE_DOWNLOADS
+  - GPU
 releaseNotes: >-
-  🚨 This release includes important security fixes. Update is strongly recommended.
+  This update adds support for GPU passthrough in umbrelOS 1.5.
 
 
-  The update also includes several enhancements and bug fixes to improve your streaming experience:
+  The release notes of the previous version included the following changes:
     - Added support for Icelandic in Movie and TV show libraries
     - New preference for downloads temp directory
     - Added option to set number of simultaneous background transcodes, including downloads

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: portainer
 category: developer
 name: Portainer
-version: "2.33.2"
+version: "2.33.2-gpu"
 tagline: Run custom Docker containers on your Umbrel
 description: >-
   ⚠️ Make sure to only use named Docker volumes for your stacks and containers. Data in bind-mounted volumes
@@ -51,7 +51,10 @@ path: ""
 defaultUsername: "admin"
 defaultPassword: "changeme"
 releaseNotes: >-
-  This update includes several improvements and fixes:
+  This update adds support for GPU passthrough in umbrelOS 1.5.
+
+
+  The release notes of the previous version included the following changes:
     - Fixed issues with environment status updates and access control
     - Improved security with increased Content-Security-Policy restrictions
     - Enhanced GitOps functionality and Helm repository validation
@@ -63,6 +66,8 @@ releaseNotes: >-
 
 
   Full release notes are found at https://github.com/portainer/portainer/releases.
+permissions:
+  - GPU
 developer: Portainer
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/774

--- a/sabnzbd/umbrel-app.yml
+++ b/sabnzbd/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: sabnzbd
 category: networking
 name: SABnzbd
-version: "4.5.3"
+version: "4.5.3-gpu"
 tagline: The automated Usenet download tool
 description: >-
   SABnzbd makes Usenet as simple and streamlined as possible by automating everything we can. All you have to do is add an .nzb.
@@ -30,7 +30,10 @@ repo: https://github.com/sabnzbd/sabnzbd
 support: https://forums.sabnzbd.org/
 port: 9876
 releaseNotes: >-
-  This release includes several bug fixes and improvements:
+  This update adds support for GPU passthrough in umbrelOS 1.5.
+
+
+  The release notes of the previous version included the following changes:
 
     - Remember if 'Permanently delete' was previously checked
     - Include all available IP-addresses when selecting the fastest
@@ -43,6 +46,7 @@ releaseNotes: >-
   Full release notes are available at https://github.com/sabnzbd/sabnzbd/releases
 permissions:
   - STORAGE_DOWNLOADS
+  - GPU
 gallery:
   - 1.jpg
   - 2.jpg


### PR DESCRIPTION
Enable GPU acceleration for emby, frigate, immich, jellyfin, plex, portainer, and zabnzbd