### PR TITLE
fix: enable proxy auth for qbittorrent

### DIFF
--- a/qbittorrent/docker-compose.yml
+++ b/qbittorrent/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       APP_HOST: qbittorrent_server_1
       APP_PORT: 8080
-      PROXY_AUTH_ADD: "false"
+      PROXY_AUTH_ADD: "true"
 
   server:
     image: ghcr.io/hotio/qbittorrent:release-5.1.2@sha256:4c731e88dd419a20f0e158cef9672e902a7e2c71acea48b8989567f00b5fb095

--- a/qbittorrent/umbrel-app.yml
+++ b/qbittorrent/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: qbittorrent
 category: networking
 name: qBittorrent
-version: "5.1.2"
+version: "5.1.2-auth-proxy-patch"
 tagline: Free and reliable P2P Bittorrent client
 description: >-
   qBittorrent is an open-source software alternative to µTorrent. It's designed to meet the needs of most users while using as little CPU and memory as possible.
@@ -35,6 +35,10 @@ releaseNotes: >-
     - Improved ratio handling and compilation compatibility
     - Enhanced IPv6 support and fixed memory leaks
     - Improved path autofill and preview functionality
+  
+  
+  Security updates:
+    - Enable Proxy Auth
 
 
   Full release notes for qBittorrent are available at https://www.qbittorrent.org/news


### PR DESCRIPTION
I've enabled the auth proxy for qbittorrent, because the native auth is no longer working, I'll dig further more into it on why it is not working, also it says in the description that: 

> This app comes bundled with two alternative Web UI's: VueTorrent and Nightwalker. To enable them, navigate to tools --> options --> Web UI and select "Use alternative Web UI". In the "Files location" field, enter "/app/vuetorrent" for VueTorrent or "/app/nightwalker" for Nightwalker and then click "Save".

but I when I try to setup an alternate UI it does not work and then I dig into the container to check if `vuetorrent` and `nightwalker` were present in the `/app`, but there is no files with these name.

logs:
```
$ pwd
/app
$ ls
forwarded_port_update_app  privoxy.conf  qBittorrent  qBittorrent.conf  qbittorrent-nox-lib1  qbittorrent-nox-lib2  unbound.conf
$ ls -a
.  ..  forwarded_port_update_app  privoxy.conf  qBittorrent  qBittorrent.conf  qbittorrent-nox-lib1  qbittorrent-nox-lib2  unbound.conf
```

If the alternate UI is not there, we might remove them from the app description and gallery images.

cc. @al-lac 