### PR TITLE
datum: switch to new env variables

### DIFF
--- a/datum/hooks/pre-start
+++ b/datum/hooks/pre-start
@@ -10,7 +10,7 @@ if [ -f "${DATUM_CONFIG_FILE}" ]; then
   echo "Checking DATUM configuration file."
   
   # Check if Knots environment variables are set
-  if [ -z "${APP_BITCOIN_KNOTS_RPC_USER}" ] || [ -z "${APP_BITCOIN_KNOTS_RPC_PASS}" ] || [ -z "${APP_BITCOIN_KNOTS_NODE_IP}" ] || [ -z "${APP_BITCOIN_KNOTS_INTERNAL_RPC_PORT}" ]; then
+  if [ -z "${APP_BITCOIN_KNOTS_RPC_USER}" ] || [ -z "${APP_BITCOIN_KNOTS_RPC_PASS}" ] || [ -z "${APP_BITCOIN_KNOTS_NODE_IP}" ] || [ -z "${APP_BITCOIN_KNOTS_RPC_PORT}" ]; then
     echo "Missing Bitcoin Knots environment variables. Exiting."
     exit 1
   fi
@@ -20,7 +20,7 @@ if [ -f "${DATUM_CONFIG_FILE}" ]; then
   # Update the configuration
   jq --arg user "$APP_BITCOIN_KNOTS_RPC_USER" \
      --arg pass "$APP_BITCOIN_KNOTS_RPC_PASS" \
-     --arg url "${APP_BITCOIN_KNOTS_NODE_IP}:${APP_BITCOIN_KNOTS_INTERNAL_RPC_PORT}" \
+     --arg url "${APP_BITCOIN_KNOTS_NODE_IP}:${APP_BITCOIN_KNOTS_RPC_PORT}" \
      '.bitcoind.rpcuser = $user | 
       .bitcoind.rpcpassword = $pass | 
       .bitcoind.rpcurl = $url' \

--- a/datum/umbrel-app.yml
+++ b/datum/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: datum
 category: bitcoin
 name: DATUM
-version: "v0.4.1-beta"
+version: "v0.4.1-beta-rev2"
 tagline: Self-sovereign Bitcoin mining
 description: >-
   ⚙️ Please read the important setup instructions at the bottom of this page.
@@ -69,7 +69,7 @@ path: ""
 defaultUsername: "admin"
 deterministicPassword: true
 releaseNotes: >-
-  Full release notes can be found at https://github.com/OCEAN-xyz/datum_gateway/releases/tag/v0.4.1beta
+  Internal package cleanup.
 widgets:
   - id: "stats"
     type: "three-stats"


### PR DESCRIPTION
Just to avoid keeping [these variables](https://github.com/getumbrel/umbrel-apps/blob/a3a66cec8eff947041699dcf6558d3683a37c277/bitcoin-knots/exports.sh#L17C1-L19C50) around for nothing.
Once merged I will remove them in the next Bitcoin Knots update.