### PR TITLE
fix(twenty): make frontend work across multiple access hostnames (Tailscale, LAN, umbrel.local)

### DIFF
--- a/twenty/docker-compose.yml
+++ b/twenty/docker-compose.yml
@@ -10,6 +10,21 @@ services:
   server:
     image: twentycrm/twenty:v1.20.0@sha256:b3120df567a73c849a7a1ae58fa4f3d7bdd5072939312be702375960ed601557
     user: "1000:1000"
+    # Neutralize Twenty's bootstrap injection of SERVER_URL into the frontend
+    # HTML so the frontend's built-in window.location.origin fallback takes
+    # over. Without this, Twenty hardcodes http://umbrel.local:2020 as the
+    # API base URL, which breaks whenever the user accesses Umbrel via a
+    # different hostname — most notably Tailscale (umbrel.*.ts.net) or the
+    # LAN IP. With the injection disabled, the frontend auto-detects its
+    # backend URL from whichever hostname served the page, so Twenty works
+    # over LAN, Tailscale, and umbrel.local interchangeably.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        printf '%s\n' '"use strict";' 'Object.defineProperty(exports, "__esModule", { value: true });' 'exports.generateFrontConfig = function () {};' > /app/packages/twenty-server/dist/utils/generate-front-config.js
+        sed -i 's|"REACT_APP_SERVER_BASE_URL": *"[^"]*"|"REACT_APP_SERVER_BASE_URL": ""|g' /app/packages/twenty-server/dist/front/index.html 2>/dev/null || true
+        exec /app/entrypoint.sh node dist/main
     volumes:
       - ${APP_DATA_DIR}/data/server-local-data:/app/packages/twenty-server/.local-storage
       - ${APP_DATA_DIR}/data/docker-data:/app/docker-data


### PR DESCRIPTION
## Summary

Fixes Twenty CRM's "Unable to Reach Back-end" error when accessing Umbrel via a hostname other than `umbrel.local` — most notably Tailscale, which is a first-class Umbrel feature.

## Problem

Twenty's server hardcodes `SERVER_URL` into the frontend HTML at bootstrap (see [`generate-front-config.ts`](https://github.com/twentyhq/twenty/blob/main/packages/twenty-server/src/utils/generate-front-config.ts)), which locks the browser into making API calls to that single URL.

The current compose sets `SERVER_URL=http://umbrel.local:2020`. That works on LAN, but the moment the user accesses Umbrel remotely via Tailscale (`umbrel.*.ts.net`) or via the LAN IP directly, the frontend loads but can't reach the backend because `umbrel.local` doesn't resolve from those hostnames.

Since Umbrel ships Tailscale as a built-in remote-access feature, this is a reliable first-failure for anyone installing Twenty from the app store and then trying to use it remotely.

Related upstream discussion: twentyhq/twenty#19576 — the Twenty maintainer's (reasonable) position is that a single stable `SERVER_URL` is the intended deployment model. But that doesn't fit Umbrel's multi-hostname access pattern, so fixing this at the packaging layer is cleaner than pushing the change upstream.

## Fix

Override the container entrypoint to replace Twenty's `generate-front-config.js` with a no-op before the server starts. This neutralizes the bootstrap injection so [Twenty's built-in same-origin fallback](https://github.com/twentyhq/twenty/blob/main/packages/twenty-front/src/config/index.ts) kicks in — the frontend derives the backend URL from `window.location.origin`, matching whichever hostname served the page.

`SERVER_URL` is still set on the backend (needed for OAuth redirects, email links, webhook URLs if the user configures those).

## Test plan

Tested on a live Umbrel (v1.5) running Twenty v1.20.0:

- [x] Access via `http://umbrel.local:2020` on LAN → loads, reaches backend, full UI usable
- [x] Access via `http://<tailnet-hostname>:2020` via Tailscale → loads, reaches backend, full UI usable
- [x] Server startup logs clean (no errors from neutralized `generateFrontConfig`)
- [x] `curl http://localhost:2020` returns HTML with `REACT_APP_SERVER_BASE_URL: ""`
- [x] Server health check passes (`/healthz` returns 200)

## Security review

- Scope: only changes which URL the frontend uses to talk to the backend (hardcoded URL → `window.location.origin`)
- Port 2020 remains behind the Umbrel app proxy; no additional network exposure
- Same-origin API calls are strictly safer than the prior cross-origin pattern (no CORS relaxation needed)
- Entrypoint runs as user 1000 inside the container, same as before; only touches container-internal files that are re-created on every restart