### PR TITLE
Disable Samba

### DIFF
--- a/samba/umbrel-app.yml
+++ b/samba/umbrel-app.yml
@@ -1,4 +1,4 @@
-manifestVersion: 1
+manifestVersion: 1.2
 id: samba
 name: Samba
 tagline: Make your storage accessible using Samba
@@ -6,6 +6,8 @@ category: networking
 version: "4.23.5-r1"
 port: 9445
 description: >-
+  ⚠️ Removal Notice: Samba has been disabled because umbrelOS now includes built-in network file sharing with better functionality.
+
   📂 Simplify your file sharing with Samba!
 
   Samba is a powerful tool that makes it easy to share files across different devices on your network. It allows your Umbrel device to seamlessly share files with Windows, macOS, Linux, and more. Whether you're sharing documents, media files, or backups, Samba makes it simple and secure.

--- a/samba/umbrel-app.yml
+++ b/samba/umbrel-app.yml
@@ -6,7 +6,7 @@ category: networking
 version: "4.23.5-r1"
 port: 9445
 description: >-
-  ⚠️ Removal Notice: Samba has been disabled because umbrelOS now includes built-in network file sharing with better functionality.
+  ⚠️ Removal Notice: The Samba app has been removed from the Umbrel App Store as file sharing is now natively integrated into umbrelOS.
 
   📂 Simplify your file sharing with Samba!
 

--- a/samba/umbrel-app.yml
+++ b/samba/umbrel-app.yml
@@ -45,3 +45,4 @@ dependencies: []
 path: ""
 defaultUsername: "umbrel"
 deterministicPassword: true
+disabled: true


### PR DESCRIPTION
## App name
Samba

umbrelOS now includes built-in Samba-based file sharing, so keeping the Samba app in the store creates two ways to do the same thing. The app also has less functionality than the native implementation, which makes it more confusing than useful for users.

This PR disables Samba in two ways: it keeps `disabled: true` for umbrelOS v1.1+ and bumps `manifestVersion` to `1.2` with a removal notice in the description so legacy versions of umbrelOS also can't install it and can see why.
