### PR TITLE
Update Bitaxe Sentry to version 0.6.1

### DIFF
--- a/bitaxe-sentry/docker-compose.yml
+++ b/bitaxe-sentry/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       APP_PORT: 7070
 
   sentry:
-    image: zachprice105/bitaxe-sentry:v0.6.0@sha256:f1908c24783f604f98b615c14d2790d00d3098b59d316aafd687abdff3774897
+    image: zachprice105/bitaxe-sentry:v0.6.1@sha256:2326e3ea1f7e054da41768a4648277cd523d19a235490a2c0ae364315abbc8ee
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -16,7 +16,7 @@ services:
       DB_DATA_DIR: "/var/lib/bitaxe"
 
   web:
-    image: zachprice105/bitaxe-sentry:v0.6.0@sha256:f1908c24783f604f98b615c14d2790d00d3098b59d316aafd687abdff3774897
+    image: zachprice105/bitaxe-sentry:v0.6.1@sha256:2326e3ea1f7e054da41768a4648277cd523d19a235490a2c0ae364315abbc8ee
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/bitaxe-sentry/umbrel-app.yml
+++ b/bitaxe-sentry/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bitaxe-sentry
 category: bitcoin
 name: Bitaxe Sentry
-version: "0.6.0"
+version: "0.6.1"
 tagline: Bitaxe stats and alerts, all in one
 description: >-
   Bitaxe Sentry is a monitoring and management solution for Bitaxe ASIC miners.
@@ -14,11 +14,8 @@ description: >-
     - 🌡️ Temperature and hashrate monitoring
     - 🚨 Discord notifications for critical events
 releaseNotes: >-
-  This release includes multiple feature improvements:
-    - Added error rate tracking and visualization for Bitaxe miners
-    - Display timestamps in user's local timezone instead of UTC
-    - Allow muting individual miner notifications for a time duration
-    - Added Alembic database migration system for future schema changes
+  This release includes a minor bug fix:
+    - Changed mh/s to gh/s to reflect the correct unit of hashrate
 developer: Zach Price
 website: https://github.com/zachchan105/bitaxe-sentry
 repo: https://github.com/zachchan105/bitaxe-sentry


### PR DESCRIPTION
This release includes a minor bug fix:
- Changed mh/s to gh/s to reflect the correct unit of hashrate

Tested on Umbrel within a VM