### PR TITLE
Add Nostr VPN app

### DIFF
--- a/nostr-vpn/Dockerfile
+++ b/nostr-vpn/Dockerfile
@@ -1,0 +1,59 @@
+FROM debian:bookworm-slim
+
+ARG TARGETARCH=amd64
+
+# Install minimal runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    iproute2 \
+    kmod \
+    curl \
+    python3 \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
+    && apt-get autoremove -y \
+    && rm -rf /var/cache/apt/archives/*
+
+# Download and install nvpn CLI - supports both amd64 and arm64
+RUN case "${TARGETARCH}" in \
+        amd64) ARCH="x86_64-unknown-linux-musl" ;; \
+        arm64) ARCH="aarch64-unknown-linux-musl" ;; \
+        *) echo "unsupported architecture: ${TARGETARCH}"; exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/mmalmi/nostr-vpn/releases/download/v0.3.4/nvpn-${ARCH}.tar.gz" | tar -xz -C /tmp && \
+    mv /tmp/nvpn/nvpn /usr/local/bin/ && \
+    chmod +x /usr/local/bin/nvpn && \
+    rm -rf /tmp/nvpn
+
+# Copy application files
+COPY nvpn-web.py /usr/local/bin/nvpn-web
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/nvpn-web /usr/local/bin/entrypoint.sh
+
+# Create data directory structure
+# Note: The /data volume is mounted by Umbrel with uid:1000 permissions.
+# This directory structure is created at build time; runtime permissions
+# depend on Umbrel's volume creation behavior.
+RUN mkdir -p /data/.config/nvpn
+
+# Remove curl after use - not needed at runtime (healthcheck uses docker's curl)
+RUN apt-get remove -y --purge curl && rm -rf /var/lib/apt/lists/*
+
+# Run as non-root user
+USER 1000:1000
+
+# Set environment variables
+ENV PATH="/usr/local/bin:${PATH}"
+ENV NVPN_DATA_DIR=/data
+ENV HOME=/data
+ENV PYTHONUNBUFFERED=1
+
+# Explicitly disable Python bytecode caching for security
+ENV PYTHONDONTWRITEBYTECODE=1
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/')" 2>/dev/null || exit 1
+
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.7"
+
+services:
+  server:
+    image: ghcr.io/umbrel-apps/nostr-vpn:0.3.4@sha256:174f882a17e0daa7fca8e1c63a69c3c676c1d8c10d995550e80a45ba18600b25
+    restart: on-failure
+    stop_grace_period: 1m
+    network_mode: host
+    labels:
+      yantr.app: "nostr-vpn"
+      yantr.service: "VPN Service"
+    volumes:
+      # Note: Umbrel creates ${APP_DATA_DIR}/data with proper permissions (uid:1000) before
+      # starting the container. The container runs as non-root user (1000:1000).
+      # This is standard Umbrel behavior for all apps with persistent data.
+      - ${APP_DATA_DIR}/data:/data:rw
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun:rwm
+    environment:
+      - NVPN_DATA_DIR=/data
+      - HOME=/data
+    security_opt:
+      - no-new-privileges:true
+      - seccomp:unconfined
+    read_only: false
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    # Umbrel app proxy handles external auth - this service is internal only
+    # Web interface bound to 127.0.0.1 only

--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   server:
-    image: ghcr.io/madutxo/nostr-vpn:v0.3.4@sha256:174f882a17e0daa7fca8e1c63a69c3c676c1d8c10d995550e80a45ba18600b25
+    image: ghcr.io/madutxo/nostr-vpn:v0.3.4@sha256:ae977391fb2398c4f3b9eef5edd0705f86e74da62cdec799578d79b34227f5e1
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -2,31 +2,15 @@ version: "3.7"
 
 services:
   server:
-    # TODO: Image to be built and published by Umbrel team from upstream
-    # Upstream: https://github.com/mmalmi/nostr-vpn
-    # This is a placeholder - will be replaced after PR merge
     image: ghcr.io/getumbrel/nostr-vpn:v0.3.4
-    user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
     network_mode: host
-    labels:
-      yantr.app: "nostr-vpn"
-      yantr.service: "VPN Service"
     volumes:
-      - ${APP_DATA_DIR}/data:/data:rw
+      - ${APP_DATA_DIR}/data:/data
     cap_add:
       - NET_ADMIN
     devices:
-      - /dev/net/tun:/dev/net/tun:rwm
+      - /dev/net/tun:/dev/net/tun
     environment:
       - NVPN_DATA_DIR=/data
-      - HOME=/data
-    security_opt:
-      - no-new-privileges:true
-      - seccomp:unconfined
-    healthcheck:
-      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/')"]
-      interval: 30s
-      timeout: 10s
-      retries: 3

--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.7"
 services:
   server:
     image: ghcr.io/getumbrel/nostr-vpn:v0.3.4
+    user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
     network_mode: host

--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3.7"
 
 services:
   server:
+    # Image will be published to Umbrel GHCR namespace after PR merge
+    # Built from upstream: https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.4
     image: ghcr.io/madutxo/nostr-vpn:v0.3.4@sha256:ae977391fb2398c4f3b9eef5edd0705f86e74da62cdec799578d79b34227f5e1
     user: "1000:1000"
     restart: on-failure

--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   server:
-    image: ghcr.io/getumbrel/nostr-vpn:v0.3.4
+    image: ghcr.io/getumbrel/nostr-vpn:v0.3.4@sha256:174f882a17e0
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -2,7 +2,8 @@ version: "3.7"
 
 services:
   server:
-    image: ghcr.io/umbrel-apps/nostr-vpn:0.3.4@sha256:174f882a17e0daa7fca8e1c63a69c3c676c1d8c10d995550e80a45ba18600b25
+    image: ghcr.io/madutxo/nostr-vpn:v0.3.4
+    user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
     network_mode: host
@@ -10,9 +11,6 @@ services:
       yantr.app: "nostr-vpn"
       yantr.service: "VPN Service"
     volumes:
-      # Note: Umbrel creates ${APP_DATA_DIR}/data with proper permissions (uid:1000) before
-      # starting the container. The container runs as non-root user (1000:1000).
-      # This is standard Umbrel behavior for all apps with persistent data.
       - ${APP_DATA_DIR}/data:/data:rw
     cap_add:
       - NET_ADMIN
@@ -24,11 +22,8 @@ services:
     security_opt:
       - no-new-privileges:true
       - seccomp:unconfined
-    read_only: false
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/')"]
       interval: 30s
       timeout: 10s
       retries: 3
-    # Umbrel app proxy handles external auth - this service is internal only
-    # Web interface bound to 127.0.0.1 only

--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -2,9 +2,10 @@ version: "3.7"
 
 services:
   server:
-    # Image will be published to Umbrel GHCR namespace after PR merge
-    # Built from upstream: https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.4
-    image: ghcr.io/madutxo/nostr-vpn:v0.3.4@sha256:ae977391fb2398c4f3b9eef5edd0705f86e74da62cdec799578d79b34227f5e1
+    # TODO: Image to be built and published by Umbrel team from upstream
+    # Upstream: https://github.com/mmalmi/nostr-vpn
+    # This is a placeholder - will be replaced after PR merge
+    image: ghcr.io/getumbrel/nostr-vpn:v0.3.4
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   server:
-    image: ghcr.io/getumbrel/nostr-vpn:v0.3.4@sha256:174f882a17e0
+    image: ghcr.io/getumbrel/nostr-vpn:v0.3.4
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   server:
-    image: ghcr.io/madutxo/nostr-vpn:v0.3.4
+    image: ghcr.io/madutxo/nostr-vpn:v0.3.4@sha256:174f882a17e0daa7fca8e1c63a69c3c676c1d8c10d995550e80a45ba18600b25
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/nostr-vpn/entrypoint.sh
+++ b/nostr-vpn/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Create required directories with proper ownership
+# This runs as root before the USER switch
+mkdir -p /data/.config/nvpn
+chown -R 1000:1000 /data 2>/dev/null || true
+
+# Start the web interface
+exec /usr/local/bin/nvpn-web

--- a/nostr-vpn/exports.sh
+++ b/nostr-vpn/exports.sh
@@ -1,0 +1,11 @@
+# Nostr VPN environment exports
+
+# IP ADDRESSES
+export APP_NOSTR_VPN_NODE_IP="10.21.21.9"
+export APP_NOSTR_VPN_TOR_PROXY_IP="10.21.22.10"
+
+# DATA DIR
+export APP_NOSTR_VPN_DATA_DIR="${EXPORTS_APP_DIR}/data/nostr-vpn"
+
+# PORTS
+export APP_NOSTR_VPN_PORT="8080"

--- a/nostr-vpn/nvpn-web.py
+++ b/nostr-vpn/nvpn-web.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import http.server
+import socketserver
+import os
+import subprocess
+import signal
+
+PORT = 8080
+HOST = "127.0.0.1"  # Bind to localhost only - not exposed to network
+DATA_DIR = os.environ.get('NVPN_DATA_DIR', '/data')
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/':
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html')
+            self.send_header('X-Content-Type-Options', 'nosniff')
+            self.send_header('X-Frame-Options', 'DENY')
+            self.send_header('X-XSS-Protection', '1; mode=block')
+            self.end_headers()
+            
+            # Get status - simpler output for security
+            try:
+                result = subprocess.run(['nvpn', 'status'], capture_output=True, text=True, timeout=5)
+                status = result.stdout if result.returncode == 0 else result.stderr
+            except Exception as e:
+                status = 'Not initialized'
+            
+            # Minimal HTML - no command exposure
+            html = f"""<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Nostr VPN</title>
+<style>
+body {{ font-family: -apple-system, sans-serif; max-width: 500px; margin: 50px auto; padding: 20px; background: #1a1a2e; color: #eee; text-align: center; }}
+h1 {{ color: #00d4ff; }}
+.status {{ background: #16213e; padding: 20px; border-radius: 10px; margin: 20px 0; }}
+pre {{ background: #0f0f23; padding: 10px; border-radius: 5px; overflow-x: auto; font-size: 12px; text-align: left; }}
+</style>
+</head>
+<body>
+<h1>Nostr VPN</h1>
+<div class="status">
+<h2>Status</h2>
+<pre>{status}</pre>
+</div>
+<p>Use Umbrel terminal for management</p>
+</body>
+</html>"""
+            self.wfile.write(html.encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        pass  # No logging for security
+
+def signal_handler(sig, frame):
+    print('Shutting down...')
+    httpd.shutdown()
+
+signal.signal(signal.SIGTERM, signal_handler)
+
+# Bind to localhost only - not exposed to external network
+with socketserver.TCPServer((HOST, PORT), Handler) as httpd:
+    print(f'Nostr VPN status on http://{HOST}:{PORT}')
+    httpd.serve_forever()

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -1,0 +1,27 @@
+manifestVersion: 1
+id: nostr-vpn
+category: networking
+name: Nostr VPN
+version: "v0.3.4"
+tagline: A Tailscale-style mesh VPN powered by Nostr
+description: >-
+  Nostr VPN is a decentralized mesh VPN that uses Nostr for peer discovery
+  and signaling, and WireGuard for the encrypted data plane. It creates a
+  private network between your devices without requiring a central server.
+
+
+  Features include:
+  - Nostr-based peer discovery and signaling
+  - WireGuard encryption
+  - NAT traversal support
+  - Exit node support
+  - MagicDNS support
+  - Peer-to-peer mesh networking
+developer: nostr-vpn contributors
+website: https://github.com/mmalmi/nostr-vpn
+dependencies: []
+repo: https://github.com/mmalmi/nostr-vpn
+support: https://github.com/mmalmi/nostr-vpn/issues
+port: 8080
+gallery: []
+releaseNotes: ""

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -23,15 +23,6 @@ dependencies: []
 repo: https://github.com/mmalmi/nostr-vpn
 support: https://github.com/mmalmi/nostr-vpn/issues
 port: 8080
-gallery:
-  - 1.jpg
-  - 2.jpg
-  - 3.jpg
 path: ""
-deterministicPassword: false
-torOnly: false
 submitter: MadUTXO
-submission: ""
-releaseNotes: >-
-  Initial release for Umbrel.
-  This version packages the upstream nostr-vpn CLI for Umbrel.
+submission: https://github.com/getumbrel/umbrel-apps/pull/5296

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -27,4 +27,4 @@ path: ""
 gallery: []
 releaseNotes: ""
 submitter: MadUTXO
-submission: https://github.com/getumbrel/umbrel-apps/pull/5296
+submission: ""

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -23,10 +23,7 @@ dependencies: []
 repo: https://github.com/mmalmi/nostr-vpn
 support: https://github.com/mmalmi/nostr-vpn/issues
 port: 8080
-gallery:
-  - 1.jpg
-  - 2.jpg
-  - 3.jpg
+gallery: []
 path: ""
 submitter: MadUTXO
 submission: https://github.com/getumbrel/umbrel-apps/pull/5296

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -3,7 +3,7 @@ id: nostr-vpn
 category: networking
 name: Nostr VPN
 version: "v0.3.4"
-tagline: A Tailscale-style mesh VPN powered by Nostr
+tagline: A decentralized mesh VPN powered by Nostr
 description: >-
   Nostr VPN is a decentralized mesh VPN that uses Nostr for peer discovery
   and signaling, and WireGuard for the encrypted data plane. It creates a
@@ -23,8 +23,15 @@ dependencies: []
 repo: https://github.com/mmalmi/nostr-vpn
 support: https://github.com/mmalmi/nostr-vpn/issues
 port: 8080
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
 path: ""
-gallery: []
-releaseNotes: ""
+deterministicPassword: false
+torOnly: false
 submitter: MadUTXO
 submission: ""
+releaseNotes: >-
+  Initial release for Umbrel.
+  This version packages the upstream nostr-vpn CLI for Umbrel.

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -23,6 +23,10 @@ dependencies: []
 repo: https://github.com/mmalmi/nostr-vpn
 support: https://github.com/mmalmi/nostr-vpn/issues
 port: 8080
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
 path: ""
 submitter: MadUTXO
 submission: https://github.com/getumbrel/umbrel-apps/pull/5296

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -23,5 +23,8 @@ dependencies: []
 repo: https://github.com/mmalmi/nostr-vpn
 support: https://github.com/mmalmi/nostr-vpn/issues
 port: 8080
+path: ""
 gallery: []
 releaseNotes: ""
+submitter: MadUTXO
+submission: https://github.com/getumbrel/umbrel-apps/pull/5296


### PR DESCRIPTION
## App Submission

### App name
Nostr VPN

### 256x256 SVG icon
_(Upload an icon with no rounded corners as it will be dynamically rounded with CSS.)
We will help finalize this icon before the app goes live in the Umbrel App Store._

### Gallery images
_(Upload 3 to 5 high-quality gallery images (1440x900px) of your app in PNG format, or just upload 3 to 5 screenshots of your app and we will help you design the gallery images.)
We will help finalize these images before the app goes live in the Umbrel App Store._

### I have tested my app on:
- [x] umbrelOS on a Raspberry Pi
- [ ] umbrelOS on an Umbrel Home
- [x] umbrelOS on Linux VM

---

## Description

Nostr VPN is a Tailscale-style mesh VPN powered by Nostr for peer discovery and signaling, with WireGuard for the encrypted data plane.

### Features
- Nostr-based peer discovery and signaling
- WireGuard encryption
- NAT traversal support
- Exit node support
- MagicDNS support
- Peer-to-peer mesh networking

### Technical Details
- Uses host network mode for VPN functionality
- Requires NET_ADMIN capability for tunnel creation
- Non-root user (uid:1000)
- Web interface bound to localhost only for security
- Multi-arch support (amd64, arm64)

---

**Important Note:** This PR packages the original [nostr-vpn](https://github.com/mmalmi/nostr-vpn) project for Umbrel. The upstream project is a Tailscale-style mesh VPN that uses Nostr for peer discovery and WireGuard for the encrypted data plane.

For support or issues with the VPN functionality itself, please refer to the upstream repository: https://github.com/mmalmi/nostr-vpn/issues