### PR TITLE
plane: fix file uploads by preserving port in proxy Host header

### DIFF
--- a/plane/config/nginx.conf
+++ b/plane/config/nginx.conf
@@ -19,11 +19,11 @@ server {
   port_in_redirect off;
   absolute_redirect off;
 
-  proxy_set_header Host                $host;
+  proxy_set_header Host                $http_host;
   proxy_set_header X-Real-IP           $remote_addr;
   proxy_set_header X-Forwarded-For     $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto   $final_proto;
-  proxy_set_header X-Forwarded-Host    $host;
+  proxy_set_header X-Forwarded-Host    $http_host;
   proxy_set_header X-Forwarded-Port    $final_port;
 
   location /spaces/ {

--- a/plane/config/nginx.conf
+++ b/plane/config/nginx.conf
@@ -1,3 +1,5 @@
+# Umbrel Plane canonical nginx.conf 29-April-2026
+
 # Use incoming X-Forwarded-Port if set, else default to 8762
 map $http_x_forwarded_port $final_port {
     default $http_x_forwarded_port;

--- a/plane/hooks/pre-start
+++ b/plane/hooks/pre-start
@@ -98,4 +98,81 @@ else
     echo "NGINX_HOST is already set. No changes made."
 fi
 
+NGINX_CONFIG_FILE="${APP_DIR}/config/nginx.conf"
+MARKER_REGEX='^# Umbrel Plane canonical nginx.conf 29-April-2026'
+
+if [[ ! -f "${NGINX_CONFIG_FILE}" ]] || ! grep -qx "${MARKER_REGEX}" "${NGINX_CONFIG_FILE}"; then
+  echo "Updating nginx configuration file for plane."
+  cat >"${NGINX_CONFIG_FILE}" <<'EOF'
+# Umbrel Plane canonical nginx.conf 29-April-2026
+
+# Use incoming X-Forwarded-Port if set, else default to 8762
+map $http_x_forwarded_port $final_port {
+    default $http_x_forwarded_port;
+    ""      8762;
+}
+
+map $http_x_forwarded_proto $final_proto {
+    default $http_x_forwarded_proto;
+    ""      $scheme;
+}
+
+server {
+  listen 8762;
+
+  # FILE_SIZE_LIMIT is bytes in Plane env; nginx wants m/g sizes.
+  # 52428800 bytes ≈ 50m
+  client_max_body_size 50m;
+
+  port_in_redirect off;
+  absolute_redirect off;
+
+  proxy_set_header Host                $http_host;
+  proxy_set_header X-Real-IP           $remote_addr;
+  proxy_set_header X-Forwarded-For     $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto   $final_proto;
+  proxy_set_header X-Forwarded-Host    $http_host;
+  proxy_set_header X-Forwarded-Port    $final_port;
+
+  location /spaces/ {
+    proxy_pass http://plane_space_1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+  }
+
+  location /god-mode/ {
+    proxy_pass http://plane_admin_1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+  }
+
+  location /live/ {
+    proxy_pass http://plane_live_1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+  }
+
+  location /api/ {
+    proxy_pass http://plane_api_1:8000;
+  }
+
+  location /auth/ {
+    proxy_pass http://plane_api_1:8000;
+  }
+
+  location /uploads {
+    proxy_pass http://plane-minio-1:9000;
+  }
+
+  location / {
+    proxy_pass http://plane_web_1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+  }
+}
+EOF
+
+  echo "Updated nginx configuration file for plane."
+fi
+
 exit 0

--- a/plane/umbrel-app.yml
+++ b/plane/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: plane
 category: files
 name: Plane
-version: "1.3.0"
+version: "1.3.1"
 tagline: Modern project management for all teams
 description: >-
   Meet Plane, an open-source project management tool to track issues, run sprints cycles, and manage product roadmaps without the chaos of managing the tool itself. 🧘‍♀️
@@ -33,7 +33,8 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
-releaseNotes: ""
+releaseNotes: |
+  Fix file uploads (project covers, attachments, avatars). The internal nginx proxy was stripping the port from the Host header, causing the Plane backend to construct upload URLs without the port suffix.
 torOnly: false
 submitter: al-lac
 submission: https://github.com/getumbrel/umbrel-apps/pull/4126

--- a/plane/umbrel-app.yml
+++ b/plane/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: plane
 category: files
 name: Plane
-version: "1.3.1"
+version: "1.3.0-1"
 tagline: Modern project management for all teams
 description: >-
   Meet Plane, an open-source project management tool to track issues, run sprints cycles, and manage product roadmaps without the chaos of managing the tool itself. 🧘‍♀️
@@ -34,7 +34,7 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: |
-  Fix file uploads (project covers, attachments, avatars). The internal nginx proxy was stripping the port from the Host header, causing the Plane backend to construct upload URLs without the port suffix.
+  This bugfix update fixes an issue with file uploads (project covers, attachments, avatars).
 torOnly: false
 submitter: al-lac
 submission: https://github.com/getumbrel/umbrel-apps/pull/4126


### PR DESCRIPTION
The internal nginx config used $host for proxy_set_header on both Host and X-Forwarded-Host, which strips the port. The Plane backend then constructed absolute upload URLs without the port, causing browsers to POST to umbrel.local:80 instead of umbrel.local:8762, returning 404.

Fix: use $http_host instead, which preserves the original Host header including the port.

Related to this issue for more context: https://github.com/getumbrel/umbrel-apps/issues/5454