### PR TITLE
Update ord to 0.27.1

### DIFF
--- a/ordinals/docker-compose.yml
+++ b/ordinals/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   ord:
-    image: nmfretz/ord:0.23.3@sha256:97c1d62ca3701fbdabd3fe0c29663f20b529183f41494ccaa2d444b9684fc472
+    image: nmfretz/ord:0.27.1@sha256:241db02d32ab66012724a680b471460ec4d87076aba102013371223d143ec159
     # This needs to run as root
     # user: "1000:1000"
     restart: on-failure

--- a/ordinals/hooks/pre-start
+++ b/ordinals/hooks/pre-start
@@ -26,16 +26,17 @@ if [[ -f "${APP_DATA_DIR}/index.redb" ]]; then
 fi
 
 # re-index ord on major version upgrades (so far in ord's history, this has been required on every major version update)
-# 0.23 update note: updating from 0.22.x to 0.23.x does not require re-indexing, see https://x.com/rodarmor/status/1909286899275251887 
-# for fresh installs this file will be harmlessly created 
-if [[ ! -f "${APP_DATA_DIR}/AT_LEAST_0-22-2" ]]; then
+# 0.23 update note: updating from 0.22.x to 0.23.x does not require re-indexing, see https://x.com/rodarmor/status/1909286899275251887
+# 0.27.1 update note: updating from 0.23.x to 0.27.1 requires re-indexing (schema version 30 -> 34)
+# for fresh installs this file will be harmlessly created
+if [[ ! -f "${APP_DATA_DIR}/AT_LEAST_0-27-1" ]]; then
     # delete index db for all bitcoin networks
     for file in "${ORDINALS_DATA_DIR}/index.redb" "${ORDINALS_DATA_DIR}/testnet3/index.redb" "${ORDINALS_DATA_DIR}/testnet4/index.redb" "${ORDINALS_DATA_DIR}/regtest/index.redb" "${ORDINALS_DATA_DIR}/signet/index.redb"; do
         if [[ -f "${file}" ]]; then
             rm -f "${file}"
         fi
     done
-    touch "${APP_DATA_DIR}/AT_LEAST_0-22-2"
+    touch "${APP_DATA_DIR}/AT_LEAST_0-27-1"
 fi
 
 # migrate all wallet database files to ord/wallets, ord/testnet3/wallets, ord/regtest/wallets, and ord/signet/wallets for pre-0.18.2 versions: https://github.com/ordinals/ord/releases/tag/0.18.2

--- a/ordinals/umbrel-app.yml
+++ b/ordinals/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ordinals
 category: bitcoin
 name: Ordinals
-version: "0.23.3"
+version: "0.27.1"
 tagline: Run your own index, block explorer, and command-line wallet for Ordinals
 description: >
   Run your own index, block explorer, and command-line wallet for Ordinals. The app automatically connects to your Bitcoin node on umbrelOS for trustless operation. Simply install the app and wait for Ordinals to index inscriptions and runes.
@@ -16,7 +16,7 @@ description: >
 
   Disclaimer: The Ordinals app does not control, filter, or moderate the content hosted on the Bitcoin blockchain. Consequently, you may come across NSFW (Not Safe For Work), objectionable, or unlawful material while using the app.
 releaseNotes: >-
-  Note: this major version update from 0.22.2 to 0.23.3 will NOT require ord to re-index from scratch.
+  ⚠️ This update from 0.23.3 to 0.27.1 requires ord to re-index from scratch due to database schema changes. Re-indexing will happen automatically on app update and may take several days depending on your hardware.
 
 
   ⏳ If ord is currently indexing, it may take a few minutes to safely shut down before updating. Please be patient during this process.


### PR DESCRIPTION
## Summary
- Update ord from 0.23.3 to 0.27.1
- Docker image: `nmfretz/ord:0.27.1`

## Re-indexing required

ord's database schema version changed from **30** (0.23.3) to **34** (0.27.1), bumped in [ordinals/ord#4436](https://github.com/ordinals/ord/pull/4436) for the 0.24.1 release. ord does not support automatic schema migration — it errors out with "consider deleting and rebuilding the index" when there's a mismatch:

```rust
cmp::Ordering::Less => bail!(
    "index at `{}` appears to have been built with an older, incompatible version of ord, 
    consider deleting and rebuilding the index: index schema {schema_version}, 
    ord schema {SCHEMA_VERSION}",
    path.display()
),
```

The pre-start hook handles this automatically by deleting existing `index.redb` files when the `AT_LEAST_0-27-1` marker file is not present. ord will then rebuild the index from scratch on startup.

## Changes
- **docker-compose.yml**: Updated image tag and digest to 0.27.1
- **umbrel-app.yml**: Bumped version to 0.27.1, updated release notes to inform users about the automatic re-index
- **hooks/pre-start**: Updated migration guard from `AT_LEAST_0-22-2` to `AT_LEAST_0-27-1` to trigger index deletion on upgrade