### PR TITLE
enable authenticated UI instead of Internal unauthenticated UI

### DIFF
--- a/frigate/docker-compose.yml
+++ b/frigate/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app_proxy:
     environment:
       APP_HOST: frigate_web_1
-      APP_PORT: 5000
+      APP_PORT: 8971
       PROXY_AUTH_ADD: "false"
   
   web:


### PR DESCRIPTION
From the Frigate documentation:
Port 5000: Internal unauthenticated UI and API access. Access to this port should be limited. Intended to be used within the docker network for services that integrate with Frigate.

Port 8971: Authenticated UI and API access without TLS. Reverse proxies should use this port. ______________________________________________________________ 
Frigate’s port 5000 is intended for internal, unauthenticated access only. Umbrel currently exposes this port to users, which unintentionally publishes an unauthenticated UI. This PR switches the exposed port to 8971, the officially documented authenticated interface. The change aligns Umbrel with Frigate’s security model and provides safer defaults. No functionality is removed; only the user-facing port is corrected.