### PR TITLE
Update linter action to 1.8.0 SHA

### DIFF
--- a/.github/workflows/lint-apps.yml
+++ b/.github/workflows/lint-apps.yml
@@ -10,4 +10,4 @@ jobs:
     name: Lint apps
     runs-on: ubuntu-latest
     steps:
-      - uses: sharknoon/umbrel-app-linter-action@28d2ca16e3899585a245f1a580cc2361035e23d5
+      - uses: sharknoon/umbrel-app-linter-action@d0b39f9ec5867fd001b05d5ddd6037dcc35f41bd


### PR DESCRIPTION
Updates the linter action to version 1.8.0 which uses node 24 for continued support.

Closes #5079 