### PR TITLE
Update docker-compose.yml and added GPU capabilities for nvdia systems

### DIFF
--- a/ollama/docker-compose.yml
+++ b/ollama/docker-compose.yml
@@ -15,3 +15,12 @@ services:
     volumes:
       - ${APP_DATA_DIR}/data:/root/.ollama
     restart: on-failure
+    
+    # --- GPU Configuration Added Below ---
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all # Use 1 for a single GPU, or 'all' for everything available
+              capabilities: [gpu]


### PR DESCRIPTION
version: '3.9'

services:
  app_proxy:
    environment:
      APP_HOST: ollama_ollama_1
      APP_PORT: 11434
      PROXY_AUTH_ADD: "false"

  ollama:
    image: ollama/ollama:0.14.1@sha256:ab381bda4be8e04790e32551fac37f209fe0bb12ab49ba4b7c32d0f0800cf4c3
    environment:
      OLLAMA_ORIGINS: "*"
      OLLAMA_CONTEXT_LENGTH: 8192
    volumes:
      - ${APP_DATA_DIR}/data:/root/.ollama
    restart: on-failure
    
    # --- GPU Configuration Added Below ---
    deploy:
      resources:
        reservations:
          devices:
            - driver: nvidia
              count: all
              capabilities: [gpu]