### PR TITLE
App Submission: Holesail Switchboard

### DIFF
--- a/holesail-switchboard/docker-compose.yml
+++ b/holesail-switchboard/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: holesail-switchboard_web_1
+      APP_PORT: 3160
+  web:
+    image: orenz0/holesail-switchboard:v2.0.8@sha256:87bee9070543a0ec929289fc1d6ebe37b899350b4844d35ff1f2b38e689868ad
+    restart: on-failure
+    stop_grace_period: 1m
+    ports:
+      - 3161:3161
+      - 3162:3162
+      - 3163:3163
+      - 3164:3164
+      - 3165:3165
+      - 3166:3166
+      - 3167:3167
+      - 3168:3168
+      - 3169:3169
+      - 3170:3170
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+    environment:
+      HSSB_DATA_FILE: /data/data.json
+      HSSB_HOST: 0.0.0.0
+      HSSB_PORT: 3160
+      HSSB_CLIENT_HOST: 0.0.0.0
+      HSSB_FIXED_CLIENT_PORTS: 3161-3170
+      HSSB_SUBTITLE: "For more information, visit: https://github.com/oren-z0/holesail-switchboard/blob/main/docs/Umbrel.md"

--- a/holesail-switchboard/docker-compose.yml
+++ b/holesail-switchboard/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
       APP_HOST: holesail-switchboard_web_1
       APP_PORT: 3160
+
   web:
     image: orenz0/holesail-switchboard:v2.0.8@sha256:87bee9070543a0ec929289fc1d6ebe37b899350b4844d35ff1f2b38e689868ad
     restart: on-failure

--- a/holesail-switchboard/umbrel-app.yml
+++ b/holesail-switchboard/umbrel-app.yml
@@ -13,23 +13,16 @@ description: >-
 
 
   Features:
-
-  - Create and manage multiple P2P servers and clients from a single dashboard
-
-  - QR code generation for easy sharing of server connection URLs
-
-  - Secure mode support for private connections
-
-  - Persistent configuration that survives restarts
+    - Create and manage multiple P2P servers and clients from a single dashboard
+    - QR code generation for easy sharing of server connection URLs
+    - Secure mode support for private connections
+    - Persistent configuration that survives restarts
 
 
   Use cases:
-
-  - Expose your Umbrel apps to the internet without port forwarding
-
-  - Share access to local services with friends and family
-
-  - Connect to remote services securely
+    - Expose your Umbrel apps to the internet without port forwarding
+    - Share access to local services with friends and family
+    - Connect to remote services securely
 releaseNotes: ""
 developer: oren-z0
 website: https://github.com/oren-z0/holesail-switchboard

--- a/holesail-switchboard/umbrel-app.yml
+++ b/holesail-switchboard/umbrel-app.yml
@@ -1,0 +1,45 @@
+manifestVersion: 1
+id: holesail-switchboard
+category: networking
+name: Holesail Switchboard
+version: "2.0.8"
+tagline: Manage multiple holesail P2P tunnels from a single dashboard
+description: >-
+  Running Umbrel behind a home router (NAT) without a public domain? Tor is too slow?
+
+
+  Holesail Switchboard provides a web interface to manage multiple holesail servers and clients,
+  allowing you to create instant P2P tunnels that bypass any network, firewall, or NAT restrictions.
+
+
+  Features:
+
+  - Create and manage multiple P2P servers and clients from a single dashboard
+
+  - QR code generation for easy sharing of server connection URLs
+
+  - Secure mode support for private connections
+
+  - Persistent configuration that survives restarts
+
+
+  Use cases:
+
+  - Expose your Umbrel apps to the internet without port forwarding
+
+  - Share access to local services with friends and family
+
+  - Connect to remote services securely
+releaseNotes: ""
+developer: oren-z0
+website: https://github.com/oren-z0/holesail-switchboard
+dependencies: []
+repo: https://github.com/oren-z0/holesail-switchboard
+support: https://github.com/oren-z0/holesail-switchboard/discussions
+port: 3160
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: oren-z0
+submission: https://github.com/getumbrel/umbrel-apps/pull/4648

--- a/holesail-switchboard/umbrel-app.yml
+++ b/holesail-switchboard/umbrel-app.yml
@@ -23,6 +23,8 @@ description: >-
     - Expose your Umbrel apps to the internet without port forwarding
     - Share access to local services with friends and family
     - Connect to remote services securely
+
+  For more information: https://github.com/oren-z0/holesail-switchboard/blob/main/docs/Umbrel.md
 releaseNotes: ""
 developer: oren-z0
 website: https://github.com/oren-z0/holesail-switchboard

--- a/holesail-switchboard/umbrel-app.yml
+++ b/holesail-switchboard/umbrel-app.yml
@@ -32,7 +32,12 @@ dependencies: []
 repo: https://github.com/oren-z0/holesail-switchboard
 support: https://github.com/oren-z0/holesail-switchboard/discussions
 port: 3160
-gallery: []
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+  - 4.jpg
+  - 5.jpg
 path: ""
 defaultUsername: ""
 defaultPassword: ""


### PR DESCRIPTION
# App Submission

### App name
Holesail Switchboard

### 256x256 SVG icon

Created with ChatGPT and some GIMP, I don't know how to turn this to an SVG:

<img width="256" height="256" alt="holesail-switchboard-logo" src="https://github.com/user-attachments/assets/54354193-b866-473b-b0f7-22b89632f083" />

### Gallery Images


<img width="1440" height="900" alt="127 0 0 1_5002_" src="https://github.com/user-attachments/assets/406b1aeb-b059-4264-9421-dbe5bf7df5b7" />
<img width="1440" height="900" alt="127 0 0 1_5002_ (4)" src="https://github.com/user-attachments/assets/cd43fb13-46bf-4fa2-be08-b23288ef8a24" />
<img width="1440" height="900" alt="127 0 0 1_5002_ (3)" src="https://github.com/user-attachments/assets/29550b6f-bea4-4b85-af06-194b5e7286e5" />
<img width="1440" height="900" alt="127 0 0 1_5002_ (2)" src="https://github.com/user-attachments/assets/ac8b95d5-263c-405e-8222-3f1a35a961dd" />
<img width="1440" height="900" alt="127 0 0 1_5002_ (1)" src="https://github.com/user-attachments/assets/06787ab0-d742-460e-b93e-59b85193d187" />

### I have tested my app on:
- [x] umbrelOS on a Raspberry Pi
- [ ] umbrelOS on an Umbrel Home
- [ ] umbrelOS on Linux VM

This app  uses ports 3161-3170 for its clients. For example when the user connects client 3161 to a remote Holesail Server "hs://0000...", he could access that server via `http://umbrel.local:3161`.