### PR TITLE
fix: repo and support link for homarr

### DIFF
--- a/homarr/umbrel-app.yml
+++ b/homarr/umbrel-app.yml
@@ -23,8 +23,8 @@ developer: homarr-labs
 website: https://homarr.dev/
 submitter: dennysubke
 submission: https://github.com/getumbrel/umbrel-apps/pull/3254
-repo: https://github.com/ajnart/homarr
-support: https://github.com/ajnart/homarr/issues
+repo: https://github.com/homarr-labs/homarr
+support: https://github.com/homarr-labs/homarr/issues
 gallery:
   - 1.jpg
   - 2.jpg


### PR DESCRIPTION
homarr is migrated to a new org and repo and the old one is archived.