### PR TITLE
Update hermes-agent to version 2026.4.16

### DIFF
--- a/hermes-agent/docker-compose.yml
+++ b/hermes-agent/docker-compose.yml
@@ -27,7 +27,7 @@ services:
   gateway:
     # Using latest tag because upstream version tags are amd64-only. Pinned by digest.
     # Switch to a version tag when multiarch version tags are available.
-    image: nousresearch/hermes-agent:latest@sha256:b0f87728fb313f97c91d19178624a2a67375d6ceeb27800853c866f94c42dfed
+    image: nousresearch/hermes-agent:v2026.4.16@sha256:14ba9a26cf2d498ea773f1825326c404795ec4cb436a9479d22b7a345396c370
     command: gateway run
     stop_grace_period: 1m
     restart: on-failure

--- a/hermes-agent/umbrel-app.yml
+++ b/hermes-agent/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: hermes-agent
 category: ai
 name: Hermes Agent
-version: "2026.4.13"
+version: "2026.4.16"
 tagline: The AI agent that grows with you
 description: >-
   Hermes Agent is an AI agent that gets better the more you use it by creating its own skills, storing user preferences, and updating its memory.
@@ -36,9 +36,21 @@ gallery:
   - 1.jpg
   - 2.jpg
   - 3.jpg
+  - 4.jpg
 path: "/terminal"
 defaultUsername: ""
 defaultPassword: ""
-releaseNotes: ""
+releaseNotes: >-
+  What's new in Hermes Agent (2026.4.16):
+    - Adds Nous Tool Gateway support for paid Nous Portal subscribers.
+    - Unlocks web search, image generation, text-to-speech, and browser automation without needing separate API keys.
+    - Lets users enable gateway tools directly from hermes model, with per-tool opt-in settings.
+    - Improves integration with hermes tools and hermes status.
+    - Updates runtime behavior to prefer the Nous gateway automatically when available.
+    - Replaces the old hidden managed-tools environment flag with cleaner subscription-based detection.
+    - And much more.
+  
+  
+  Full details at https://github.com/NousResearch/hermes-agent/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/5376


### PR DESCRIPTION
This updates hermes-agent to version 2026.4.16, still pending umbrel container update.