### PR TITLE
Knots: add version selection

### DIFF
--- a/bitcoin-knots/docker-compose.yml
+++ b/bitcoin-knots/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
   
   app:
-    image: ghcr.io/retropex/umbrel-bitcoin-knots:1.0.5-knots.v29.2@sha256:d75df53e0fc8b15ace68d8b9edbaca475d3e71735b63b2061fadbc9c92e2e193
+    image: ghcr.io/retropex/umbrel-bitcoin-knots:1.1.0@sha256:f455204f1f8b4f7a2b6f0c70966f77b50015a171cdaf218353f7d4f251301425
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 15m30s

--- a/bitcoin-knots/umbrel-app.yml
+++ b/bitcoin-knots/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - bitcoin
 category: bitcoin
 name: Bitcoin Knots
-version: "29.2"
+version: "29.2-2"
 tagline: Run your personal node powered by Bitcoin Knots
 description: >-
   Take control of your digital sovereignty by choosing Bitcoin Knots to run your node! By using Knots, you’re supporting a version of Bitcoin that prioritizes efficiency, security, and flexibility. With Bitcoin Knots’ enhanced configuration options, you can fine-tune your node to help keep the network clean and resilient, actively reducing unnecessary load from spam or parasitic transactions.
@@ -36,7 +36,7 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  Full Bitcoin Knots v29.2.knots20251010 release notes are found at https://github.com/bitcoinknots/bitcoin/releases/tag/v29.2.knots20251010
+  Add version selection for Bitcoin Knots and code improvements.
 widgets:
   - id: "stats"
     type: "four-stats"


### PR DESCRIPTION
Hey,

Due to some users that want to run an alternative version of knots, I would like to add the support of an alternative version of knots directly inside the package in order to avoid the user having to manually move the data from one package to another.

Such change should be merged only if it's very stable since bitcoind is upstream to a lot of services. that why code review would be very appreciated, thanks in advance!

PR of the package change:
https://github.com/Retropex/umbrel-bitcoin/pull/7