### PR TITLE
Update Bitcoin Node to 1.2.2

### DIFF
--- a/bitcoin/docker-compose.yml
+++ b/bitcoin/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   app:
-    image: ghcr.io/getumbrel/umbrel-bitcoin:v1.2.1@sha256:edbccb43ba98d6adfad99c2f6cd5401b9dce0175ae1743d01017f8e01ca0eb05
+    image: ghcr.io/getumbrel/umbrel-bitcoin:v1.2.2@sha256:bc72c7fe705c582b8be1740c52449ac82de4d40b0e91ea090513aac6d4fc9393
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 15m30s

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bitcoin
 category: bitcoin
 name: Bitcoin Node
-version: "1.2.1"
+version: "1.2.2"
 tagline: Run your personal node powered by Bitcoin Core
 description: >-
   Run your Bitcoin node, powered by Bitcoin Core. Independently store and validate every Bitcoin transaction.
@@ -36,10 +36,7 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This update adds support for Bitcoin Core v30.2, updates the I2P daemon to v2.59.0, and includes general performance improvements.
-
-
-  Note: If you have previously selected a specific Bitcoin Core version in the app settings, it will not automatically update. You can switch to v30.2 from the settings at any time.
+  This update fixes an issue that could cause the Bitcoin Node app to crash and restart unexpectedly.
 widgets:
   - id: "stats"
     type: "four-stats"


### PR DESCRIPTION
Updates Bitcoin Node to 1.2.2, fixing an issue that could cause the app to restart unexpectedly.