### PR TITLE
Update Bitcoin Knots to v1.2.9

### DIFF
--- a/bitcoin-knots/docker-compose.yml
+++ b/bitcoin-knots/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
   
   app:
-    image: ghcr.io/retropex/umbrel-bitcoin-knots:1.2.8@sha256:ae9e27f619347b04fe11f1eb7d7e09dfc3bff525eeb1f9e54a4f02b6b3b9e32d
+    image: ghcr.io/retropex/umbrel-bitcoin-knots:1.2.9@sha256:70b79b4395af9bbe5e8463a5cc7b56e2add299d6f5813ac93b1a54f5952ccab9
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 15m30s

--- a/bitcoin-knots/umbrel-app.yml
+++ b/bitcoin-knots/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - bitcoin
 category: bitcoin
 name: Bitcoin Knots
-version: "1.2.8"
+version: "1.2.9"
 tagline: Run your personal node powered by Bitcoin Knots
 description: >-
   Take control of your digital sovereignty by choosing Bitcoin Knots to run your node! By using Knots, you’re supporting a version of Bitcoin that prioritizes efficiency, security, and flexibility. With Bitcoin Knots’ enhanced configuration options, you can fine-tune your node to help keep the network clean and resilient, actively reducing unnecessary load from spam or parasitic transactions.
@@ -36,7 +36,8 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  Update Knots to v29.3.knots20260210 and BIP 110 to v29.3.knots20260210-bip110-v0.3
+  Update BIP 110 to v29.3.knots20260210-bip110-v0.4.1
+
   People who have selected BIP110 in the settings will automatically be on the latest version, no need to select BIP110 again.
 widgets:
   - id: "stats"


### PR DESCRIPTION
Relevant diff and commits:

https://github.com/Retropex/umbrel-bitcoin/compare/v1.2.9..v1.2.8
https://github.com/Retropex/docker-bitcoind-prebuilt/commit/87462edb125a6c877e61eea8b4605a4c78203bbf