### PR TITLE
Update OpenClaw to v2026.2.26

### DIFF
--- a/openclaw/docker-compose.yml
+++ b/openclaw/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_PORT: 18789
 
   gateway:
-    image: ghcr.io/getumbrel/openclaw-umbrel:2026.2.19@sha256:ab0c2684f9a1db84d82277d465e6ff9c090225d690470b0c1f8c424405f5e7e0
+    image: ghcr.io/getumbrel/openclaw-umbrel:2026.2.26@sha256:27215a8f6c547e32cd2968d32493a672171ed53145b9036b9bec4683f8adf020
     user: "1000:1000"
     init: true
     restart: on-failure

--- a/openclaw/umbrel-app.yml
+++ b/openclaw/umbrel-app.yml
@@ -3,7 +3,7 @@ id: openclaw
 name: OpenClaw
 tagline: The AI that actually does things
 category: ai
-version: "2026.2.19"
+version: "2026.2.26"
 port: 18789
 path: ""
 description: >-
@@ -39,19 +39,16 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  This release brings Apple Watch support, major security hardening, and numerous reliability improvements:
-    - Apple Watch companion app with inbox UI and notification relay
-    - iOS background wake via push notifications to reduce invoke failures when the app is backgrounded
-    - Paired device management with commands to remove or clear paired devices
-    - Telegram channel posts now share the same pipeline as regular messages for consistent behavior
-    - Cron and heartbeat delivery now correctly targets configured Telegram topics
-    - Gateway auth now defaults to token mode with auto-generated tokens on startup
-    - Security fixes for SSRF, prototype pollution, privilege escalation, path traversal, and command injection across multiple components
-    - Browser URL navigation now routed through SSRF-guarded validation
-    - Rate limiting added to control-plane write operations
-    - Webhook ingress hardened for Feishu and Zalo with token checks and replay protection
+  What's new on umbrelOS:
+    - Redesigned onboarding with a streamlined setup flow
+    - Improved reliability with graceful shutdown handling and better recovery from configuration issues
 
 
-  Full release notes can be found at https://github.com/openclaw/openclaw/releases
+  What's new in OpenClaw (v2026.2.20 → v2026.2.26):
+    - External secrets management
+    - Android device support
+    - Multilingual stop phrases
+    - Security hardening
+    - And much more. Full details at https://github.com/openclaw/openclaw/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/4649


### PR DESCRIPTION
What's new on umbrelOS:
  - Redesigned onboarding with a streamlined CLI setup flow
  - Improved reliability with graceful shutdown handling and better recovery from configuration issues

What's new in OpenClaw (v2026.2.20 → v2026.2.26):
  - External secrets management
  - Android device support
  - Multilingual stop phrases
  - Security hardening
  - And much more. Full details at https://github.com/openclaw/openclaw/releases
  
<img width="838" height="482" alt="image" src="https://github.com/user-attachments/assets/107bd993-7622-473e-bd64-a8115fbd6034" />

<img width="838" height="482" alt="image" src="https://github.com/user-attachments/assets/e337ff9f-1eda-49cf-811d-477ff8d2ca21" />

<img width="837" height="386" alt="image" src="https://github.com/user-attachments/assets/f8fc7061-18ff-4a59-8aca-f6e7e8f6e139" />

