### PR TITLE
Update Jellyfin to version 10.11.4 in docker-compose and umbrel-app configuration files

### DIFF
--- a/jellyfin/docker-compose.yml
+++ b/jellyfin/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: linuxserver/jellyfin:10.10.7@sha256:01c9d2311eb7710867fb3a8c2718068a276cff468a71d2a2dc58a0f5165ad0d2
+    image: linuxserver/jellyfin:10.11.4@sha256:234ea8d508b2cba26054d0dac9d4c0353435dce483e8b266947d473629774559
     restart: on-failure
     hostname: "${DEVICE_HOSTNAME}"
     environment:

--- a/jellyfin/umbrel-app.yml
+++ b/jellyfin/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jellyfin
 category: media
 name: Jellyfin
-version: "10.10.7-gpu"
+version: "10.11.4-gpu"
 tagline: The Free Software Media System
 description: >-
   Jellyfin is the volunteer-built media solution that puts you in control of your media. Stream to any device from your own server, with no strings attached. Your media, your server, your way.
@@ -32,22 +32,22 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  This update adds support for GPU passthrough in umbrelOS 1.5.
+  We are pleased to announce the latest stable release of Jellyfin, version 10.11.4! This minor release brings several bugfixes to improve your Jellyfin experience. As always, please ensure you take a full backup before upgrading!
 
+  You can find more details about and discuss this release on our forums.
 
-  The release notes of the previous version included the following changes.
-
-
-  ⚠️ If you're using a reverse proxy, ensure you have explicitly configured trusted proxies before upgrading. See the Jellyfin documentation for more information.
-
-
-  Key improvements in this release:
-    - Fixed issues with metadata search and handling
-    - Improved support for various audio and video formats
-    - Enhanced security for API parameters and proxy configurations
-    - Better handling of ratings and premiere dates
-    - Improved system stability and performance
-
+  Changelog (10):
+  📈 General Changes:
+    - Fix ResolveLinkTarget crashing on exFAT drives [PR #15568], by @theguymadmax
+    - Cache OpenApi document generation [PR #15672], by @crobibero
+    - Revert "Localization/iso6392.txt: change pob and pop" [PR #15555], by @MBR-0001
+    - Add hidden file check in BdInfoDirectoryInfo.cs. [PR #15582], by @QuintonQu
+    - Fix isMovie filter logic [PR #15594], by @theguymadmax
+    - Fix locked fields not saving [PR #15564], by @theguymadmax
+    - Save item to database before providers run to prevent FK errors [PR #15563], by @theguymadmax
+    - Prevent copying HDR streams when only SDR is supported [PR #15556], by @gnattu
+    - Fix NullReferenceException in filesystem path comparison [PR #15548], by @theguymadmax
+    - Restrict first video frame probing to file protocol [PR #15557], by @gnattu
 
   Full release notes can be found at https://github.com/jellyfin/jellyfin/releases
 torOnly: false


### PR DESCRIPTION
This pull request updates Jellyfin to the latest stable release 10.11.4 across all relevant configuration files:

- Updated docker-compose.yml to use the new Jellyfin image
- Updated Umbrel app configuration files to match the new version