### PR TITLE
Update bitcoin-regtest-dashboard to 1.0.3

### DIFF
--- a/bitcoin-regtest-dashboard/docker-compose.yml
+++ b/bitcoin-regtest-dashboard/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   # Bitcoin Core in regtest mode (self-contained, no dependencies)
   bitcoin:
-    image: ghcr.io/getumbrel/docker-bitcoind:v30.0@sha256:f5826a32aed9287cc5ffdec0996f5272634c4b346529cb8627224986ff555101
+    image: ghcr.io/getumbrel/docker-bitcoind:v30.2@sha256:75ad7da4eaa2a56b92e5703ff39fa86aa7b9012c50749ca082f018a761d136cd
     user: "1000:1000"
     restart: on-failure
     entrypoint: ["/bin/sh", "-c"]
@@ -71,7 +71,7 @@ services:
 
   # Bitcoin Regtest Dashboard
   dashboard:
-    image: coreylphillips/bitcoin-regtest-dashboard:v1.0.2@sha256:2e485c790163fd13347a692e685cb753ff178d571651dd7eea7c9a91e8fc0817
+    image: coreylphillips/bitcoin-regtest-dashboard:v1.0.3@sha256:f1ccffc2002f107559338f015097e49af7f547eababfcd1f53f0f2bdbd159c88
     user: "1000:1000"
     restart: on-failure
     environment:

--- a/bitcoin-regtest-dashboard/umbrel-app.yml
+++ b/bitcoin-regtest-dashboard/umbrel-app.yml
@@ -1,8 +1,8 @@
 manifestVersion: 1
 id: bitcoin-regtest-dashboard
-category: developer
+category: bitcoin
 name: Bitcoin Regtest Dashboard
-version: "1.0.2"
+version: "1.0.3"
 tagline: Development toolkit for Bitcoin regtest
 description: >-
   A self-contained development dashboard with its own Bitcoin Core regtest node and Electrs instance. No external dependencies required.
@@ -22,7 +22,12 @@ description: >-
 
   Perfect for Bitcoin developers who need quick access to regtest node functionality
   for testing wallets, applications, and Bitcoin integrations.
-releaseNotes: ""
+releaseNotes: >-
+  - Refreshed app icon
+
+  - Now listed under the Bitcoin category in the Umbrel store
+
+  - Upgraded Bitcoin Core to v30.2
 developer: Corey Phillips
 website: https://github.com/coreyphillips/bitcoin-regtest-dashboard
 dependencies: []

--- a/bitcoin-regtest-dashboard/umbrel-app.yml
+++ b/bitcoin-regtest-dashboard/umbrel-app.yml
@@ -23,11 +23,10 @@ description: >-
   Perfect for Bitcoin developers who need quick access to regtest node functionality
   for testing wallets, applications, and Bitcoin integrations.
 releaseNotes: >-
-  - Refreshed app icon
-
-  - Now listed under the Bitcoin category in the Umbrel store
-
-  - Upgraded Bitcoin Core to v30.2
+  This update contains various small improvements:
+    - Refreshed app icon
+    - Now listed under the Bitcoin category in the Umbrel store
+    - Upgraded Bitcoin Core to v30.2
 developer: Corey Phillips
 website: https://github.com/coreyphillips/bitcoin-regtest-dashboard
 dependencies: []


### PR DESCRIPTION
This update brings the bitcoin-regtest-dashboard app to version 1.0.3

Highlights from version 1.0.3:
- Bumps `ghcr.io/getumbrel/docker-bitcoind` from `v30.0` to `v30.2`
- Updates the Umbrel category from `developer-tools` to  `bitcoin`
- Updates icon