### PR TITLE
Fix mempool 3.3.1 app metadata

### DIFF
--- a/mempool/umbrel-app.yml
+++ b/mempool/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: mempool
 category: bitcoin
 name: mempool
-version: "3.3.0"
+version: "3.3.1"
 tagline: Be your own explorer
 description: >-
   Run your own instance of The Mempool Open Source Project and trust no one.

--- a/mempool/umbrel-app.yml
+++ b/mempool/umbrel-app.yml
@@ -13,10 +13,10 @@ description: >-
 
   This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com
 releaseNotes: >-
-  This update brings the mempool app to version 3.3.1.
+  This release upgrades mempool from 3.2.1 to 3.3.1, including the 3.3.0 feature release.
 
 
-  Highlights from version 3.3.0:
+  Highlights:
     - Preview coinbase transactions from Stratum jobs
     - Taproot script tree visualization
     - Sighash icons & highlighting


### PR DESCRIPTION
Follow-up to #5344.

I merged the mempool 3.3.1 update to avoid holding up the app release, then split these small metadata tweaks into this follow-up PR.