### PR TITLE
Update the mempool app to v3.3.1

### DIFF
--- a/mempool/docker-compose.yml
+++ b/mempool/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_MEMPOOL_PORT
       PROXY_AUTH_ADD: "false"
   web:
-    image: mempool/frontend:v3.3.0@sha256:fca39d6bea78378e367704ec85d29bf8068379d4c2c58debf9ea8bae6982c9bb
+    image: mempool/frontend:v3.3.1@sha256:0a162e7e0d26a01e9686ddf69c96c4beae5fe10b0daa1020f3d392e033c058f1
     user: "1000:1000"
     init: true
     restart: on-failure

--- a/mempool/docker-compose.yml
+++ b/mempool/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       default:
         ipv4_address: $APP_MEMPOOL_IP
   api:
-    image: mempool/backend:v3.3.0@sha256:a860898d7f82756573c11b3a0b554db949589cbca772a29b7695fffac18d61f6
+    image: mempool/backend:v3.3.1@sha256:358c0a517c8dcf26e7f5c02447de5bab33ec7e3fa6318685cf8012ce36098e3a
     user: "1000:1000"
     init: true
     restart: on-failure

--- a/mempool/docker-compose.yml
+++ b/mempool/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: $APP_MEMPOOL_PORT
       PROXY_AUTH_ADD: "false"
   web:
-    image: mempool/frontend:v3.2.1@sha256:dd126cf383bd425ad46710925697c6a7925675a535c1026c206f2c092231e106
+    image: mempool/frontend:v3.3.0@sha256:fca39d6bea78378e367704ec85d29bf8068379d4c2c58debf9ea8bae6982c9bb
     user: "1000:1000"
     init: true
     restart: on-failure
@@ -23,7 +23,7 @@ services:
       default:
         ipv4_address: $APP_MEMPOOL_IP
   api:
-    image: mempool/backend:v3.2.1@sha256:d3531090e3bdd9a3dd38151349c5027768c3b7132438db267df8d8f026e15e61
+    image: mempool/backend:v3.3.0@sha256:a860898d7f82756573c11b3a0b554db949589cbca772a29b7695fffac18d61f6
     user: "1000:1000"
     init: true
     restart: on-failure

--- a/mempool/umbrel-app.yml
+++ b/mempool/umbrel-app.yml
@@ -13,7 +13,7 @@ description: >-
 
   This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com
 releaseNotes: >-
-  This update brings the mempool app to version 3.3.0.
+  This update brings the mempool app to version 3.3.1.
 
 
   Highlights from version 3.3.0:

--- a/mempool/umbrel-app.yml
+++ b/mempool/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: mempool
 category: bitcoin
 name: mempool
-version: "3.2.1"
+version: "3.3.0"
 tagline: Be your own explorer
 description: >-
   Run your own instance of The Mempool Open Source Project and trust no one.
@@ -13,21 +13,25 @@ description: >-
 
   This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com
 releaseNotes: >-
-  This update brings the mempool app to version 3.2.1, which includes a hotfix for a potential crash loop if the list of mining pools fails to get updated from our GitHub repo.
+  This update brings the mempool app to version 3.3.0.
 
 
-  Highlights from version 3.2.0:
-    - Support for v3 transactions
-    - Support for anchor outputs
-    - New UTXO bubble chart on the address page
-    - DATUM miner tags
-    - Tags to identify runestone messages and inscriptions
-    - Package broadcast
-    - Stratum job data visualizations
-    - Taproot multisig labels
-    - Transaction & PSBT preview feature
-    - Address poisoning detection
-
+  Highlights from version 3.3.0:
+    - Preview coinbase transactions from Stratum jobs
+    - Taproot script tree visualization
+    - Sighash icons & highlighting
+    - Stale block comparisons & visualizations
+    - Annex goggles support & labeling
+    - Sub-1-Sat/vB support
+    - Ephemeral dust support
+    - Display signatures in PSBT previews
+    - Simplicity support (Liquid)
+    - /api/tx/:txId/merkle-proof API endpoint for non-esplora backends
+    - Angular 16 -> 20 upgrade
+    - Decimal fee recommendations
+    - Taproot witness annotations
+    - Miscellaneous bugfixes and improvements
+    - Regtest support
 
   Full release notes are found at https://github.com/mempool/mempool/releases
 developer: Mempool Holdings S.A. de C.V.


### PR DESCRIPTION
This update brings the mempool app to version 3.3.0.

Highlights from version 3.3.0:
- Preview coinbase transactions from Stratum jobs
- Taproot script tree visualization
- Sighash icons & highlighting
- Stale block comparisons & visualizations
- Annex goggles support & labeling
- Sub-1-Sat/vB support
- Ephemeral dust support
- Display signatures in PSBT previews
- Simplicity support (Liquid)
- /api/tx/:txId/merkle-proof API endpoint for non-esplora backends
- Angular 16 -> 20 upgrade
- Decimal fee recommendations
- Taproot witness annotations
- Miscellaneous bugfixes and improvements
- Regtest support

Full release notes are found at https://github.com/mempool/mempool/releases

🫡