### PR TITLE
Update seerr to version 3.2.0

### DIFF
--- a/jellyseerr/docker-compose.yml
+++ b/jellyseerr/docker-compose.yml
@@ -8,7 +8,15 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: fallenbagel/jellyseerr:2.7.3@sha256:4538137bc5af902dece165f2bf73776d9cf4eafb6dd714670724af8f3eb77764
+    image: ghcr.io/seerr-team/seerr:3.1.0@sha256:b35ba0461c4a1033d117ac1e5968fd4cbe777899e4cbfbdeaf3d10a42a0eb7e9
+    user: "1000:1000"
+    init: true
     volumes:
       - ${APP_DATA_DIR}/data/config:/app/config
     restart: on-failure
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/status || exit 1
+      start_period: 20s
+      timeout: 3s
+      interval: 15s
+      retries: 3

--- a/jellyseerr/docker-compose.yml
+++ b/jellyseerr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: ghcr.io/seerr-team/seerr:3.1.0@sha256:b35ba0461c4a1033d117ac1e5968fd4cbe777899e4cbfbdeaf3d10a42a0eb7e9
+    image: ghcr.io/seerr-team/seerr:v3.2.0@sha256:c4cbd5121236ac2f70a843a0b920b68a27976be57917555f1c45b08a1e6b2aad
     user: "1000:1000"
     init: true
     volumes:

--- a/jellyseerr/hooks/pre-start
+++ b/jellyseerr/hooks/pre-start
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# v3.0.0 allowed the seerr container to run as non-root: https://github.com/seerr-team/seerr/releases/tag/v3.0.0
+# Jellyseerr / Seerr previously ran as root, so we now recursively set the owner of the data directory to 1000:1000 so that pre-3.0.0 users do not have a broken app
+APP_DATA_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)/data"
+
+# Recursively set ownership of all files and directories under APP_DATA_DIR to 1000:1000
+chown -R 1000:1000 "${APP_DATA_DIR}"

--- a/jellyseerr/umbrel-app.yml
+++ b/jellyseerr/umbrel-app.yml
@@ -1,24 +1,39 @@
-manifestVersion: 1
+manifestVersion: 1.1
 id: jellyseerr
 category: media
-name: Jellyseerr
-version: "2.7.3"
+name: Seerr
+version: "3.1.0"
 tagline: Beautiful media discovery for Jellyfin users
 description: >-
-  Jellyseerr is a request management and media discovery tool built to work with your existing Jellyfin ecosystem.
+  Seerr is a free and open source software application for managing requests for your media library.
 
-  Jellyseerr scans your Jellyfin libraries at regular intervals, so it knows which items are already available on your server.
-  It also integrates with the popular DVR applications Radarr and Sonarr, and supports activity monitoring within Jellyseerr itself.
+
+  It integrates with the media server of your choice: Jellyfin, Plex, and Emby. In addition, it integrates with your existing services, such as Sonarr, Radarr.
+
+
+  Seerr scans your libraries at regular intervals, so it knows which items are already available on your server.
+
+  It also integrates with the popular DVR applications Radarr and Sonarr, and supports activity monitoring within Seerr itself.
+
 
   🛠️ SET-UP INSTRUCTIONS
 
-  During initial set-up, you will need to input your Umbrel device's IP address to connect to Jellyfin (and optional services such as Radarr and Sonarr).
-  You can find your device's IP address by visiting your router's admin dashboard or by using an IP scanning tool like Angry IP Scanner.
-developer: Fallenbagel
-website: https://github.com/Fallenbagel/jellyseerr
+
+  During initial set-up, you will need to input your Umbrel device's IP address to connect to Jellyfin / Plex / Emby (and optional services such as Radarr and Sonarr).
+
+  You can find your device's IP address in the Umbrel Settings.
+
+
+  You can also use the following addresses:
+    - **Jellyfin:** jellyfin_server_1:8096
+    - **Emby:** emby_server_1:8086
+    - **Radarr:** radarr_server_1:7878
+    - **Sonarr:** sonarr_server_1:8989
+developer: Seerr Team
+website: https://docs.seerr.dev/
 dependencies: []
-repo: https://github.com/Fallenbagel/jellyseerr
-support: https://github.com/Fallenbagel/jellyseerr/issues
+repo: https://github.com/seerr-team/seerr
+support: https://github.com/seerr-team/seerr/issues
 port: 5056
 gallery:
   - 1.jpg
@@ -28,16 +43,17 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Key highlights in this release:
+  This release introduces **Seerr**, the new unified project that merges the Jellyseerr and Overseerr teams and codebases into a single platform for managing media discovery and requests.
 
-    - Fixed an issue with API documentation for user settings
-    - Improved handling of username fields in UserSettings API schema
-    - Updated Plex Watchlist URL
-    - Enhanced blacklist keyword handling
-    - Improved media availability notifications
-    - Fixed issues with deleting media files and applying proxy settings
 
-  Full release notes are available at https://github.com/fallenbagel/jellyseerr/releases
+  Key highlights and improvements:
+    - Jellyseerr and Overseerr projects merged into a single unified platform called Seerr
+    - One shared codebase and team moving forward for faster development and maintenance
+    - Continued support for Plex, Jellyfin, and Emby media server ecosystems
+    - Rebranding and infrastructure updates as part of the new project foundation
+
+
+  Full release notes are available at https://github.com/seerr-team/seerr/releases
 torOnly: false
 submitter: johnpc
 submission: "https://github.com/getumbrel/umbrel-apps/pull/924"

--- a/jellyseerr/umbrel-app.yml
+++ b/jellyseerr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: jellyseerr
 category: media
 name: Seerr
-version: "3.1.0"
+version: "3.2.0"
 tagline: Beautiful media discovery for Jellyfin users
 description: >-
   Seerr is a free and open source software application for managing requests for your media library.
@@ -29,6 +29,7 @@ description: >-
     - **Emby:** emby_server_1:8086
     - **Radarr:** radarr_server_1:7878
     - **Sonarr:** sonarr_server_1:8989
+    - **Plex:** No address needed
 developer: Seerr Team
 website: https://docs.seerr.dev/
 dependencies: []
@@ -51,6 +52,7 @@ releaseNotes: >-
     - One shared codebase and team moving forward for faster development and maintenance
     - Continued support for Plex, Jellyfin, and Emby media server ecosystems
     - Rebranding and infrastructure updates as part of the new project foundation
+    - Various improvements and bug fixes
 
 
   Full release notes are available at https://github.com/seerr-team/seerr/releases


### PR DESCRIPTION
This update transforms jellyseerr into seerr and updates it to the latest version.

Tested a fresh install and update from jellyseer version 2.7.3.