### PR TITLE
Kokoro: Correct wrong link

### DIFF
--- a/kokoro/umbrel-app.yml
+++ b/kokoro/umbrel-app.yml
@@ -17,7 +17,7 @@ description: >-
 
   ⚙️ The API is available at "umbrel.local:8877", and the API documentation can be found at "umbrel.local:8877/docs".
 developer: Hexgrad
-website: https://kokorotts.net/
+website: https://huggingface.co/hexgrad/Kokoro-82M
 submitter: dennysubke
 submission: https://github.com/getumbrel/umbrel-apps/pull/2498
 repo: https://github.com/remsky/Kokoro-FastAPI


### PR DESCRIPTION
The linked website isn’t associated with the developer. I’ve updated the “official website” to the source referenced by the dev: https://huggingface.co/hexgrad/Kokoro-82M