### PR TITLE
Update miner-sentinel to version 1.0.1

### DIFF
--- a/miner-sentinel/docker-compose.yml
+++ b/miner-sentinel/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       retries: 5
 
   backend:
-    image: dcbert/minersentinel-backend:1.0.0@sha256:0a545cb0dbbaa7772560963ebb4cff63ad3919ac1ba8750aa5850388a7b1788c
+    image: dcbert/minersentinel-backend:1.0.1@sha256:d5f46aa215f181637e51d529da8a440c7f73ebdf2cf2cee763ca8afc58e20000
     restart: on-failure
     stop_grace_period: 1m
     depends_on:
@@ -57,7 +57,7 @@ services:
       "
 
   frontend:
-    image: dcbert/minersentinel-frontend:1.0.0@sha256:2144eb49160f841f0d4191a59942f7b18a1a3e89058332c2e6e807886158652a
+    image: dcbert/minersentinel-frontend:1.0.1@sha256:b7ee9a7cc8bf797b45baa7ce56e4bd8a4635ffd085f80aa7ce4ac8832211d62d
     restart: on-failure
     stop_grace_period: 1m
     depends_on:
@@ -66,7 +66,7 @@ services:
       VITE_API_URL: "http://${DEVICE_DOMAIN_NAME}:3080"
 
   data-service:
-    image: dcbert/minersentinel-data-service:1.0.0@sha256:aee26fe4db5f5d6d403154e73f609b454eccc54e7c78f21998dfda7ff4f5f589
+    image: dcbert/minersentinel-data-service:1.0.1@sha256:f87bbc9f4e755454718a3eb8190502c7cc65e7d7fb8b40158cf487c26a773f53
     restart: on-failure
     stop_grace_period: 1m
     depends_on:

--- a/miner-sentinel/docker-compose.yml
+++ b/miner-sentinel/docker-compose.yml
@@ -31,8 +31,8 @@ services:
       - db
     environment:
       # Database configuration
-      DB_HOST: miner-sentinel_db_1
-      DB_PORT: 5432
+      POSTGRES_HOST: miner-sentinel_db_1
+      POSTGRES_PORT: 5432
       POSTGRES_DB: minersentinel
       POSTGRES_USER: minersentinel
       POSTGRES_PASSWORD: minersentinel

--- a/miner-sentinel/umbrel-app.yml
+++ b/miner-sentinel/umbrel-app.yml
@@ -48,7 +48,10 @@ description: >-
   Designed for Umbrel with Docker containerization for easy deployment and updates.
 
 releaseNotes: >-
-  Fixed the cors error that prevented users from adding new devices if they user the ip address instead of the domain name to access the app. This update ensures that both the domain name and the IP address are included in the allowed origins, allowing users to add new devices regardless of how they access the app.
+  Fixed the cors error that prevented users from adding new devices if they user the ip address instead of the domain name to access the app.
+  
+  
+  This update ensures that both the domain name and the IP address are included in the allowed origins, allowing users to add new devices regardless of how they access the app.
 developer: Davide Bert
 website: https://github.com/dcbert/miner-sentinel
 dependencies: []

--- a/miner-sentinel/umbrel-app.yml
+++ b/miner-sentinel/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: miner-sentinel
 category: bitcoin
 name: MinerSentinel
-version: "1.0.0-1"
+version: "1.0.1"
 tagline: Unified monitoring dashboard for Bitaxe and Avalon Bitcoin miners
 description: >-
   MinerSentinel is a self-hosted monitoring solution designed for Bitcoin home miners running Bitaxe and Avalon Nano 3s ASIC devices. It provides a centralized dashboard to track performance, health, and profitability metrics across your entire mining fleet.
@@ -48,7 +48,7 @@ description: >-
   Designed for Umbrel with Docker containerization for easy deployment and updates.
 
 releaseNotes: >-
-  This update solves a problem with logging into the app.
+  Fixed the cors error that prevented users from adding new devices if they user the ip address instead of the domain name to access the app. This update ensures that both the domain name and the IP address are included in the allowed origins, allowing users to add new devices regardless of how they access the app.
 developer: Davide Bert
 website: https://github.com/dcbert/miner-sentinel
 dependencies: []


### PR DESCRIPTION
## What

Updated the `miner-sentinel` Docker image to the latest version.

## Changes
- Updated image reference in `docker-compose.yml` (new tag / sha256)
- Bumped app version in `umbrel-app.yml`
- Added release notes

## Why
This includes the fix for the issue where the app would only work correctly with IP-based URLs (instead of domain-based ones). Users can now use either without problems.

Related issue: https://github.com/dcbert/miner-sentinel/issues/10

## Testing
- Tested on Umbrel OS (latest)
- App starts correctly with both IP and domain URLs
- No breaking changes

---

**Ready for review** 