### PR TITLE
Update Canary to v1.0.1

### DIFF
--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.0.0@sha256:69be76f68aa542aabb1473a1400f6037ca4888e44cf055b89ae748047fa6fb95
+    image: schjonhaug/canary-backend:v1.0.1@sha256:2b26806f58711508ec39254f2cdf592bc39600d54976c7325ee19f54682131fd
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -25,7 +25,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.0.0@sha256:bc6b915f823e98669ad622d340c0371f0b01aded864a921555e42ec3dd0b289c
+    image: schjonhaug/canary-frontend:v1.0.1@sha256:96feb660b3deef68c2803f92a167441d5a7c7a4fd8d29ae67c36d26b4a6b19b7
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: canary
 category: bitcoin
 name: Canary
-version: "1.0.0"
+version: "1.0.1"
 tagline: Early warning system for Bitcoin cold storage
 description: >-
   A canary in the cold mine. When your bitcoins are in cold storage, you seldom check on them.
@@ -27,7 +27,8 @@ gallery:
   - 1.jpg
   - 2.jpg
   - 3.jpg
-releaseNotes: ""
+releaseNotes: >-
+  Fixed API connectivity issue that prevented adding wallets when running on Umbrel.
 path: ""
 defaultUsername: ""
 defaultPassword: ""


### PR DESCRIPTION
## Summary
- Fixed API connectivity issue that prevented adding wallets when running on Umbrel
- Fixed Docker image permissions for migrations directory

## Changes
- Updated frontend image to v1.0.1 with correct `NEXT_PUBLIC_API_URL` build configuration
- Updated backend image to v1.0.1 with proper file ownership for migrations

## Testing
- Tested on umbrelOS running on Raspberry Pi
- Successfully added mainnet wallet and verified connectivity