### PR TITLE
Update overseerr to version 3.2.0 (Seerr migration)

### DIFF
--- a/overseerr/docker-compose.yml
+++ b/overseerr/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: '3.7'
 
 services:
   app_proxy:
@@ -8,10 +8,15 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/overseerr:1.35.0@sha256:53a1b839ffa81f139e1552840772bff8a5d13f5c78a69cce22458b9a6cd0844d
-    environment:
-      - PUID=1000
-      - PGID=1000
+    image: ghcr.io/seerr-team/seerr:v3.2.0@sha256:c4cbd5121236ac2f70a843a0b920b68a27976be57917555f1c45b08a1e6b2aad
+    user: "1000:1000"
+    init: true
     volumes:
-      - ${APP_DATA_DIR}/data/config:/config
+      - ${APP_DATA_DIR}/data/config:/app/config
     restart: on-failure
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/status || exit 1
+      start_period: 20s
+      timeout: 3s
+      interval: 15s
+      retries: 3

--- a/overseerr/hooks/pre-start
+++ b/overseerr/hooks/pre-start
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# v3.0.0 allowed the seerr container to run as non-root: https://github.com/seerr-team/seerr/releases/tag/v3.0.0
+# Overseerr previously ran as root via PUID/PGID, so we now recursively set the owner of the data directory to 1000:1000 so that pre-3.0.0 users do not have a broken app
+APP_DATA_DIR="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)/data"
+
+# Recursively set ownership of all files and directories under APP_DATA_DIR to 1000:1000
+chown -R 1000:1000 "${APP_DATA_DIR}"

--- a/overseerr/umbrel-app.yml
+++ b/overseerr/umbrel-app.yml
@@ -1,44 +1,40 @@
-manifestVersion: 1
+manifestVersion: 1.1
 id: overseerr
 category: media
-name: Overseerr
-version: "1.35.0"
-tagline: Beautiful media discovery
+name: Seerr
+version: "3.2.0"
+tagline: Beautiful media discovery and request management
 description: >-
-  Overseerr is a request management and media discovery tool built to work with your existing Plex ecosystem.
+  Seerr is a free and open source software application for managing requests for your media library.
 
 
-  Overseerr scans your Plex libraries at regular intervals, so it knows which items are already available on your server.
-  It also integrates with the popular DVR applications Radarr and Sonarr, and supports activity monitoring within Overseerr itself.
+  It integrates with the media server of your choice: Jellyfin, Plex, and Emby. In addition, it integrates with your existing services, such as Sonarr, Radarr.
+
+
+  Seerr scans your libraries at regular intervals, so it knows which items are already available on your server.
+
+  It also integrates with the popular DVR applications Radarr and Sonarr, and supports activity monitoring within Seerr itself.
 
 
   🛠️ SET-UP INSTRUCTIONS
 
-  During initial set-up, you will need to input your Umbrel device's IP address to connect to Plex (and optional services such as Radarr and Sonarr).
-  You can find your device's IP address by visiting your router's admin dashboard or by using an IP scanning tool like Angry IP Scanner.
-releaseNotes: >-
-  This release includes several bug fixes and improvements:
-    - Better handling for active webpush subscriptions and notification management
-    - Corrected edge cases with deletion not updating requests properly
-    - Fixed availability sync for currently available non-completed media
-    - Improved handling of partial seasons and specials
-    - Updated Plex Watchlist URL
-    - Fixed notification sending for wrong status scenarios
-    - Corrected series setting to partially available status
+
+  During initial set-up, you will need to input your Umbrel device's IP address to connect to Jellyfin / Plex / Emby (and optional services such as Radarr and Sonarr).
+
+  You can find your device's IP address in the Umbrel Settings.
 
 
-  New features:
-    - Updated to Node 20 for improved performance and security
-    - Prepared migration path for future Seerr transition
-    - Enhanced PWA app badge functionality
-
-
-  Full release notes can be found at https://github.com/sct/overseerr/releases
-developer: Ryan Cohen
-website: https://overseerr.dev/
+  You can also use the following addresses:
+    - **Jellyfin:** jellyfin_server_1:8096
+    - **Emby:** emby_server_1:8086
+    - **Radarr:** radarr_server_1:7878
+    - **Sonarr:** sonarr_server_1:8989
+    - **Plex:** No address needed
+developer: Seerr Team
+website: https://docs.seerr.dev/
 dependencies: []
-repo: https://github.com/sct/overseerr
-support: https://github.com/sct/overseerr/issues
+repo: https://github.com/seerr-team/seerr
+support: https://github.com/seerr-team/seerr/issues
 port: 5055
 gallery:
   - 1.jpg
@@ -47,6 +43,23 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: >-
+  This release migrates the Overseerr app to **Seerr**, the new unified project that merges the Overseerr and Jellyseerr teams and codebases into a single platform for managing media discovery and requests.
+
+
+  Your existing Overseerr configuration and database will be migrated automatically on first start (see https://docs.seerr.dev/migration-guide).
+
+
+  Key highlights and improvements:
+    - Overseerr and Jellyseerr projects merged into a single unified platform called Seerr
+    - One shared codebase and team moving forward for faster development and maintenance
+    - Continued support for Plex, Jellyfin, and Emby media server ecosystems
+    - Container now runs as non-root (UID 1000); existing data ownership is fixed automatically by a pre-start hook
+    - Rebranding and infrastructure updates as part of the new project foundation
+    - Various improvements and bug fixes
+
+
+  Full release notes are available at https://github.com/seerr-team/seerr/releases
 torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/607


### PR DESCRIPTION
Mirrors PR #4993 (which updated the `jellyseerr/` folder to Seerr v3.2.0) for the `overseerr/` folder. Closes #5518.

## Why

The Overseerr and Jellyseerr projects were merged upstream into a single project called **Seerr**. PR #4993 handled the `jellyseerr/` side; this PR handles the `overseerr/` side so that users with the Overseerr app installed on Umbrel get an in-place update path instead of being stranded on `linuxserver/overseerr:1.35.0`.

The Seerr image automatically migrates an existing Overseerr config directory on first start — no manual data migration required (see https://docs.seerr.dev/migration-guide).

## Changes

- `overseerr/docker-compose.yml`
  - image: `linuxserver/overseerr:1.35.0` → `ghcr.io/seerr-team/seerr:v3.2.0`
  - dropped `PUID`/`PGID` env, added `user: "1000:1000"` and `init: true` (required by Seerr v3.0.0+)
  - container mount path `/config` → `/app/config` (host path `${APP_DATA_DIR}/data/config` unchanged, so existing config is preserved)
  - added healthcheck (matches `jellyseerr/`)
- `overseerr/hooks/pre-start` (new, executable)
  - `chown -R 1000:1000` on the data dir so existing root-owned Overseerr data is readable by the non-root Seerr container
- `overseerr/umbrel-app.yml`
  - `manifestVersion`: 1 → 1.1
  - `name`: Overseerr → Seerr
  - `version`: 1.35.0 → 3.2.0
  - `developer`/`website`/`repo`/`support`: pointed at the Seerr project
  - `tagline`/`description`/`releaseNotes`: updated, with migration note
  - `port: 5055` kept (avoids breaking bookmarks; jellyseerr-side uses 5056 so no host-port conflict if a user had both apps installed)

## Open question for maintainers

After this PR + #4993, both `jellyseerr/` and `overseerr/` folders will have `name: Seerr` and the App Store will show two listings called "Seerr" (different `id`s). Three options:
1. **Accept the duplicate** as a transitional state, with a follow-up PR later to deprecate one of the folders once usage drains.
2. **Differentiate display names** — e.g. keep this one as "Seerr (Overseerr migration)" or similar.
3. **Mark the overseerr app as deprecated** instead of updating it, and direct users to install the Seerr (jellyseerr) app and copy their config across.

Happy to amend this PR to whichever option is preferred. As-is it mirrors #4993 most closely (option 1).

## Notes

- Gallery (`1.jpg`/`2.jpg`/`3.jpg`) left untouched — these are the old Overseerr screenshots and likely warrant the "awaiting gallery assets" label like #4993 got.