### PR TITLE
Update forgejo to version 11.0.10

### DIFF
--- a/forgejo/docker-compose.yml
+++ b/forgejo/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: codeberg.org/forgejo/forgejo:11.0.8-rootless@sha256:962eff77a6a4a0d4ccf573a63c856eb33457e27035b38ecfa0469ada7a42978d
+    image: codeberg.org/forgejo/forgejo:11.0.10-rootless@sha256:d0247afd85fde057d4d3233fd13ba840b7a2bc569c93db8a5e6d4ef5b946a36e
     user: "1000:1000"
     restart: on-failure
     ports:

--- a/forgejo/umbrel-app.yml
+++ b/forgejo/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: forgejo
 category: developer
 name: Forgejo
-version: "11.0.8"
+version: "11.0.10"
 tagline: A self-hosted lightweight software forge
 description: >-
   Forgejo is a self-hosted lightweight software forge, designed to be a fully self-hosted, privacy-respecting alternative to GitHub, GitLab, and Bitbucket. It is a fork of Gitea with additional features and community-driven enhancements. Forgejo is written in Go and can run on low-resource hardware like a Raspberry Pi. 
@@ -49,12 +49,8 @@ gallery:
   - 3.jpg
 releaseNotes: >-
   🚨 This release includes important security fixes:
-    - Fixed dependency repository permission checks in API operations
-    - Prevented draft releases from being read before publication
-    - Fixed misconfigured security checks on tag delete operations
-    - Corrected enforcement of head branch protection rules during pull request updates
-    - Fixed issue where issue owners could delete other users' comment edit history
-    - Prevented bypassing of tag protection rules during tag deletion
+    - Fixed excess creation of commit_status records
+    - Upgraded Go version to 1.25.6, addressing denial of service vulnerabilities
 
 
   Full release notes are available at https://forgejo.org/releases/


### PR DESCRIPTION
Update to the latest LTS version 11.0.10, which includes minor security updates and fixes.

I have manually tested on my end by updating the image on my instance. Everything seems to work just fine.

[Release notes](https://codeberg.org/forgejo/forgejo/src/branch/forgejo/release-notes-published/11.0.10.md)