### PR TITLE
Update OpenClaw to 2026.4.27

### DIFF
--- a/openclaw/docker-compose.yml
+++ b/openclaw/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_PORT: 18789
 
   gateway:
-    image: ghcr.io/getumbrel/openclaw-umbrel:2026.4.26@sha256:5435c4234c0609dbf728c132d2a046849c7d73282bbd8d5d0416a007dc0ef970
+    image: ghcr.io/getumbrel/openclaw-umbrel:2026.4.27@sha256:276006c9c44d6f60b863bb8642a1207f8cac41411b6ea01de21c6087bf20b2e8
     user: "1000:1000"
     init: true
     restart: on-failure

--- a/openclaw/docker-compose.yml
+++ b/openclaw/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_PORT: 18789
 
   gateway:
-    image: ghcr.io/getumbrel/openclaw-umbrel:2026.4.14@sha256:90be9c46cae1902c520196677f127c773305ad80de523b077e7f75ee0fdb48e5
+    image: ghcr.io/getumbrel/openclaw-umbrel:2026.4.26@sha256:5435c4234c0609dbf728c132d2a046849c7d73282bbd8d5d0416a007dc0ef970
     user: "1000:1000"
     init: true
     restart: on-failure

--- a/openclaw/umbrel-app.yml
+++ b/openclaw/umbrel-app.yml
@@ -3,7 +3,7 @@ id: openclaw
 name: OpenClaw
 tagline: The AI that actually does things
 category: ai
-version: "2026.4.14"
+version: "2026.4.26"
 port: 18789
 path: ""
 description: >-
@@ -39,28 +39,18 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  What's new in OpenClaw (v2026.4.12 → v2026.4.14):
-    - Added forward-compatibility support for GPT-5.4-pro in the Codex provider
-    - Telegram forum topics now surface human-readable topic names in agent context
-    - Fixed Ollama runs timing out too early due to incorrect stream timeout settings
-    - Fixed Codex provider dropping all custom models from every provider in models.json
-    - Fixed image and PDF tools rejecting valid Ollama vision models
-    - Fixed Slack interactive triggers potentially bypassing configured allowlists
-    - Fixed local attachment path resolution failing open instead of closed on errors
-    - Blocked AI model from enabling dangerous security flags via config patch tool
-    - Fixed Google Gemini image requests returning 404 due to incorrect URL suffix handling
-    - Fixed Ollama streaming completions reporting bogus token counts causing premature compaction
-    - Fixed memory embedding providers with non-OpenAI prefixes failing with unknown provider error
-    - Fixed browser SSRF policy blocking normal hostname navigation and local CDP control
-    - Fixed Control UI freezing on maliciously crafted markdown via ReDoS vulnerability
-    - Fixed observer-mode setups where deny send policy was blocking inbound message processing
-    - Fixed WhatsApp encrypted media writes causing transient crashes on image sends
-    - Fixed heartbeat, cron, and exec turns overwriting shared session routing metadata
-    - Fixed Ollama memory embeddings adapter and added endpoint-aware cache keys
-    - Fixed voice-note replies silently dropping due to temp file handling issues
-    - Fixed AAC voice notes failing transcription due to incorrect MIME type mapping
-    - Fixed GPT-5.4 embedded runs failing request validation due to incorrect reasoning effort mapping
-    - Multiple additional security hardening, stability, and compatibility fixes across channels, agents, and providers
+  What's new in OpenClaw (v2026.4.14 → v2026.4.26):
+    - Added new and improved channel support, including QQBot group chat features and the Yuanbao channel plugin
+    - Added Google Live browser Talk sessions and expanded realtime voice support in the Control UI
+    - Added Cerebras as a bundled provider plugin
+    - Added stronger plugin install, discovery, repair, and startup handling
+    - Added richer TTS controls, new TTS providers, and chat-scoped voice reply settings
+    - Added PWA install support and Web Push notifications in the Control UI
+    - Added TUI setup improvements, context mode selection, and a shorter startup greeting
+    - Improved browser automation with safer tab URLs, better iframe snapshots, and deeper browser diagnostics
+    - Improved onboarding and model setup performance by avoiding unnecessary provider and plugin runtime loads
+    - Fixed many gateway, provider, Docker, memory, channel, agent, and Control UI stability issues
+    - Fixed multiple security and privacy issues around tokens, skills responses, transcripts, config handling, and UI rendering
     - And much more. Full details at https://github.com/openclaw/openclaw/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/4649

--- a/openclaw/umbrel-app.yml
+++ b/openclaw/umbrel-app.yml
@@ -3,7 +3,7 @@ id: openclaw
 name: OpenClaw
 tagline: The AI that actually does things
 category: ai
-version: "2026.4.26"
+version: "2026.4.27"
 port: 18789
 path: ""
 description: >-
@@ -39,18 +39,16 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  What's new in OpenClaw (v2026.4.14 → v2026.4.26):
-    - Added new and improved channel support, including QQBot group chat features and the Yuanbao channel plugin
-    - Added Google Live browser Talk sessions and expanded realtime voice support in the Control UI
-    - Added Cerebras as a bundled provider plugin
-    - Added stronger plugin install, discovery, repair, and startup handling
-    - Added richer TTS controls, new TTS providers, and chat-scoped voice reply settings
+  What's new in OpenClaw (v2026.4.14 → v2026.4.27):
+    - Added new and improved channel support, including QQBot group chats, Yuanbao, Matrix, Telegram, Slack, Discord, and LINE improvements
+    - Added new bundled provider plugins, including DeepInfra and Cerebras, with expanded model catalog support
+    - Added richer voice and media support, including Google Live browser Talk sessions, TTS controls, and non-image file attachments
+    - Added Codex Computer Use setup and improved Codex/ACP agent integration
     - Added PWA install support and Web Push notifications in the Control UI
     - Added TUI setup improvements, context mode selection, and a shorter startup greeting
     - Improved browser automation with safer tab URLs, better iframe snapshots, and deeper browser diagnostics
-    - Improved onboarding and model setup performance by avoiding unnecessary provider and plugin runtime loads
-    - Fixed many gateway, provider, Docker, memory, channel, agent, and Control UI stability issues
-    - Fixed multiple security and privacy issues around tokens, skills responses, transcripts, config handling, and UI rendering
+    - Improved gateway startup, plugin runtime dependency handling, model setup, memory, and provider discovery performance
+    - Fixed many gateway, provider, Docker, memory, channel, agent, Control UI, security, and privacy issues
     - And much more. Full details at https://github.com/openclaw/openclaw/releases
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/4649


### PR DESCRIPTION
waiting for next openclaw release to see if the performance (speed) regressions have been addressed.