### PR TITLE
canary: Update to v1.1.0

### DIFF
--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.0.1@sha256:2b26806f58711508ec39254f2cdf592bc39600d54976c7325ee19f54682131fd
+    image: schjonhaug/canary-backend:v1.1.0@sha256:1f028a0b54d8ceb81d34602756845dba6117822889d23ab5f6cbda3d6fbad700
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -25,7 +25,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.0.1@sha256:96feb660b3deef68c2803f92a167441d5a7c7a4fd8d29ae67c36d26b4a6b19b7
+    image: schjonhaug/canary-frontend:v1.1.0@sha256:0598c7b7ba0d78f1c38ea06484917452af1feeae68182b90dd25f165e08d1b39
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: canary
 category: bitcoin
 name: Canary
-version: "1.0.1"
+version: "1.1.0"
 tagline: Early warning system for Bitcoin cold storage
 description: >-
   A canary in the cold mine. When your bitcoins are in cold storage, you seldom check on them.
@@ -27,7 +27,7 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  Fixed API connectivity issue that prevented adding wallets when running on Umbrel.
+  Added support for custom ntfy server configuration, allowing you to use your own self-hosted ntfy instance for notifications.
 path: ""
 defaultUsername: ""
 defaultPassword: ""


### PR DESCRIPTION
## Summary
- Added support for custom ntfy server configuration, allowing users to use their own self-hosted ntfy instance for notifications
- Removed redundant bitcoin dependency (Canary communicates exclusively through Electrum via BDK; since electrs already declares bitcoin as its dependency, listing both is redundant)

## Test plan
- [x] Tested upgrade from v1.0.1 to v1.1.0 on local Umbrel
- [x] Verified ntfy custom server configuration works