### PR TITLE
Update downtify to version 1.1.4

### DIFF
--- a/downtify/docker-compose.yml
+++ b/downtify/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8000
 
   downtify:
-    image: ghcr.io/henriquesebastiao/downtify:1.1.3@sha256:a0e9e12cd4bc614c97f12873a7e8fbe722d4b5e706111b6aa2c98ec667fb16b4
+    image: ghcr.io/henriquesebastiao/downtify:1.1.4@sha256:6d5035afa5d1c1b8013b59f19b90727b38c2715251f0e99db282b3875c5b821a
     stop_grace_period: 1m
     volumes:
       - ${UMBREL_ROOT}/data/storage/downloads/downtify:/downloads

--- a/downtify/umbrel-app.yml
+++ b/downtify/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: downtify
 category: media
 name: Downtify
-version: "1.1.3"
+version: "1.1.4"
 tagline: Download Spotify music with album art and metadata
 description: >-
   Downtify allows you to download music by copy-pasting the Spotify link for a song, album, etc. The songs are downloaded from YouTube, along with album art, lyrics, and other metadata about the songs.
@@ -20,11 +20,7 @@ repo: https://github.com/henriquesebastiao/downtify
 port: 8789
 releaseNotes: >-
   This release includes the following bug fixes:
-    - Fixed download errors that were preventing content from being saved
-    - Resolved Spotify API errors that caused 500 status code failures
-    - Fixed issues when searching for albums
-    - Addressed rate limit errors to improve application stability
-    - Resolved client authentication problems
+    - Resolved authentication issues with the Spotify API
 
 
   Full release notes can be found at https://github.com/henriquesebastiao/downtify/releases


### PR DESCRIPTION
This version of Downtify fixes issues related to the Spotify API request limit that prevented searching for and downloading music.