### PR TITLE
Update cloudflared to 2026.1.2

### DIFF
--- a/cloudflared/docker-compose.yml
+++ b/cloudflared/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       CLOUDFLARED_TOKEN_FILE: "/app/data/token"
 
   connector:
-    image: ghcr.io/radiokot/umbrel-cloudflared-connector:1.0.1-cf.2025.10.0@sha256:036b1d4d0f9d654a4e235e8d25f41887827f7f4d7988ed263c6c37451eee5a96
+    image: ghcr.io/radiokot/umbrel-cloudflared-connector:1.0.1-cf.2026.1.2@sha256:ea7fa000e30bf610cc09a4ba173c3d0f93811d5d87b6f740ed5eab517d858b60
     hostname: cloudflared-connector
     restart: on-failure
     stop_grace_period: 3s

--- a/cloudflared/umbrel-app.yml
+++ b/cloudflared/umbrel-app.yml
@@ -3,7 +3,7 @@ id: cloudflared
 name: Cloudflare Tunnel
 tagline: Access your Umbrel apps from the Internet using Cloudflare network
 category: networking
-version: "2025.10.0"
+version: "2026.1.2"
 port: 4499
 description: >-
   Start a secure tunnel to access your Umbrel apps from the Internet using the Cloudflare network. 
@@ -34,12 +34,7 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  This release contains various improvements and bug fixes.
-
-
-  Key Highlights:
-    - The tunneling daemon (cloudflared) has been updated to 2025.10.0
-    - Fixed slow tunnel restart when changing an already configured token
+  The tunneling daemon (cloudflared) has been updated to 2026.1.2
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
The tunneling daemon (cloudflared) has been updated to 2026.1.2