### PR TITLE
Update downtify to 1.1.1

### DIFF
--- a/downtify/docker-compose.yml
+++ b/downtify/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8000
 
   downtify:
-    image: henriquesebastiao/downtify:1.1.0@sha256:b8c88de2677d00848d6e9af39bfdd67fc7e2bf02012b136aeda4da80e0a3cf3d
+    image: ghcr.io/henriquesebastiao/downtify:1.1.1@sha256:6799338c2369d18941d2e4b9cbc99c762a694e3bce5b769678a3f4edd0ba8b6c
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/downtify/umbrel-app.yml
+++ b/downtify/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: downtify
 category: media
 name: Downtify
-version: "1.1.0"
+version: "1.1.1"
 tagline: Download Spotify music with album art and metadata
 description: >-
   Downtify allows you to download music by copy-pasting the Spotify link for a song, album, etc. The songs are downloaded from YouTube, along with album art, lyrics, and other metadata about the songs.
@@ -19,8 +19,8 @@ dependencies: []
 repo: https://github.com/henriquesebastiao/downtify
 port: 8789
 releaseNotes: >-
-  This version includes new features and improvements:
-    - Added list file view
+  This release includes the following bug fixes:
+    - Fixes yt-dlp error that caused download errors
 
 
   Full release notes can be found at https://github.com/henriquesebastiao/downtify/releases


### PR DESCRIPTION
This pull request updates Downtify to version 1.1.1.

The new version fixes a critical bug that caused all downloads to fail. This error was caused by the lack of an updated `yt-dlp` library.