### PR TITLE
Update electrs to v0.10.10

### DIFF
--- a/electrs/docker-compose.yml
+++ b/electrs/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         ipv4_address: $APP_ELECTRS_IP
   
   electrs:
-    image: getumbrel/electrs:v0.10.9@sha256:622657fbdc7331a69f5b3444e6f87867d51ac27d90c399c8bf25d9aab020052b
+    image: getumbrel/electrs:v0.10.10@sha256:c991fd3d8b19614fa7309525e8ccb6c0a87464f8bf6bd4dff1479b493f7308f2
     restart: always
     environment:
       ELECTRS_LOG_FILTERS: "INFO"

--- a/electrs/umbrel-app.yml
+++ b/electrs/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: electrs
 category: bitcoin
 name: Electrs
-version: "0.10.9-patch.3"
+version: "0.10.10"
 tagline: A simple and efficient Electrum Server
 description: >
   Run your personal Electrum server and connect your Electrum-compatible wallet,
@@ -30,10 +30,10 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >
-  This update adds support for Backups in umbrelOS 1.5.
+  This update bumps the underlying electrs version to 0.10.10.
+  
 
-
-  Full electrs release notes are available at https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#0109-feb-01-2025
+  Full electrs release notes are available at https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#01010-jul-19-2025
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/242
 backupIgnore:


### PR DESCRIPTION
Updates electrs from 0.10.9 to 0.10.10. There are no meaningful changes for users in this update (mostly documentation changes https://github.com/romanz/electrs/compare/v0.10.9...v0.10.10), but we should do this update anyways since it is starting to look super out of date in the app store.

- Tested on arm64 and amd64.
- Tested wallet connection.