### PR TITLE
Bitcoin Knots: update bip 110 to v0.1

### DIFF
--- a/bitcoin-knots/docker-compose.yml
+++ b/bitcoin-knots/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
   
   app:
-    image: ghcr.io/retropex/umbrel-bitcoin-knots:1.2.4@sha256:2c16d47275a9772644b3a2f9695ab4996bc494b672e4c8df6261eb90f04f5b38
+    image: ghcr.io/retropex/umbrel-bitcoin-knots:1.2.5@sha256:d1f1bf49dfd526cdd3edad8336d2c6ff0201121738a1fb5eb2399656341fecd3
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 15m30s

--- a/bitcoin-knots/umbrel-app.yml
+++ b/bitcoin-knots/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - bitcoin
 category: bitcoin
 name: Bitcoin Knots
-version: "29.2-4"
+version: "29.2-5"
 tagline: Run your personal node powered by Bitcoin Knots
 description: >-
   Take control of your digital sovereignty by choosing Bitcoin Knots to run your node! By using Knots, you’re supporting a version of Bitcoin that prioritizes efficiency, security, and flexibility. With Bitcoin Knots’ enhanced configuration options, you can fine-tune your node to help keep the network clean and resilient, actively reducing unnecessary load from spam or parasitic transactions.
@@ -36,8 +36,7 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  Add BIP 110 in the version selector.
-  If you want to signal for activation of BIP 110, please select "BIP110" in the settings.
+  Update BIP 110 to v0.1
 widgets:
   - id: "stats"
     type: "four-stats"


### PR DESCRIPTION
Add a one-time pop-up to warn the user that BIP 110 signaling has started.

Warper:
https://github.com/Retropex/umbrel-bitcoin/commit/c7ab69e1c7c7a0a36d7bfadfaa928cdb1386e4c6
https://github.com/Retropex/umbrel-bitcoin/commit/c729ffbcb302566b5763320289e139c02d1fed8b

bitcoind:
https://github.com/Retropex/docker-bitcoind-prebuilt/commit/6980ce56639dcc824541051c68424bfbc606a9b7