### PR TITLE
Update downtify to 1.1.2

### DIFF
--- a/downtify/docker-compose.yml
+++ b/downtify/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8000
 
   downtify:
-    image: ghcr.io/henriquesebastiao/downtify:1.1.1@sha256:6799338c2369d18941d2e4b9cbc99c762a694e3bce5b769678a3f4edd0ba8b6c
+    image: ghcr.io/henriquesebastiao/downtify:1.1.2@sha256:d17b4b2155dbe0accee602f98e4707bdb739e3d825fe7e1dafe50a0946dc7576
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/downtify/umbrel-app.yml
+++ b/downtify/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: downtify
 category: media
 name: Downtify
-version: "1.1.1"
+version: "1.1.2"
 tagline: Download Spotify music with album art and metadata
 description: >-
   Downtify allows you to download music by copy-pasting the Spotify link for a song, album, etc. The songs are downloaded from YouTube, along with album art, lyrics, and other metadata about the songs.
@@ -20,7 +20,7 @@ repo: https://github.com/henriquesebastiao/downtify
 port: 8789
 releaseNotes: >-
   This release includes the following bug fixes:
-    - Fixes yt-dlp error that caused download errors
+    - Fixed error Your application has reached a rate/request limit in music download and search
 
 
   Full release notes can be found at https://github.com/henriquesebastiao/downtify/releases


### PR DESCRIPTION
This pull request updates Downtify to version 1.1.2.

This new version fixes a bug that prevented music downloads and searches due to excessive use of the CLIENT_ID and CLIENT_SCRET credentials by Downtify users; the credentials have been updated in this new version.