### PR TITLE
Update Core Lightning - fix CLNRest host binding and add provider contract exports

### DIFF
--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     image: ghcr.io/elementsproject/cln-application:25.07.3@sha256:af22cebd21e1175651049d09cf2dd547da569fddd55e4c7766e5956bd47e91fa
     command: npm run start
     restart: on-failure
+    depends_on:
+      - lightningd
     volumes:
       - ${APP_DATA_DIR}/data/app:${APP_CONFIG_DIR}
       - ${APP_CORE_LIGHTNING_DATA_DIR}:${CORE_LIGHTNING_PATH}
@@ -23,7 +25,7 @@ services:
       APP_MODE: ${APP_MODE}
       LIGHTNING_DATA_DIR: ${CORE_LIGHTNING_PATH}
       APP_CONFIG_FILE: ${APP_CONFIG_DIR}/config.json
-      LIGHTNING_VARS_FILE: ${COMMANDO_CONFIG}
+      LIGHTNING_VARS_FILE: ${CLNREST_RUNE_PATH}
       LIGHTNING_WS_PROTOCOL: ws
       LIGHTNING_WS_PORT: ${APP_CORE_LIGHTNING_WEBSOCKET_PORT}
       LIGHTNING_WS_CLIENT_KEY_FILE: ${CORE_LIGHTNING_PATH}/${APP_CORE_LIGHTNING_BITCOIN_NETWORK}/client-key.pem
@@ -32,7 +34,7 @@ services:
       LIGHTNING_REST_PROTOCOL: https
       LIGHTNING_REST_HOST: ${DEVICE_DOMAIN_NAME}
       LIGHTNING_REST_TOR_HOST: ${APP_CORE_LIGHTNING_HIDDEN_SERVICE}
-      LIGHTNING_REST_PORT: ${CORE_LIGHTNING_REST_PORT}
+      LIGHTNING_REST_PORT: ${CLNREST_PORT}
       LIGHTNING_REST_CLIENT_KEY_FILE: ${CORE_LIGHTNING_PATH}/${APP_CORE_LIGHTNING_BITCOIN_NETWORK}/client-key.pem
       LIGHTNING_REST_CLIENT_CERT_FILE: ${CORE_LIGHTNING_PATH}/${APP_CORE_LIGHTNING_BITCOIN_NETWORK}/client.pem
       LIGHTNING_REST_CA_CERT_FILE: ${CORE_LIGHTNING_PATH}/${APP_CORE_LIGHTNING_BITCOIN_NETWORK}/ca.pem
@@ -49,10 +51,12 @@ services:
   lightningd:
     image: elementsproject/lightningd:v25.09.3@sha256:ca95610b7db23a8fad5cf6e36044ecd4ff9124dcc7dae50bd151084d39feaf70
     restart: on-failure
+    depends_on:
+      - tor
     ports:
       - ${APP_CORE_LIGHTNING_DAEMON_PORT}:9735
       - ${APP_CORE_LIGHTNING_WEBSOCKET_PORT}:${APP_CORE_LIGHTNING_WEBSOCKET_PORT}
-      - ${CORE_LIGHTNING_REST_PORT}:${CORE_LIGHTNING_REST_PORT}
+      - ${CLNREST_PORT}:${CLNREST_PORT}
       - ${APP_CORE_LIGHTNING_DAEMON_GRPC_PORT}:${APP_CORE_LIGHTNING_DAEMON_GRPC_PORT}
     environment:
       LIGHTNINGD_NETWORK: ${APP_CORE_LIGHTNING_BITCOIN_NETWORK}
@@ -71,8 +75,9 @@ services:
       - --database-upgrade=true
       - --grpc-host=${APP_CORE_LIGHTNING_DAEMON_IP}
       - --grpc-port=${APP_CORE_LIGHTNING_DAEMON_GRPC_PORT}
-      - --clnrest-host=${APP_CORE_LIGHTNING_DAEMON_IP}
-      - --clnrest-port=${CORE_LIGHTNING_REST_PORT}
+      - --clnrest-host=${CLNREST_HOST}
+      - --clnrest-port=${CLNREST_PORT}
+
     volumes:
       - "${APP_CORE_LIGHTNING_DATA_DIR}:${CORE_LIGHTNING_PATH}"
     networks:

--- a/core-lightning/exports.sh
+++ b/core-lightning/exports.sh
@@ -1,21 +1,103 @@
+# shellcheck shell=bash
+# =============================================================================
+# Core Lightning Provider Contract (exports.sh)
+# =============================================================================
+# CLN is the canonical provider in the Umbrel dependency graph.
+# All interface endpoints — JSON-RPC, CLNRest, gRPC, WebSocket — are exported
+# here. Consumers bind to these; they never reconstruct URLs or hardcode paths.
+# =============================================================================
+
+# --- Identity & Network Topology ---
 export APP_CORE_LIGHTNING_IP="10.21.21.94"
 export APP_CORE_LIGHTNING_PORT="2103"
 export APP_CORE_LIGHTNING_DAEMON_IP="10.21.21.96"
+# APP_CORE_LIGHTNING_DAEMON_PORT: host-published P2P port (mapped to 9735 inside container).
+# Use APP_CORE_LIGHTNING_P2P_PORT for intra-container peer connections.
 export APP_CORE_LIGHTNING_DAEMON_PORT="9736"
-export APP_CORE_LIGHTNING_DAEMON_GRPC_PORT="2110"
+export APP_CORE_LIGHTNING_P2P_PORT="9735"
 export APP_CORE_LIGHTNING_WEBSOCKET_PORT="2106"
+export APP_CORE_LIGHTNING_DAEMON_GRPC_PORT="2110"
 export APP_CORE_LIGHTNING_DATA_DIR="${EXPORTS_APP_DIR}/data/lightningd"
-export CORE_LIGHTNING_REST_PORT="2107"
 
+# --- Bitcoin Network ---
 export APP_CORE_LIGHTNING_BITCOIN_NETWORK="${APP_BITCOIN_NETWORK}"
 if [[ "${APP_BITCOIN_NETWORK}" == "mainnet" ]]; then
 	export APP_CORE_LIGHTNING_BITCOIN_NETWORK="bitcoin"
 fi
 
+# --- Tor Hidden Service ---
 lightning_hidden_service_file="${EXPORTS_TOR_DATA_DIR}/app-${EXPORTS_APP_ID}-rest/hostname"
+# shellcheck disable=SC2155
 export APP_CORE_LIGHTNING_HIDDEN_SERVICE="$(cat "${lightning_hidden_service_file}" 2>/dev/null || echo "notyetset.onion")"
 
+# --- Container-internal paths ---
+export CORE_LIGHTNING_PATH="/root/.lightning"
 export APP_CONFIG_DIR="/data/app"
 export APP_MODE="production"
-export CORE_LIGHTNING_PATH="/root/.lightning"
-export COMMANDO_CONFIG="/root/.lightning/.commando-env"
+
+# =============================================================================
+# TLS Certificate Paths (host-side, all interfaces share the same keypair)
+# These are the canonical APP_CORE_LIGHTNING_* names for cert assets.
+# Consumers mounting ${APP_CORE_LIGHTNING_DATA_DIR} as a volume can access
+# the same files under their own mount path; these vars are for host-path use.
+# =============================================================================
+export APP_CORE_LIGHTNING_CA_CERT="${EXPORTS_APP_DIR}/data/lightningd/${APP_CORE_LIGHTNING_BITCOIN_NETWORK}/ca.pem"
+export APP_CORE_LIGHTNING_SERVER_CERT="${EXPORTS_APP_DIR}/data/lightningd/${APP_CORE_LIGHTNING_BITCOIN_NETWORK}/server.pem"
+export APP_CORE_LIGHTNING_CLIENT_CERT="${EXPORTS_APP_DIR}/data/lightningd/${APP_CORE_LIGHTNING_BITCOIN_NETWORK}/client.pem"
+export APP_CORE_LIGHTNING_CLIENT_KEY="${EXPORTS_APP_DIR}/data/lightningd/${APP_CORE_LIGHTNING_BITCOIN_NETWORK}/client-key.pem"
+
+# =============================================================================
+# CLNRest Interface (native plugin, v23.08+)
+# Replaces the deprecated c-lightning-REST Node.js plugin.
+# CLNREST_HOST is the bind address for lightningd's --clnrest-host flag.
+# CLNREST_URL is the consumer-facing endpoint (routable from other containers).
+# Consumers: RTL, cln-application
+# =============================================================================
+export CLNREST_HOST="0.0.0.0"
+export CLNREST_PORT="2107"
+export CLNREST_URL="https://${APP_CORE_LIGHTNING_DAEMON_IP}:${CLNREST_PORT}"
+# CLNREST_SERVER_CERT: path to lightningd's own TLS certificate (server.pem).
+# Use CLNREST_CA (ca.pem) to verify the server — not this cert directly.
+export CLNREST_SERVER_CERT="${APP_CORE_LIGHTNING_SERVER_CERT}"
+export CLNREST_CA="${APP_CORE_LIGHTNING_CA_CERT}"
+# mTLS client keypair — for consumers that authenticate as a client to CLNRest.
+export CLNREST_CLIENT_CERT="${APP_CORE_LIGHTNING_CLIENT_CERT}"
+export CLNREST_CLIENT_KEY="${APP_CORE_LIGHTNING_CLIENT_KEY}"
+export CLNREST_RUNE_PATH="${CORE_LIGHTNING_PATH}/.commando-env"
+# Deprecated alias for CLNREST_SERVER_CERT — kept for backward compatibility.
+export CLNREST_CERT="${CLNREST_SERVER_CERT}"
+
+# =============================================================================
+# URL Helpers
+# Pre-built endpoint URLs so consumers never reconstruct them from parts.
+# =============================================================================
+export APP_CORE_LIGHTNING_WEBSOCKET_URL="ws://${APP_CORE_LIGHTNING_DAEMON_IP}:${APP_CORE_LIGHTNING_WEBSOCKET_PORT}"
+# gRPC address format: host:port (used by grpc libs, not a full URL scheme)
+export APP_CORE_LIGHTNING_GRPC_URL="${APP_CORE_LIGHTNING_DAEMON_IP}:${APP_CORE_LIGHTNING_DAEMON_GRPC_PORT}"
+
+# Backward-compat aliases — kept so existing app configs that reference these names continue to work.
+export CORE_LIGHTNING_REST_PORT="${CLNREST_PORT}"
+export COMMANDO_CONFIG="${CLNREST_RUNE_PATH}"
+
+# =============================================================================
+# gRPC Interface
+# Consumers: Boltz, cln-application
+# Use APP_CORE_LIGHTNING_GRPC_URL for the full address string.
+# =============================================================================
+export APP_CORE_LIGHTNING_GRPC_HOST="${APP_CORE_LIGHTNING_DAEMON_IP}"
+export APP_CORE_LIGHTNING_GRPC_PORT="${APP_CORE_LIGHTNING_DAEMON_GRPC_PORT}"
+
+# =============================================================================
+# JSON-RPC Interface (unix domain socket)
+# Consumers: LNbits JSON-RPC fallback (CoreLightningWallet via pyln-client)
+# =============================================================================
+export APP_CORE_LIGHTNING_RPC_SOCKET="${EXPORTS_APP_DIR}/data/lightningd/${APP_CORE_LIGHTNING_BITCOIN_NETWORK}/lightning-rpc"
+
+# =============================================================================
+# Block Explorer (local Mempool for privacy)
+# =============================================================================
+BLOCK_EXPLORER_URL="http://umbrel.local:3006"
+if [[ "${APP_BITCOIN_NETWORK}" != "mainnet" ]]; then
+	BLOCK_EXPLORER_URL="${BLOCK_EXPLORER_URL}/${APP_BITCOIN_NETWORK}"
+fi
+export APP_CORE_LIGHTNING_BLOCK_EXPLORER_URL="${BLOCK_EXPLORER_URL}"


### PR DESCRIPTION
CLNRest was bound to the container-internal daemon IP, making it unreachable from other containers (RTL, LNbits). This change:

- Adds `CLNREST_HOST=0.0.0.0` to exports.sh so consumers can reference the bind address without hardcoding it
- Passes `--clnrest-host=${CLNREST_HOST}` to lightningd (was daemon IP, now 0.0.0.0 so CLNRest listens on all interfaces)
- Exports `CLNREST_URL`, `CLNREST_RUNE_PATH`, `CLNREST_PORT`, and TLS cert paths as the provider contract for CLNRest consumers (RTL, cln-application)
- Replaces `--clnrest-port=${CORE_LIGHTNING_REST_PORT}` with the canonical `CLNREST_PORT`; keeps `CORE_LIGHTNING_REST_PORT` as a backward-compat alias
- Adds `depends_on` for startup ordering (lightningd → tor, app → lightningd)

## Testing
Tested on Pi5 running umbrelOS 1.5.0 with Core Lightning v25.09.3. CLNRest is now reachable from RTL and LNbits containers.

## Breaking Changes
None. Backward-compatible aliases (`CORE_LIGHTNING_REST_PORT`, `COMMANDO_CONFIG`) are preserved.