### PR TITLE
Add ZMQ publish option to Monero command, required for p2pool mining

### DIFF
--- a/monero/docker-compose.yml
+++ b/monero/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     # "unless-stopped" ensures monerod restarts via UI-triggered daemon restarts, not just on failure
     restart: unless-stopped
     stop_grace_period: 15m
-    command: "${APP_MONERO_COMMAND}"
+    command: "${APP_MONERO_COMMAND}" --zmq-pub=tcp://0.0.0.0:18083
     image: ghcr.io/sethforprivacy/simple-monerod:v0.18.4.6@sha256:ed9299d73634a13f10de85e63d104276bf5e4ce5175ee4cc16f64f4bbeacbbd4
     ports:
       - "${APP_MONERO_P2P_PORT}:${APP_MONERO_P2P_PORT}"

--- a/monero/docker-compose.yml
+++ b/monero/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     # "unless-stopped" ensures monerod restarts via UI-triggered daemon restarts, not just on failure
     restart: unless-stopped
     stop_grace_period: 15m
-    command: "${APP_MONERO_COMMAND}" --zmq-pub=tcp://0.0.0.0:18083
+    command: "${APP_MONERO_COMMAND} --zmq-pub=tcp://0.0.0.0:18083"
     image: ghcr.io/sethforprivacy/simple-monerod:v0.18.4.6@sha256:ed9299d73634a13f10de85e63d104276bf5e4ce5175ee4cc16f64f4bbeacbbd4
     ports:
       - "${APP_MONERO_P2P_PORT}:${APP_MONERO_P2P_PORT}"


### PR DESCRIPTION
This publishing is required for Monero nodes to connect with the P2pool decentralized mining protocol. Users currently have to add this in manually. Adding it here would make the mining experience seamless for non-technical users.