### PR TITLE
fix: disable proxy auth for kitchenowl

### DIFF
--- a/kitchenowl/docker-compose.yml
+++ b/kitchenowl/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
       APP_HOST: kitchenowl_web_1
       APP_PORT: 8080
+      PROXY_AUTH_ADD: "false"
 
   web:
     image: tombursch/kitchenowl:v0.7.4@sha256:9d5e4402c2abc734e1536586caa103840a7ebe961fdce1570e31b956abeba70b

--- a/kitchenowl/umbrel-app.yml
+++ b/kitchenowl/umbrel-app.yml
@@ -3,7 +3,7 @@ id: kitchenowl
 name: KitchenOwl
 tagline: A grocery list and recipe manager
 category: files
-version: "0.7.4"
+version: "0.7.4-auth-proxy-patch"
 port: 8474
 description: >-
   👨‍🍳 KitchenOwl is a self-hosted, open-source application designed to simplify household management, particularly when it comes to organizing groceries, recipes, meal planning, and shared expenses. Built with privacy and usability in mind, KitchenOwl empowers individuals, families, and shared households to collaboratively manage kitchen-related tasks through a sleek and intuitive interface available on mobile, desktop, and the web.
@@ -45,6 +45,10 @@ releaseNotes: >-
     - Added support for Farsi and Traditional Chinese languages
     - Fixed some minor UI bugs
     - Improved recipe scraping
+  
+  
+  Security updates:
+    - Disable Proxy Auth
 
 
   Full release notes: https://github.com/TomBursch/kitchenowl/releases/tag/v0.7.4


### PR DESCRIPTION
fix: #3768 