### PR TITLE
App Submission: Hermes Agent

### DIFF
--- a/hermes-agent/docker-compose.yml
+++ b/hermes-agent/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: hermes-agent_web_1
+      APP_PORT: 18789
+
+  # Web terminal + dashboard proxy
+  web:
+    image: ghcr.io/getumbrel/hermes-agent-umbrel:v2026.4.13@sha256:fb5fb72235da9ae71ca32b535501e1a78d751fcf16e38b5a9560a548ad9d0d8e
+    # Shell prompt shows "umbrel@hermes" instead of "umbrel@<container-id>"
+    hostname: hermes
+    init: true
+    user: "1000:1000"
+    restart: on-failure
+    depends_on:
+      - gateway
+    volumes:
+      - ${APP_DATA_DIR}/data/hermes:/opt/data
+    environment:
+      APP_SEED: ${APP_SEED}
+      # Tells the dashboard to probe the gateway via HTTP instead of local PID detection
+      GATEWAY_HEALTH_URL: http://hermes-agent_gateway_1:8642
+
+  # Hermes messaging gateway
+  gateway:
+    image: nousresearch/hermes-agent:latest@sha256:b0f87728fb313f97c91d19178624a2a67375d6ceeb27800853c866f94c42dfed
+    command: gateway run
+    stop_grace_period: 1m
+    restart: on-failure
+    volumes:
+      - ${APP_DATA_DIR}/data/hermes:/opt/data
+    environment:
+      HERMES_UID: "1000"
+      HERMES_GID: "1000"
+      # API server exposes the health endpoint the dashboard probes via GATEWAY_HEALTH_URL.
+      # Must bind to 0.0.0.0 (not default 127.0.0.1) to be reachable from the web container.
+      # Binding to 0.0.0.0 requires an API key — we reuse APP_SEED since the port is
+      # internal only (not exposed to host).
+      API_SERVER_ENABLED: "true"
+      API_SERVER_HOST: "0.0.0.0"
+      API_SERVER_KEY: ${APP_SEED}

--- a/hermes-agent/docker-compose.yml
+++ b/hermes-agent/docker-compose.yml
@@ -25,6 +25,8 @@ services:
 
   # Hermes messaging gateway
   gateway:
+    # Using latest tag because upstream version tags are amd64-only. Pinned by digest.
+    # Switch to a version tag when multiarch version tags are available.
     image: nousresearch/hermes-agent:latest@sha256:b0f87728fb313f97c91d19178624a2a67375d6ceeb27800853c866f94c42dfed
     command: gateway run
     stop_grace_period: 1m

--- a/hermes-agent/umbrel-app.yml
+++ b/hermes-agent/umbrel-app.yml
@@ -1,0 +1,44 @@
+manifestVersion: 1
+id: hermes-agent
+category: ai
+name: Hermes Agent
+version: "2026.4.13"
+tagline: The AI agent that grows with you
+description: >-
+  Hermes Agent is an AI agent that gets better the more you use it by creating its own skills, storing user preferences, and updating its memory.
+
+
+  On Umbrel, it opens in a browser-based terminal where you can chat with Hermes directly, run setup, and manage your agent. The built-in management dashboard is also available for configuring settings, reviewing sessions, and monitoring the gateway.
+
+
+  Use Hermes Agent to browse the web, edit files, run shell commands, connect services like Telegram, Signal, WhatsApp, and Discord, save reusable skills, and remember important details across sessions.
+
+
+  Hermes Agent runs inside the Umbrel app sandbox, so it can work freely inside its own environment while your other apps and data stay separate.
+
+
+  ## What It Does
+
+    - **Chat and act** - Ask questions, automate tasks, and let Hermes use tools for you.
+
+    - **Works across channels** - Connect chat apps and keep talking to the same agent wherever you want.
+
+    - **Remembers your workflow** - Save preferences, context, and reusable skills that carry across sessions.
+
+    - **Manage it from the dashboard** - Configure settings, review activity, and monitor the agent from your browser.
+developer: Nous Research
+website: https://hermes-agent.nousresearch.com
+dependencies: []
+repo: https://github.com/NousResearch/hermes-agent
+support: https://github.com/NousResearch/hermes-agent/issues
+port: 18790
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+path: "/terminal"
+defaultUsername: ""
+defaultPassword: ""
+releaseNotes: ""
+submitter: Umbrel
+submission: https://github.com/getumbrel/umbrel-apps/pull/5376


### PR DESCRIPTION
Uses two containers — the official `nousresearch/hermes-agent` image for the messaging gateway, and a custom wrapper image (`ghcr.io/getumbrel/hermes-agent-umbrel`) that adds a browser-based terminal for CLI setup/chat and proxies the official dashboard. The terminal approach gives users the full onboarding flow and access to hermes chat.

Wrapper image source: https://github.com/getumbrel/hermes-umbrel

Tested fresh install, full setup flow through the terminal, Telegram integration, dashboard health monitoring on both arm64 and amd64, and data persistence across app restarts and updates.