### PR TITLE
Update papra to version 26.0.0

### DIFF
--- a/papra/docker-compose.yml
+++ b/papra/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     environment:
       APP_HOST: papra_server_1
       APP_PORT: 1221
-      PROXY_AUTH_ADD: "false"
+      PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
     image: ghcr.io/papra-hq/papra:26.0.0-rootless@sha256:e41d2237a59b072063e4059a85492cb11fe4aefb706851becbbce88c7c2ae072

--- a/papra/umbrel-app.yml
+++ b/papra/umbrel-app.yml
@@ -24,20 +24,16 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  - Added support for two factor authentication
-
-  - The documents page can now be used with advanced search queries
-
-  - Improved search speed by using document and organization ids in index
-
-  - Auto assign admin role to the first user registering
-
-  - Added a "Show more results" option in quick search when there is more document not displayed
-  
-  - Added about page and modal with version informations
+  This update comes with various new features and improvements:
+    - Added support for two factor authentication
+    - The documents page can now be used with advanced search queries
+    - Improved search speed by using document and organization ids in index
+    - Auto assign admin role to the first user registering
+    - Added a "Show more results" option in quick search when there is more document not displayed
+    - Added about page and modal with version informations
 
 
-  Full release notes are found at https://github.com/papra-hq/papra/releases/tag/%40papra%2Fdocker%4026.0.0
+  Full release notes are found at https://github.com/papra-hq/papra/releases
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
I have tested new version on Raspberry Pi 5

Added `PROXY_AUTH_ADD: "false"` because Papra has its own auth and Umbrel's auth cause problems, when I'm trying to open the app via Cloudflare Tunnel