### PR TITLE
Deprecate Tallycoin

### DIFF
--- a/tallycoin-connect/umbrel-app.yml
+++ b/tallycoin-connect/umbrel-app.yml
@@ -1,10 +1,15 @@
-manifestVersion: 1
+manifestVersion: 1.2
 id: tallycoin-connect
 category: bitcoin
 name: Tallycoin Connect
 version: "1.8.0-1"
 tagline: Crowdfund donations directly to your Umbrel node with Tallycoin
-description: Tallycoin is a crowdfunding platform with bitcoin and lightning donations. Together with the Tallycoin Connect app, you can receive donations directly to your Umbrel node. Zero fees!
+description: >-
+  ⚠️ Deprecation notice: This app has been deprecated by the project developers and therefore will no longer receive any app updates.
+  Tallycoin platform shut down June 1st, 2024. Therefore, Tallycoin Connect service will not function.
+  
+  
+  Tallycoin is a crowdfunding platform with bitcoin and lightning donations. Together with the Tallycoin Connect app, you can receive donations directly to your Umbrel node. Zero fees!
 developer: djbooth007
 website: https://tallycoin.app/connect/
 dependencies:
@@ -31,3 +36,4 @@ releaseNotes: >-
   There are no updates to the Tallycoin Connect app itself.
 submitter: d11n
 submission: https://github.com/getumbrel/umbrel/pull/1052
+disabled: true


### PR DESCRIPTION
Tallycoin platform shut down June 1st, 2024. Therefore, Tallycoin Connect service will not function.

https://github.com/djbooth007/tallycoin_connect