### PR TITLE
Update hombridge to version 1.11.1-2025-11-08

### DIFF
--- a/homebridge/docker-compose.yml
+++ b/homebridge/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   server:
-    image: homebridge/homebridge:2025-10-22@sha256:a5f8e9dc34639562a3f9322ae40c0eda76a7606de92933197c3cd3118dd2c1f0
+    image: homebridge/homebridge:2025-11-08@sha256:4b2cc22d3e764555061105cf7c745501aaa8fb17d2e4e0a5ecea5d9ef42ac02e
     # container runs as root
     network_mode: host
     # available at port 8581

--- a/homebridge/umbrel-app.yml
+++ b/homebridge/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: homebridge
 category: automation
 name: Homebridge
-version: "1.11.0-2025-10-22-gpu"
+version: "1.11.1-2025-11-08"
 tagline: "HomeKit support for the impatient"
 description: >-
   Bringing HomeKit support where there is none. Homebridge allows you to integrate with smart home devices that do not natively support HomeKit.
@@ -42,8 +42,9 @@ permissions:
   - GPU
 releaseNotes: >-
   This release includes several improvements and updates:
-    - Upgraded Homebridge to version 1.7.13
-    - Updated Node.js to version 22.21.0
+    - Upgraded Homebridge to version 1.11.1 and APT Package to version 1.7.16
+    - Updated Node.js to version 22.21.1
+    - Support for GPU passthrough in umbrelOS 1.5.
 
 
   Full release notes can be found at https://github.com/homebridge/homebridge/releases


### PR DESCRIPTION
Tested on an Umbrel dev instance.

This update also adds GPU passthrough support which makes it possible to use the GPU for video transcoding (UniFi Bridge, ...).

Closes #4026 