### PR TITLE
lightning-terminal: update to `v0.16.1-alpha`

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.16.0-alpha@sha256:8ea51a5361c7d34376dcf4630746b953529af39a56306a94b1871aee4fa81b70
+    image: lightninglabs/lightning-terminal:v0.16.1-alpha@sha256:7f8e16d940ee350ff38b2d8e71bda0c512a89822fa62a60097ac7ecc71d660ae
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.16.0-alpha"
+version: "0.16.1-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -59,8 +59,8 @@ releaseNotes: >-
   ⚠️ Please update your Lightning Node app to the latest version available in the app store to ensure compatibility with Lightning Terminal.
 
 
-  This version of Lightning Terminal (LiT) ships lnd v0.20.0-beta, loop v0.31.6-beta, faraday v0.2.16-alpha,
-  pool v0.6.6-beta and tapd v0.7.0.
+  This version of Lightning Terminal (LiT) ships lnd v0.20.1-beta, loop v0.31.8-beta, faraday v0.2.16-alpha,
+  pool v0.6.6-beta and tapd v0.7.1.
 
 
   IMPORTANT NOTE: To avoid loss of funds, it's imperative that you read the
@@ -98,7 +98,7 @@ releaseNotes: >-
   feedback from the community.
 
 
-  This release packages LND v0.20.0-beta, Taproot Assets Daemon v0.7.0,
-  Loop v0.31.6-beta, Pool v0.6.6-beta and Faraday v0.2.16-alpha.
+  This release packages LND v0.20.1-beta, Taproot Assets Daemon v0.7.1,
+  Loop v0.31.8-beta, Pool v0.6.6-beta and Faraday v0.2.16-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
In this PR we bump Litd to `v0.16.1-alpha`.

See the release notes here: https://github.com/lightninglabs/lightning-terminal/blob/master/docs/release-notes/release-notes-0.16.1.md