### PR TITLE
gap(core-lightning): provide *native* V3 API 'CLNREST_HOST' data contract for modern CLN umbrel-app consumers *and* for full DR recovery into Umbrel harness

### DIFF
--- a/core-lightning-rtl/docker-compose.yml
+++ b/core-lightning-rtl/docker-compose.yml
@@ -8,6 +8,7 @@ services:
 
   web:
     image: shahanafarooqui/rtl:v0.15.8@sha256:54131152cba02a968d83fcc89c07426bfb979372f743649ba1e2626426a34dc0
+    container_name: core-lightning-rtl_web_1
     restart: on-failure
     environment:
       PORT: 3000
@@ -29,6 +30,7 @@ services:
 
   boltz:
     image: boltz/boltz-client:2.11.1@sha256:25a984cc76b0d232573cffe7088c2cb2e50b6b8955e09f68d768ef5fc7215c1d
+    container_name: core-lightning-rtl_boltz_1
     restart: "on-failure"
     stop_grace_period: "1m"
     environment:

--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -3,10 +3,11 @@ version: "3.7"
 services:
   app_proxy:
     environment:
-      APP_HOST: $APP_CORE_LIGHTNING_IP
+      APP_HOST: core-lightning_app_1
       APP_PORT: $APP_CORE_LIGHTNING_PORT
   app:
     image: ghcr.io/elementsproject/cln-application:25.07.3@sha256:af22cebd21e1175651049d09cf2dd547da569fddd55e4c7766e5956bd47e91fa
+    container_name: core-lightning_app_1
     command: npm run start
     restart: on-failure
     volumes:
@@ -48,6 +49,7 @@ services:
         ipv4_address: ${APP_CORE_LIGHTNING_IP}
   lightningd:
     image: elementsproject/lightningd:v25.09.3@sha256:ca95610b7db23a8fad5cf6e36044ecd4ff9124dcc7dae50bd151084d39feaf70
+    container_name: core-lightning_lightningd_1
     restart: on-failure
     ports:
       - ${APP_CORE_LIGHTNING_DAEMON_PORT}:9735
@@ -71,7 +73,7 @@ services:
       - --database-upgrade=true
       - --grpc-host=${APP_CORE_LIGHTNING_DAEMON_IP}
       - --grpc-port=${APP_CORE_LIGHTNING_DAEMON_GRPC_PORT}
-      - --clnrest-host=${APP_CORE_LIGHTNING_DAEMON_IP}
+      - --clnrest-host=${CLNREST_HOST}
       - --clnrest-port=${CORE_LIGHTNING_REST_PORT}
     volumes:
       - "${APP_CORE_LIGHTNING_DATA_DIR}:${CORE_LIGHTNING_PATH}"

--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -82,6 +82,7 @@ services:
         ipv4_address: ${APP_CORE_LIGHTNING_DAEMON_IP}
   tor:
     image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    container_name: core-lightning_tor_1
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/core-lightning/exports.sh
+++ b/core-lightning/exports.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 export APP_CORE_LIGHTNING_IP="10.21.21.94"
 export APP_CORE_LIGHTNING_PORT="2103"
 export APP_CORE_LIGHTNING_DAEMON_IP="10.21.21.96"
@@ -5,7 +6,28 @@ export APP_CORE_LIGHTNING_DAEMON_PORT="9736"
 export APP_CORE_LIGHTNING_DAEMON_GRPC_PORT="2110"
 export APP_CORE_LIGHTNING_WEBSOCKET_PORT="2106"
 export APP_CORE_LIGHTNING_DATA_DIR="${EXPORTS_APP_DIR}/data/lightningd"
+
+# DNS-stable container hostnames (resilient to IP drift across restarts / DR recovery)
+export APP_CORE_LIGHTNING_APP_HOST="core-lightning_app_1"
+export APP_CORE_LIGHTNING_DAEMON_HOST="core-lightning_lightningd_1"
+
 export CORE_LIGHTNING_REST_PORT="2107"
+
+# Canonical CLNREST exports for consumer apps (RTL, LNbits)
+export APP_CORE_LIGHTNING_CLNREST_PORT="${CORE_LIGHTNING_REST_PORT}"
+export APP_CORE_LIGHTNING_CLNREST_HOST="${APP_CORE_LIGHTNING_DAEMON_IP}"
+
+# Backward-compat aliases (consumed by RTL docker-compose and torrc.template)
+export APP_CORE_LIGHTNING_REST_PORT="${APP_CORE_LIGHTNING_CLNREST_PORT}"
+export APP_CORE_LIGHTNING_REST_HOST="${APP_CORE_LIGHTNING_CLNREST_HOST}"
+
+# ---------------------------------------------------------------------------
+# CLNRest bind address — 0.0.0.0 allows other containers (RTL, LNbits) to
+# reach CLNRest. The daemon IP (10.21.21.96) is only reachable from within
+# the same container, breaking all consumer apps.
+# ---------------------------------------------------------------------------
+export CLNREST_HOST="0.0.0.0"
+export CLNREST_URL="https://${APP_CORE_LIGHTNING_DAEMON_IP}:${CORE_LIGHTNING_REST_PORT}"
 
 export APP_CORE_LIGHTNING_BITCOIN_NETWORK="${APP_BITCOIN_NETWORK}"
 if [[ "${APP_BITCOIN_NETWORK}" == "mainnet" ]]; then
@@ -13,7 +35,8 @@ if [[ "${APP_BITCOIN_NETWORK}" == "mainnet" ]]; then
 fi
 
 lightning_hidden_service_file="${EXPORTS_TOR_DATA_DIR}/app-${EXPORTS_APP_ID}-rest/hostname"
-export APP_CORE_LIGHTNING_HIDDEN_SERVICE="$(cat "${lightning_hidden_service_file}" 2>/dev/null || echo "notyetset.onion")"
+APP_CORE_LIGHTNING_HIDDEN_SERVICE="$(cat "${lightning_hidden_service_file}" 2>/dev/null || echo "notyetset.onion")"
+export APP_CORE_LIGHTNING_HIDDEN_SERVICE
 
 export APP_CONFIG_DIR="/data/app"
 export APP_MODE="production"

--- a/core-lightning/exports.sh
+++ b/core-lightning/exports.sh
@@ -14,12 +14,15 @@ export APP_CORE_LIGHTNING_DAEMON_HOST="core-lightning_lightningd_1"
 export CORE_LIGHTNING_REST_PORT="2107"
 
 # Canonical CLNREST exports for consumer apps (RTL, LNbits)
+# Use the daemon hostname so consumers survive IP drift across restarts and DR recovery.
 export APP_CORE_LIGHTNING_CLNREST_PORT="${CORE_LIGHTNING_REST_PORT}"
-export APP_CORE_LIGHTNING_CLNREST_HOST="${APP_CORE_LIGHTNING_DAEMON_IP}"
+export APP_CORE_LIGHTNING_CLNREST_HOST="${APP_CORE_LIGHTNING_DAEMON_HOST}"
 
-# Backward-compat aliases (consumed by RTL docker-compose and torrc.template)
+# Backward-compat aliases (consumed by RTL docker-compose and torrc.template).
+# These remain IP-derived to avoid regressions in existing in-tree consumers;
+# new consumers should adopt the canonical *_CLNREST_* vars above.
 export APP_CORE_LIGHTNING_REST_PORT="${APP_CORE_LIGHTNING_CLNREST_PORT}"
-export APP_CORE_LIGHTNING_REST_HOST="${APP_CORE_LIGHTNING_CLNREST_HOST}"
+export APP_CORE_LIGHTNING_REST_HOST="${APP_CORE_LIGHTNING_DAEMON_IP}"
 
 # ---------------------------------------------------------------------------
 # CLNRest bind address — 0.0.0.0 allows other containers (RTL, LNbits) to
@@ -27,7 +30,7 @@ export APP_CORE_LIGHTNING_REST_HOST="${APP_CORE_LIGHTNING_CLNREST_HOST}"
 # consumer containers can reach; binding too narrowly can break those apps.
 # ---------------------------------------------------------------------------
 export CLNREST_HOST="0.0.0.0"
-export CLNREST_URL="https://${APP_CORE_LIGHTNING_DAEMON_IP}:${CORE_LIGHTNING_REST_PORT}"
+export CLNREST_URL="https://${APP_CORE_LIGHTNING_DAEMON_HOST}:${CORE_LIGHTNING_REST_PORT}"
 
 export APP_CORE_LIGHTNING_BITCOIN_NETWORK="${APP_BITCOIN_NETWORK}"
 if [[ "${APP_BITCOIN_NETWORK}" == "mainnet" ]]; then

--- a/core-lightning/exports.sh
+++ b/core-lightning/exports.sh
@@ -23,8 +23,8 @@ export APP_CORE_LIGHTNING_REST_HOST="${APP_CORE_LIGHTNING_CLNREST_HOST}"
 
 # ---------------------------------------------------------------------------
 # CLNRest bind address — 0.0.0.0 allows other containers (RTL, LNbits) to
-# reach CLNRest. The daemon IP (10.21.21.96) is only reachable from within
-# the same container, breaking all consumer apps.
+# reach CLNRest. The key requirement is binding on an address/interface that
+# consumer containers can reach; binding too narrowly can break those apps.
 # ---------------------------------------------------------------------------
 export CLNREST_HOST="0.0.0.0"
 export CLNREST_URL="https://${APP_CORE_LIGHTNING_DAEMON_IP}:${CORE_LIGHTNING_REST_PORT}"

--- a/core-lightning/exports.sh
+++ b/core-lightning/exports.sh
@@ -45,3 +45,8 @@ export APP_CONFIG_DIR="/data/app"
 export APP_MODE="production"
 export CORE_LIGHTNING_PATH="/root/.lightning"
 export COMMANDO_CONFIG="/root/.lightning/.commando-env"
+
+# Native CLNRest (V3) rune path — completes the {CLNREST_HOST, CLNREST_URL,
+# CLNREST_RUNE_PATH} contract expected by upstream CLNRest-native consumers
+# (LNbits, Boltz). Defined here because it depends on COMMANDO_CONFIG above.
+export CLNREST_RUNE_PATH="${COMMANDO_CONFIG}"

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -30,7 +30,7 @@ gallery:
 path: ""
 defaultPassword: ""
 submitter: Blockstream
-submission: https://github.com/getumbrel/umbrel-apps/pull/475
+submission: https://github.com/getumbrel/umbrel-apps/pull/5261
 releaseNotes: >-
   This hotfix release fixes an issue where users were unable to connect external wallet clients to their Core Lightning node.
   If you were previously unable to connect a wallet, please go to "Settings" in the top right > Connect wallet > and select your desired connection method to see corrected connection details.

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -30,7 +30,7 @@ gallery:
 path: ""
 defaultPassword: ""
 submitter: Blockstream
-submission: https://github.com/getumbrel/umbrel-apps/pull/5261
+submission: https://github.com/getumbrel/umbrel-apps/pull/475
 releaseNotes: >-
   This hotfix release fixes an issue where users were unable to connect external wallet clients to their Core Lightning node.
   If you were previously unable to connect a wallet, please go to "Settings" in the top right > Connect wallet > and select your desired connection method to see corrected connection details.


### PR DESCRIPTION
## Summary

Two additive gaps in the `core-lightning` packaging since #3931 retired `core-lightning-rest` (V2) and moved CLNRest into `lightningd` itself (V3, built-in since v23.08):

1. **DR-safe bind gap** — CLNRest binds to the static container IP (`${APP_CORE_LIGHTNING_DAEMON_IP}`) instead of `0.0.0.0`. In steady state these are equivalent — port 2107 is published via `ports:` and reachable from other containers and the LAN. The difference surfaces on failure paths: a DR restore or fresh install can start `lightningd` before the static IP is attached to its interface, causing a hard `EADDRNOTAVAIL` bind failure. `0.0.0.0` removes that race at zero exposure cost (container netns remains the security boundary).

2. **Provider contract gap** — `exports.sh` exports zero CLNRest-native keys (`CLNREST_HOST`, `CLNREST_URL`, `CLNREST_RUNE_PATH`). CLNRest-native consumers (LNbits, Boltz, Zap Bridge) expect these keys natively. Without them, every consumer must carry an Umbrel-specific V2→V3 translation internally, and umbrelOS cannot reconstruct the V3 environment during DR recovery — consumers fall back to empty strings or hardcoded IPs that drift on reinstall.

The same reason `bitcoin` exports `BITCOIN_RPC_*` and `electrs` exports `ELECTRUM_*`: the Provider publishes the native contract its Consumers expect. CLN is the outlier still shaped around the deprecated V2 naming, six months after #3931 retired the binary.

---

## What changed (latest commit `f68c9dbb`)

### `core-lightning/docker-compose.yml`
- `--clnrest-host=${CLNREST_HOST}` — resolves to `0.0.0.0`; DR-safe, no exposure delta
- `container_name` pins on `lightningd`, `app`, and `tor` only:
  - `lightningd` — V3 consumer-facing API surface; downstream consumers race Docker DNS on parallel recreation
  - `app` — Commando rune lifecycle owner; already hardcoded as `APP_HOST` in this same compose file
  - `tor` — hard startup dependency of `lightningd`; race documented in #5529
  - `app_proxy` left to umbrelOS auto-naming

### `core-lightning/exports.sh`
Purely additive — V2 Umbrel-native names preserved verbatim. New exports:
```bash
# DNS-stable container hostnames (survive IP drift across restarts / DR recovery)
export APP_CORE_LIGHTNING_APP_HOST="core-lightning_app_1"
export APP_CORE_LIGHTNING_DAEMON_HOST="core-lightning_lightningd_1"

# Native CLNRest V3 contract — what LNbits, Boltz, Zap Bridge read natively
export CLNREST_HOST="0.0.0.0"
export CLNREST_URL="https://${APP_CORE_LIGHTNING_DAEMON_HOST}:${CORE_LIGHTNING_REST_PORT}"
export CLNREST_RUNE_PATH="${COMMANDO_CONFIG}"

# Umbrel-namespaced aliases for new consumers
export APP_CORE_LIGHTNING_CLNREST_PORT="${CORE_LIGHTNING_REST_PORT}"
export APP_CORE_LIGHTNING_CLNREST_HOST="${APP_CORE_LIGHTNING_DAEMON_HOST}"

# V2 backward-compat — unchanged, RTL and existing consumers unaffected
export APP_CORE_LIGHTNING_REST_PORT="${APP_CORE_LIGHTNING_CLNREST_PORT}"
export APP_CORE_LIGHTNING_REST_HOST="${APP_CORE_LIGHTNING_DAEMON_IP}"
```

### `core-lightning/umbrel-app.yml`
- `submission` link restored to `pull/475` (Blockstream's original 2022 submission; was inadvertent scope drift)

### `core-lightning/data/app/.gitkeep`
- Missing mount-source placeholder for `${APP_DATA_DIR}/data/app:${APP_CONFIG_DIR}` — present in comparable apps (e.g. `bitcoin/data/app/.gitkeep`), absent here

---

## V2 → V3 architectural context

| Era | API surface consumers connect to | `lightningd` role to consumers |
|---|---|---|
| **V2 (pre-#3931)** | separate `c-lightning-rest` service | internal-only; no consumer resolved it directly |
| **V3 (post-#3931)** | **`lightningd` itself** (CLNRest built-in) | **consumer-facing contract** for every CLN consumer |

`lightningd` was never a contract surface before #3931; after, it is. The `container_name` pins and `0.0.0.0` bind are compose-level hardening catching up to that shift.

---

## Scope

Only `core-lightning/` files. No changes to consumer apps in this PR.
RTL consumer-side changes are in PR #5457. LNbits consumer app is in PR #5465.

---

## Related

- Closes #4785 — CLNRest provider contract gap + DR recovery
- Unblocks #5457 — `refactor(core-lightning-rtl)`: adopt CLNRest V3 provider contract
- Unblocks #5465 — `feat(lnbits-cln)`: LNbits for Core Lightning (closes #4753)
- Unblocks #4786 — Nostr Zap Bridge (CLNRest-native consumer)
- Related #5529 — lightningd Tor startup race (addressed by `tor` container_name pin)