### PR TITLE
Update Bassin to v2.1.0-hotfix (with verified ckpool image)

### DIFF
--- a/bassin/docker-compose.yml
+++ b/bassin/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - APP_BITCOIN_ZMQ_HASHBLOCK_PORT=${APP_BITCOIN_ZMQ_HASHBLOCK_PORT}
 
   ckpool:
-    image: pinkyswear/ckpool-solo:latest@sha256:71ee905e7badd04ed119f84700fbd0f388fe6307a504b854558e3e6d26cae787
+    image: ghcr.io/getumbrel/docker-ckpool-solo:590fb2a@sha256:4060e6adf34528b9d092e87ddfb5faf42162e60fb5b3c9b0f04d1e3689c63c7f
     entrypoint: /bin/sh -c './bin/ckpool -k -B -c /config/ckpool.conf'
     user: "1000:1000"
     depends_on:

--- a/bassin/umbrel-app.yml
+++ b/bassin/umbrel-app.yml
@@ -1,5 +1,5 @@
 manifestVersion: 1.1
-version: "2.1.0"
+version: "2.1.0-hotfix"
 id: bassin
 name: Bassin
 tagline: Solo Bitcoin Mining Pool (ckPool)
@@ -21,11 +21,10 @@ category: bitcoin
 dependencies:
   - bitcoin
 releaseNotes: >-
-  Key highlights in this release:
-    - UI: Improved output of mining numbers
-    - UI: Added theme switch (light/dark)
-    - System: Set `btcsig` to "/mined by Bassin on Umbrel/"
-    - System: Do not overwrite the configuration file
+  🚨 CRITICAL SECURITY UPDATE - Please update immediately.
+
+
+  A security issue was discovered with the previous ckpool software used by this app. It has been replaced with a new version built from a verified source: https://github.com/getumbrel/docker-ckpool-solo
 port: 5008
 submitter: duckaxe
 developer: duckaxe


### PR DESCRIPTION
Updates the ckpool image to one built by Umbrel (https://github.com/getumbrel/docker-ckpool-solo) using https://bitbucket.org/ckolivas/ckpool-solo.git as source 

Tested fresh install and app update on amd64 and arm64

------------------

Context https://github.com/getumbrel/umbrel-apps/pull/4230

If you are making your way here and wondering how you can verify the ckpool image used in this update, you can confirm the following:

**Edit: if you updated Bassin within the first couple hours of the fix you should follow the steps below with this digest instead:**
sha256:4060e6adf34528b9d092e87ddfb5faf42162e60fb5b3c9b0f04d1e3689c63c7f 

from here:
https://github.com/getumbrel/umbrel-apps/blob/0c56683098bb950ff7d88232bef2865eeb53ae14/bassin/docker-compose.yml#L30

**Otherwise, the details are as follows:**

The `docker-compose.yml` for Bassin pins the ckpool image to a specific tag and a specific SHA256 manifest digest:
https://github.com/getumbrel/umbrel-apps/blob/e72b2c0f53a6fb5c575f4a20be92441511780c23/bassin/docker-compose.yml#L30

The tag `590fb2a` together with the manifest digest `4e6b8f4f9c7d74c2111a6e082a2bbdc936fa510989a81e7cef714d1da944336b` corresponds exactly to this published build:
https://github.com/getumbrel/docker-ckpool-solo/pkgs/container/docker-ckpool-solo/608213402?tag=590fb2a

<img width="754" height="415" alt="image" src="https://github.com/user-attachments/assets/ef8668f0-9aab-48e1-b13b-811abc4b61a2" />

The Dockerfile used for this build is here: https://github.com/getumbrel/docker-ckpool-solo/blob/master/Dockerfile
It clones the official ckpool source directly from https://bitbucket.org/ckolivas/ckpool-solo.git

The GitHub Action that builds the image using that Dockerfile and publishes it to ghcr is here: https://github.com/getumbrel/docker-ckpool-solo/blob/master/.github/workflows/docker-publish.yml

If you have already updated to this version or freshly installed this version and want to verify that you are indeed running this exact ckpool image then you can do the following:

From your umbrelOS homescreen go to Settings > Advanced settings > Terminal > umbrelOS

This will drop you into a terminal in umbrelOS where you can run commands.

To confirm that your system is running the exact image pinned in the docker-compose.yml, paste this command into the terminal and press `Enter`:

```
sudo docker inspect --format='{{.Config.Image}}' bassin_ckpool_1
```

If asked for a password, use the same password you use to log in to your Umbrel.

This prints the exact image reference that the running container was created from, including both the tag and the SHA256 manifest digest. You should this:

```
$ sudo docker inspect --format='{{.Config.Image}}' bassin_ckpool_1
ghcr.io/getumbrel/docker-ckpool-solo:590fb2a@sha256:4e6b8f4f9c7d74c2111a6e082a2bbdc936fa510989a81e7cef714d1da944336b
```
