### PR TITLE
Add Hermes Agent v2026.4.13-1

### DIFF
--- a/hermes-agent/docker-compose.yml
+++ b/hermes-agent/docker-compose.yml
@@ -4,23 +4,26 @@ services:
   app_proxy:
     environment:
       APP_HOST: hermes-agent_web_1
-      APP_PORT: 8080
+      APP_PORT: 9119
 
   server:
-    image: nousresearch/hermes-agent:latest@sha256:08e92cb8bf73041b8545f81f61f94b56f84bd4fd387d3d6ceb78e26ff7fb17d9
-    command: gateway run
-    user: "1000:1000"
+    image: nousresearch/hermes-agent:latest@sha256:ae4aca3179c38ce14cd480dd150d299dbcf6ac9317ae371bc77c3acb37253c6a
+    command:
+      - gateway
+      - run
     restart: on-failure
-    environment:
-      API_SERVER_ENABLED: "true"
-      API_SERVER_HOST: "0.0.0.0"
-      API_SERVER_PORT: "8642"
     volumes:
       - ${APP_DATA_DIR}/data/hermes:/opt/data
 
   web:
-    image: ghcr.io/aidencole98/hermes-agent-web-ui:v2026.4.8-upstream-r3@sha256:1c51ae0e96addb923fc37b19607af35fbd3f0cfc362edc7deb73f9e818c5b889
-    user: "1000:1000"
+    image: nousresearch/hermes-agent:latest@sha256:ae4aca3179c38ce14cd480dd150d299dbcf6ac9317ae371bc77c3acb37253c6a
+    command:
+      - dashboard
+      - --host
+      - 0.0.0.0
+      - --port
+      - "9119"
+      - --no-open
     restart: on-failure
     depends_on:
       - server

--- a/hermes-agent/docker-compose.yml
+++ b/hermes-agent/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.7'
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: hermes-agent_web_1
+      APP_PORT: 8080
+
+  server:
+    image: nousresearch/hermes-agent:latest@sha256:3c3c8e637ff48094e0a4dbff657903b0ddfd8f2e1b5a760a92a660385ccec4f4
+    command: gateway run
+    user: "1000:1000"
+    restart: on-failure
+    environment:
+      API_SERVER_ENABLED: "true"
+      API_SERVER_HOST: "0.0.0.0"
+      API_SERVER_PORT: "8642"
+    volumes:
+      - ${APP_DATA_DIR}/data/hermes:/opt/data
+
+  web:
+    image: ghcr.io/aidencole98/hermes-agent-web-ui:v2026.4.8-upstream-r1@sha256:36433092e4333ec7ef7a718c9ffd4fe101e6f91fb236fbc4a8dcef90e77bec7b
+    user: "1000:1000"
+    restart: on-failure
+    depends_on:
+      - server
+    volumes:
+      - ${APP_DATA_DIR}/data/hermes:/opt/data

--- a/hermes-agent/docker-compose.yml
+++ b/hermes-agent/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - ${APP_DATA_DIR}/data/hermes:/opt/data
 
   web:
-    image: ghcr.io/aidencole98/hermes-agent-web-ui:v2026.4.8-upstream-r2@sha256:d817f437150c1b5b1e12729ee0b486100c9b7c0b0b438919dc8a9a288ddc0064
+    image: ghcr.io/aidencole98/hermes-agent-web-ui:v2026.4.8-upstream-r3@sha256:1c51ae0e96addb923fc37b19607af35fbd3f0cfc362edc7deb73f9e818c5b889
     user: "1000:1000"
     restart: on-failure
     depends_on:

--- a/hermes-agent/docker-compose.yml
+++ b/hermes-agent/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8080
 
   server:
-    image: nousresearch/hermes-agent:latest@sha256:3c3c8e637ff48094e0a4dbff657903b0ddfd8f2e1b5a760a92a660385ccec4f4
+    image: nousresearch/hermes-agent:latest@sha256:08e92cb8bf73041b8545f81f61f94b56f84bd4fd387d3d6ceb78e26ff7fb17d9
     command: gateway run
     user: "1000:1000"
     restart: on-failure
@@ -19,7 +19,7 @@ services:
       - ${APP_DATA_DIR}/data/hermes:/opt/data
 
   web:
-    image: ghcr.io/aidencole98/hermes-agent-web-ui:v2026.4.8-upstream-r1@sha256:36433092e4333ec7ef7a718c9ffd4fe101e6f91fb236fbc4a8dcef90e77bec7b
+    image: ghcr.io/aidencole98/hermes-agent-web-ui:v2026.4.8-upstream-r2@sha256:d817f437150c1b5b1e12729ee0b486100c9b7c0b0b438919dc8a9a288ddc0064
     user: "1000:1000"
     restart: on-failure
     depends_on:

--- a/hermes-agent/docker-compose.yml
+++ b/hermes-agent/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 9119
 
   server:
-    image: nousresearch/hermes-agent:latest@sha256:ae4aca3179c38ce14cd480dd150d299dbcf6ac9317ae371bc77c3acb37253c6a
+    image: nousresearch/hermes-agent:latest@sha256:b9f289194f7d2003745f2e8449c85c2d2ae6672d56f6e62f5fecf2e94edc6b8c
     command:
       - gateway
       - run
@@ -16,7 +16,7 @@ services:
       - ${APP_DATA_DIR}/data/hermes:/opt/data
 
   web:
-    image: nousresearch/hermes-agent:latest@sha256:ae4aca3179c38ce14cd480dd150d299dbcf6ac9317ae371bc77c3acb37253c6a
+    image: nousresearch/hermes-agent:latest@sha256:b9f289194f7d2003745f2e8449c85c2d2ae6672d56f6e62f5fecf2e94edc6b8c
     command:
       - dashboard
       - --host

--- a/hermes-agent/exports.sh
+++ b/hermes-agent/exports.sh
@@ -1,0 +1,1 @@
+export APP_HERMES_AGENT_URL="http://hermes-agent_server_1:8642"

--- a/hermes-agent/exports.sh
+++ b/hermes-agent/exports.sh
@@ -1,1 +1,0 @@
-export APP_HERMES_AGENT_URL="http://hermes-agent_server_1:8642"

--- a/hermes-agent/umbrel-app.yml
+++ b/hermes-agent/umbrel-app.yml
@@ -2,16 +2,28 @@ manifestVersion: 1.2
 id: hermes-agent
 name: Hermes Agent
 category: ai
-version: "2026.4.8-1"
+version: "2026.4.8-2"
 tagline: The AI agent that grows with you
 port: 8600
 path: ""
-description: >-
-  Hermes Agent is an AI agent that lives in your terminal and gets better the more you use it. It can chat, use tools, remember important details across sessions, create reusable skills from past work, and automate tasks for you.
+description: |-
+  Hermes Agent is an AI agent that lives in your terminal and gets better the more you use it.
 
-  Use Hermes Agent to browse the web, edit files, run code, connect external services, and keep working from the same conversation over time. It also supports messaging integrations like Telegram, Signal, WhatsApp, and Discord, plus scheduled jobs and MCP servers.
 
-  On Umbrel, Hermes Agent opens in a browser terminal so you can choose your model and start chatting right away. If you want a separate UI, you can also install Hermes Workspace and point it at this same local backend.
+  On Umbrel, it opens in a browser terminal with a guided first-run setup. Pick your provider and model, then keep working from the same place every time.
+
+
+  Use Hermes Agent to browse the web, edit files, run shell commands, connect services like Telegram, Signal, WhatsApp, and Discord, save reusable skills, and remember important details across sessions.
+
+
+  Hermes Agent runs inside the Umbrel app sandbox, so it can work freely inside its own environment while your other apps and data stay separate.
+
+
+  ## What It Does
+    - **Chat and act** - Ask questions, automate tasks, and let Hermes use tools for you.
+    - **Works across channels** - Connect chat apps and keep talking to the same agent wherever you want.
+    - **Remembers your workflow** - Save preferences, context, and reusable skills that carry across sessions.
+    - **Uses real tools** - Browse sites, edit files, run code, and manage long-running jobs from the same agent.
 releaseNotes: ""
 developer: Nous Research
 website: https://hermes-agent.nousresearch.com/docs/

--- a/hermes-agent/umbrel-app.yml
+++ b/hermes-agent/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.2
 id: hermes-agent
 name: Hermes Agent
 category: ai
-version: "2026.4.8-2"
+version: "2026.4.13-1"
 tagline: The AI agent that grows with you
 port: 8600
 path: ""
@@ -10,7 +10,7 @@ description: |-
   Hermes Agent is an AI agent that gets better the more you use it by creating its own skills, storing user preferences, and updating its memory.
 
 
-  On Umbrel, it opens in a browser terminal with a guided first-run setup. Pick your provider and model, then keep working from the same place every time.
+  On Umbrel, it opens in Hermes Agent's official built-in dashboard. Set up your provider, manage your gateway, review sessions, check logs, and keep everything in one place.
 
 
   Use Hermes Agent to browse the web, edit files, run shell commands, connect services like Telegram, Signal, WhatsApp, and Discord, save reusable skills, and remember important details across sessions.
@@ -23,8 +23,13 @@ description: |-
     - **Chat and act** - Ask questions, automate tasks, and let Hermes use tools for you.
     - **Works across channels** - Connect chat apps and keep talking to the same agent wherever you want.
     - **Remembers your workflow** - Save preferences, context, and reusable skills that carry across sessions.
-    - **Uses real tools** - Browse sites, edit files, run code, and manage long-running jobs from the same agent.
-releaseNotes: ""
+    - **Manage it from the dashboard** - Configure settings, review activity, and monitor the agent from your browser.
+releaseNotes: |- 
+  Updated to Hermes Agent v0.9.0.
+
+  This release switches the Umbrel package to the official upstream Hermes image and opens in Hermes Agent's built-in dashboard.
+
+  It also includes the new web dashboard, backup and import commands, and the latest upstream fixes from v2026.4.13.
 developer: Nous Research
 website: https://hermes-agent.nousresearch.com/docs/
 submitter: aidencole98

--- a/hermes-agent/umbrel-app.yml
+++ b/hermes-agent/umbrel-app.yml
@@ -26,7 +26,7 @@ description: |-
     - **Manage it from the dashboard** - Configure settings, review activity, and monitor the agent from your browser.
 releaseNotes: ""
 developer: Nous Research
-website: https://hermes-agent.nousresearch.com/docs/
+website: https://hermes-agent.nousresearch.com
 submitter: aidencole98
 submission: https://github.com/getumbrel/umbrel-apps/pull/5293
 repo: https://github.com/NousResearch/hermes-agent

--- a/hermes-agent/umbrel-app.yml
+++ b/hermes-agent/umbrel-app.yml
@@ -7,7 +7,7 @@ tagline: The AI agent that grows with you
 port: 8600
 path: ""
 description: |-
-  Hermes Agent is an AI agent that lives in your terminal and gets better the more you use it.
+  Hermes Agent is an AI agent that gets better the more you use it by creating its own skills, storing user preferences, and updating its memory.
 
 
   On Umbrel, it opens in a browser terminal with a guided first-run setup. Pick your provider and model, then keep working from the same place every time.

--- a/hermes-agent/umbrel-app.yml
+++ b/hermes-agent/umbrel-app.yml
@@ -1,0 +1,23 @@
+manifestVersion: 1.2
+id: hermes-agent
+name: Hermes Agent
+category: ai
+version: "2026.4.8-1"
+tagline: The AI agent that grows with you
+port: 8600
+path: ""
+description: >-
+  Hermes Agent is an AI agent that lives in your terminal and gets better the more you use it. It can chat, use tools, remember important details across sessions, create reusable skills from past work, and automate tasks for you.
+
+  Use Hermes Agent to browse the web, edit files, run code, connect external services, and keep working from the same conversation over time. It also supports messaging integrations like Telegram, Signal, WhatsApp, and Discord, plus scheduled jobs and MCP servers.
+
+  On Umbrel, Hermes Agent opens in a browser terminal so you can choose your model and start chatting right away. If you want a separate UI, you can also install Hermes Workspace and point it at this same local backend.
+releaseNotes: ""
+developer: Nous Research
+website: https://hermes-agent.nousresearch.com/docs/
+submitter: aidencole98
+submission: https://github.com/getumbrel/umbrel-apps/pull/5293
+repo: https://github.com/NousResearch/hermes-agent
+support: https://github.com/NousResearch/hermes-agent/issues
+gallery: []
+dependencies: []

--- a/hermes-agent/umbrel-app.yml
+++ b/hermes-agent/umbrel-app.yml
@@ -24,12 +24,7 @@ description: |-
     - **Works across channels** - Connect chat apps and keep talking to the same agent wherever you want.
     - **Remembers your workflow** - Save preferences, context, and reusable skills that carry across sessions.
     - **Manage it from the dashboard** - Configure settings, review activity, and monitor the agent from your browser.
-releaseNotes: |- 
-  Updated to Hermes Agent v0.9.0.
-
-  This release switches the Umbrel package to the official upstream Hermes image and opens in Hermes Agent's built-in dashboard.
-
-  It also includes the new web dashboard, backup and import commands, and the latest upstream fixes from v2026.4.13.
+releaseNotes: ""
 developer: Nous Research
 website: https://hermes-agent.nousresearch.com/docs/
 submitter: aidencole98


### PR DESCRIPTION
## App name
Hermes Agent

## SVG icon
![Hermes Agent icon](https://raw.githubusercontent.com/aidencole98/hermes-agent-umbrel-image/main/assets/pr/hermes-agent/icon.svg)

## Gallery images
![Hermes Agent gallery 1](https://raw.githubusercontent.com/aidencole98/hermes-agent-umbrel-image/main/assets/pr/hermes-agent/gallery-1.png)
![Hermes Agent gallery 2](https://raw.githubusercontent.com/aidencole98/hermes-agent-umbrel-image/main/assets/pr/hermes-agent/gallery-2.png)
![Hermes Agent gallery 3](https://raw.githubusercontent.com/aidencole98/hermes-agent-umbrel-image/main/assets/pr/hermes-agent/gallery-3.png)

## Tested on
- dockerized umbrelOS 1.5.0 on amd64
- fresh install from the Umbrel App Store page after copying the package into the local app store path
- official upstream multi-arch image pinned to `nousresearch/hermes-agent:latest@sha256:ae4aca3179c38ce14cd480dd150d299dbcf6ac9317ae371bc77c3acb37253c6a`
- verified fresh install completed and brought up `hermes-agent_server_1`, `hermes-agent_web_1`, and `hermes-agent_app_proxy_1`
- verified the official built-in Hermes dashboard booted successfully
- verified the Umbrel-served app route is up and redirecting correctly through Umbrel auth

## Future / update notes
- updates Hermes Agent to `v2026.4.13` / `v0.9.0`
- drops the custom web UI path and uses the official upstream built-in dashboard
- removes the custom WebUI image and `exports.sh`
- removes the `pre-start` hook and uses a committed gitkept data directory at `data/hermes/` instead
- release notes are included because this PR is now an update to the earlier submission branch, not a brand new untouched submission
