### PR TITLE
Add pre-start hook to remove stale docker.pid file in portainer

### DIFF
--- a/portainer/hooks/pre-start
+++ b/portainer/hooks/pre-start
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DATA_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)/data"
+
+# Remove stale docker.pid file that can cause issues after power outages or crashes
+rm -f "${APP_DATA_DIR}/docker/docker.pid"

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -1,8 +1,8 @@
-manifestVersion: 1
+manifestVersion: 1.1
 id: portainer
 category: developer
 name: Portainer
-version: "2.33.6"
+version: "2.33.6-1"
 tagline: Run custom Docker containers on your Umbrel
 description: >-
   ⚠️ Make sure to only use named Docker volumes for your stacks and containers. Data in bind-mounted volumes
@@ -51,14 +51,7 @@ path: ""
 defaultUsername: "admin"
 defaultPassword: "changeme"
 releaseNotes: >-
-  This update includes several improvements and fixes:
-    - Fixed an issue where stacks could not pull private images during GitOps updates
-    - Fixed an issue where starting a stack failed when a private image had been removed
-    - Fixed an issue where duplicate or edited containers could have network issues due to persistent MAC addresses
-    - Fixed an issue where Docker Compose configs were not injected correctly into stack containers
-    - Fixed Docker Swarm Service view display issues
-    - Improved Volumes Browser to prevent adding unwanted file extensions when downloading files
-    - Resolved multiple security vulnerabilities
+  This update fixes an issue where the Docker daemon would not start after a power outage or crash.
 
 
   Full release notes are found at https://github.com/portainer/portainer/releases.


### PR DESCRIPTION
Tested on Umbrel dev instance, pending additional tests.