### PR TITLE
Portainer CE 2.39.1 LTS through Alpine-based image and without the built-in Auth Proxy

### DIFF
--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - ${APP_DATA_DIR}/data/docker:/data
 
   portainer:
-    image: portainer/portainer-ce:2.39.1@sha256:1ae8e65d50ca5498cb2c33e617495a1e3ef245b0d2392b4a44c70ae09b822891
+    image: portainer/portainer-ce:2.39.1-alpine@sha256:2d423f0e4598833b6cdccca4baf59b552522b68d90a8906f11044bbe91e427f6
     command: --host unix:///var/run/docker.sock --admin-password-file=/default-password
     restart: on-failure
     volumes:

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
       APP_HOST: portainer_portainer_1
       APP_PORT: 9000
+      PROXY_AUTH_ADD: "false"
 
   docker:
     image: docker:27.2.0-dind@sha256:f9f72ad901a78f27be922b2d320bbc263174f12919c1b37e6a01f828fa904565

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: portainer
 category: developer
 name: Portainer
-version: "2.39.1"
+version: "2.39.1-1"
 tagline: Run custom Docker containers on your Umbrel
 description: >-
   ⚠️ Make sure to only use named Docker volumes for your stacks and containers. Data in bind-mounted volumes
@@ -51,14 +51,19 @@ path: ""
 defaultUsername: "admin"
 defaultPassword: "changeme"
 releaseNotes: >-
-  This update includes several fixes and security improvements:
+  This release maintains the current LTS version (2.39.1) but applies two tiny updates:
+    - Adds a rule to skip Umbrel OS Auth Proxy (allowing machine-to-machine comms)
+    - Internal replacement that sets a different built version for Portainer itself
+
+
+  Release notes for Portainer 2.39.1 LTS remain the same:
     - Fixed an issue where Git-based Docker stacks from GitLab failed validation for non-admin users
     - Fixed an issue where groups were missing after an upgrade
     - Fixed an issue where not all containers for a service were shown
     - Fixed an issue where users could not add new environments to an existing group with many environments
     - Fixed an issue where the Edit application button was disabled for non-admin users
     - Fixed an issue where users could not view their containers or saw a blank dashboard
-    - Fixed an issue where custom template file content was accessible to unauthorized users
+    - Fixed an issue where the custom template file content was accessible to unauthorized users
     - Re-enabled image registries for FIPS
     - Resolved multiple security vulnerabilities
 

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -63,7 +63,7 @@ releaseNotes: >-
     - Fixed an issue where users could not add new environments to an existing group with many environments
     - Fixed an issue where the Edit application button was disabled for non-admin users
     - Fixed an issue where users could not view their containers or saw a blank dashboard
-    - Fixed an issue where the custom template file content was accessible to unauthorized users
+    - Fixed an issue where custom template file content was accessible to unauthorized users
     - Re-enabled image registries for FIPS
     - Resolved multiple security vulnerabilities
 


### PR DESCRIPTION
Closes https://github.com/getumbrel/umbrel-apps/issues/5306

This PR sets two main changes:
- Disables the Umbrel OS Auth Proxy because:
  - It prevents machine-to-machine comms
  - Portainer already has an internal database of users + it can connect to other OAuth/OpenID services
- Replaces the current docker image with a new one, keeping the same LTS version but based on Alpine Linux

Related links:
- Issue https://github.com/getumbrel/umbrel-apps/issues/5306
- PR https://github.com/getumbrel/umbrel-apps/issues/5307, which will be closed to preserve the LTS version