### PR TITLE
Remove stale Specter Desktop compose comments

### DIFF
--- a/specter-desktop/docker-compose.yml
+++ b/specter-desktop/docker-compose.yml
@@ -17,8 +17,6 @@ services:
       - --host=0.0.0.0
       - --specter-data-folder=/data
     environment:
-      # TODO: APP_PASSWORD
-      # These env vars no longer work from v2.0.0 onwards (after introduction of public electrum server option). Keeping them here for potential future use if Specter Desktop adds support for them again. 
       BTC_RPC_USER: $APP_BITCOIN_RPC_USER
       BTC_RPC_PASSWORD: $APP_BITCOIN_RPC_PASS
       BTC_RPC_HOST: $APP_BITCOIN_NODE_IP


### PR DESCRIPTION
Removes stale comments from Specter Desktop’s compose file. Specter Desktop v2.1.7 restored support for using the BTC_RPC_* env vars to auto-configure Bitcoin Core.