### PR TITLE
fix(blockstream-blind-oracle): avoid AdGuard host-port 8095 collision

### DIFF
--- a/blockstream-blind-oracle/exports.sh
+++ b/blockstream-blind-oracle/exports.sh
@@ -1,5 +1,5 @@
 export APP_PINSERVER_PORT="8097"
-export APP_PINSERVER_WEB_PORT="8095"
+export APP_PINSERVER_WEB_PORT="8102"
 
 local app_pinserver_hidden_service_file="${EXPORTS_TOR_DATA_DIR}/app-${EXPORTS_APP_ID}-node/hostname"
 


### PR DESCRIPTION
## Summary
Moves Blockstream Blind Oracle web port off `8095` to avoid collision with AdGuard Home.

## Root cause
- `adguard-home` runs in `network_mode: host` with web UI bound to `0.0.0.0:8095`
- `blockstream-blind-oracle` exported `APP_PINSERVER_WEB_PORT=8095`
- This causes host port collision and downstream startup/connectivity instability (including Tor-facing app path issues)

## Change
- `blockstream-blind-oracle/exports.sh`
  - `APP_PINSERVER_WEB_PORT`: `8095` -> `8102`

## Scope
Single file, single setting change to keep review noise minimal.

Draft only for now; not ready for review yet.