### PR TITLE
Fix SearXNG host trust error and update to 2026.4.7

### DIFF
--- a/searxng/data/config/settings.yml
+++ b/searxng/data/config/settings.yml
@@ -1,0 +1,8 @@
+# Overlay on top of SearXNG's built-in defaults (avoids shipping the full 3000-line config).
+# JSON format is required for API consumers like Open WebUI.
+use_default_settings: true
+
+search:
+  formats:
+    - html
+    - json

--- a/searxng/docker-compose.yml
+++ b/searxng/docker-compose.yml
@@ -3,14 +3,16 @@ version: "3.7"
 services:
   app_proxy:
     environment:
-      APP_HOST: searxng_web_1
+      APP_HOST: searxng-web
       APP_PORT: 8080
 
   web:
-    image: ghcr.io/searxng/searxng:2026.3.26-e73442400@sha256:f01ceee858fe70e0ba6bf96934cdfad1ecc51fc528e72e17065b800f98ea87bb
+    image: ghcr.io/searxng/searxng:2026.4.7-08ef7a63d@sha256:6a89a150d0163877caab1982b7a20d0a03fd4b39401a0d3f26f61ad205949442
+    container_name: searxng-web # Avoid underscores in hostname (Werkzeug rejects them)
     restart: on-failure
     environment:
       SEARXNG_SECRET: ${APP_SEED}
+      SEARXNG_LIMITER: "false" # Disable bot detection — container-to-container calls lack proxy headers
     volumes:
       - ${APP_DATA_DIR}/data/config:/etc/searxng
       - ${APP_DATA_DIR}/data/cache:/var/cache/searxng

--- a/searxng/hooks/pre-start
+++ b/searxng/hooks/pre-start
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DATA_DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")/..")"
+SETTINGS_FILE="${APP_DATA_DIR}/data/config/settings.yml"
+MIGRATED_FLAG="${APP_DATA_DIR}/SETTINGS_MIGRATED"
+
+# One-time migration: replace the auto-generated 3000-line settings.yml with our
+# minimal overlay. This enables JSON search format (required by API consumers like
+# Open WebUI) while inheriting all other defaults from SearXNG's built-in config.
+# After migration, the user owns the file and we never touch it again.
+# On fresh installs this is a harmless no-op (overwrites the bundled file with identical content).
+if [[ ! -f "${MIGRATED_FLAG}" ]]; then
+  echo "Replacing SearXNG settings.yml with minimal overlay..."
+  cat > "${SETTINGS_FILE}" <<'EOF'
+# Overlay on top of SearXNG's built-in defaults (avoids shipping the full 3000-line config).
+# JSON format is required for API consumers like Open WebUI.
+use_default_settings: true
+
+search:
+  formats:
+    - html
+    - json
+EOF
+  touch "${MIGRATED_FLAG}"
+fi

--- a/searxng/umbrel-app.yml
+++ b/searxng/umbrel-app.yml
@@ -3,7 +3,7 @@ id: searxng
 name: SearXNG
 tagline: A free internet metasearch engine
 category: networking
-version: "2026.3.26"
+version: "2026.4.7"
 port: 8182
 description: >-
   🔍 SearXNG is a metasearch engine that enables users to search the internet by combining results from multiple search providers into one comprehensive list. When a user submits a query, SearXNG sends that query simultaneously to a variety of external search engines and services. It then collects and merges the responses, presenting the user with a unified set of search results. This approach allows users to access a wider range of information from different sources without having to search each one individually.
@@ -26,20 +26,15 @@ gallery:
   - 4.jpg
   - 5.jpg
 releaseNotes: >-
-  This release includes various improvements and new features:
-    - Added new engines including Pexels, AOL, Boardreader, and Karmasearch (Brave mirror)
-    - Added Bing autocomplete support
-    - Fixed an XSS security vulnerability in template rendering
-    - Fixed Google engine issues including XPath updates, Android user agent, and image thumbnails
-    - Fixed YouTube video errors by sending proper HTTP referrer
-    - Fixed Unsplash engine blocked by bot protection
-    - Reworked the Bing engine
-    - Removed the Stract, Livespace, Searchcode, and Right DAO engines
-    - Removed fasttext-predict support
+  This release fixes compatibility with Open WebUI and other API consumers, and updates SearXNG to 2026.4.7:
+    - Fixed "host not trusted" error when called from other containers (e.g. Open WebUI)
+    - Enabled JSON search format for API consumers
+    - Fixed DuckDuckGo rate limiting by restoring Sec-Fetch headers
+    - Fixed Karmasearch bot detection and crash on long queries
+    - Fixed TubeArchivist engine connectivity
+    - Reworked Lingva translation engine with working instance
     - Updated translations and internal data
-
-
-  Full release notes can be found at https://github.com/searxng/searxng/releases
+    - And more
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
## Summary
- Fixed "host not trusted" 400 error when other containers (e.g. Open WebUI) call SearXNG — caused by underscores in the Docker-generated hostname `searxng_web_1` which Werkzeug's host validation rejects
- Set `container_name: searxng-web` (hyphens instead of underscores) and updated `APP_HOST` to match
- Added `SEARXNG_LIMITER: "false"` to disable bot detection, since container-to-container calls lack proxy headers
- Bundled a minimal `settings.yml` using `use_default_settings: true` to enable JSON search format for API consumers like Open WebUI
- Added a pre-start hook to one-time migrate existing installs from the auto-generated 3000-line `settings.yml` to our minimal overlay
- Updated SearXNG from 2026.3.26 to 2026.4.7