### PR TITLE
Update BTC Tracker to v0.6.8 (quickfix)

### DIFF
--- a/btctracker/docker-compose.yml
+++ b/btctracker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: thewilqq/btc-tracker:v0.6.7@sha256:fd956384032e801665323befc3fd50ef00c7ebee92277074d3541c601ac4ab95
+    image: thewilqq/btc-tracker:v0.6.8@sha256:282ea7c343a3455b6c12c9fd283d192717b788ace5ed2e2331090ed6df1b8450
     restart: on-failure
     user: 1000:1000
     environment:

--- a/btctracker/umbrel-app.yml
+++ b/btctracker/umbrel-app.yml
@@ -3,7 +3,7 @@ id: btctracker
 name: BTC Tracker
 tagline: A simple, privacy-focused Bitcoin investment tracker
 category: bitcoin
-version: "0.6.7"
+version: "0.6.8"
 port: 3947
 description: >-
   BTC Tracker is a user-friendly yet powerful application designed for managing and analyzing Bitcoin investments. It was created to offer a privacy-focused and straightforward alternative to existing tracking tools, which are often cluttered with unnecessary features, complicated to set up, or designed for managing large, diversified portfolios. Many of those tools require connections to external services and the sharing of sensitive information such as wallet addresses or transaction histories.
@@ -37,46 +37,14 @@ releaseNotes: >-
   🚨 Breaking Change since version 0.6.0: all existing data will be deleted and the update is not backward compatible, so please export your transactions from the previous version before updating. After installation, register again and reimport your data.
   
   
-  🔐 Security
-  
-    - Two-Factor Authentication (2FA) - Secure your account with TOTP-based 2FA
-    - Works with Google Authenticator, Authy, and other authenticator apps
-    - 10 backup codes generated for account recovery
-    - Available in Profile and Settings panels
-    - Critical: Updated Next.js from 15.3.4 to 15.3.6 to fix CVE-2025-66478 (CVSS 10.0) - Remote Code Execution vulnerability
-    - Fixed npm audit vulnerabilities
-  
-  
-  ✨ New Features
-  
-    - External Transfer Tracking - Track BTC transfers in/out without affecting P&L
-    - Transfer In: Add BTC from gifts, mining rewards, payments received
-    - Transfer Out: Remove BTC for donations, payments sent, gifts given
-    - System Status Dialog - View all background services in Settings → Price Data
-    - Transaction markers on chart - Buy/sell dots with tooltips showing details
-    - BTC/Fiat Price switch - Calculate price from either BTC amount or fiat total
-  
-  
-  🚀 Improvements
-  
-    - Improved Migration System - Automatic handling of legacy databases and upgrade issues
-    - Improved CSV Import/Export - Better handling of whitespace, quotes, and edge cases
-    - 21bitcoin Parser - Support for 21bitcoin CSV export format
-    - Simplified Migration Output - Less verbose logs, use --verbose flag for details
-  
-  
   🐛 Bug Fixes
   
-    - Fixed P&L calculation in BitcoinChart for non-USD currencies
-    - Fixed avatar display in navigation bar and persistence across Docker restarts
-    - Fixed double migration execution in Docker
-    - Removed unused migrate.sh script
+    - Fixed Yahoo Finance price fetching - Upgraded yahoo-finance2 from v2.13.3 to v3.11.2 to fix rate limiting and API compatibility issues that prevented Bitcoin price updates
   
   
-  🎨 UI
+  🔧 Improvements
   
-    - Migrated more components to shadcn/ui design system
-    - Better avatar handling with automatic refresh 
+    - Updated Yahoo Finance service to use v3 class-based initialization 
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
# App Update

Updates BTC Tracker from v0.6.7 to v0.6.8

### What's new in v0.6.8: 

**Bug Fixes**

- Fixed Yahoo Finance price fetching 
- Upgraded yahoo-finance2 from v2.13.3 to v3.11.2 to fix rate limiting and API compatibility issues that prevented Bitcoin price updates

**Improvements**- Updated Yahoo Finance service to use v3 class-based initial