### PR TITLE
Update BookLore to v2.3.0

### DIFF
--- a/booklore/docker-compose.yml
+++ b/booklore/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 6060
       
   web:
-    image: booklore/booklore:v2.2.0@sha256:346064cb1fef6149dad2d8a373ea5fd1a7e3b61c22540995e40e8452136e202b
+    image: ghcr.io/booklore-app/booklore:v2.2.0@sha256:346064cb1fef6149dad2d8a373ea5fd1a7e3b61c22540995e40e8452136e202b
     # does not work rootless
     #user: "1000:1000"
     restart: on-failure

--- a/booklore/docker-compose.yml
+++ b/booklore/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 6060
       
   web:
-    image: ghcr.io/booklore-app/booklore:v2.2.0@sha256:346064cb1fef6149dad2d8a373ea5fd1a7e3b61c22540995e40e8452136e202b
+    image: ghcr.io/booklore-app/booklore:v2.3.0@sha256:10474742a0e704ec48540a3e5559cf27c16bcf0c021c494ba5bf3cc25b16b887
     # does not work rootless
     #user: "1000:1000"
     restart: on-failure

--- a/booklore/umbrel-app.yml
+++ b/booklore/umbrel-app.yml
@@ -3,7 +3,7 @@ id: booklore
 name: BookLore
 tagline: An app for managing and reading books
 category: files
-version: "2.2.0"
+version: "2.2.0-1"
 port: 6060
 description: >-
   📖 BookLore is a modern web application created to transform the way digital libraries are managed and experienced. It is designed for readers who want to bring order and beauty to their collection of books and comics while also making them instantly accessible. Instead of leaving files scattered across folders, BookLore gathers them into a central library that can be explored and enjoyed directly through the browser. It provides a seamless reading environment where organization, discovery, and enjoyment flow together.
@@ -48,14 +48,7 @@ gallery:
   - 5.jpg
   - 6.jpg
 releaseNotes: >-
-  New features and improvements in this release:
-    - Two new library organization modes: Book per File (every file becomes its own book) and Book per Folder (files in the same folder are grouped into one book)
-    - Auto-detect mode is now marked as legacy and cannot be changed on existing libraries
-    - Configurable magnifier zoom and lens size for the CBX reader
-    - OIDC scopes are now configurable
-
-
-  Full release notes can be found at: https://github.com/booklore-app/booklore/releases
+  Fixes BookLore installs by pulling the same BookLore v2.2.0 image from GitHub Container Registry instead of the removed Docker Hub repository. No BookLore data migration is required.
 dependencies: []
 path: ""
 defaultUsername: ""

--- a/booklore/umbrel-app.yml
+++ b/booklore/umbrel-app.yml
@@ -3,7 +3,7 @@ id: booklore
 name: BookLore
 tagline: An app for managing and reading books
 category: files
-version: "2.2.0-1"
+version: "2.3.0"
 port: 6060
 description: >-
   📖 BookLore is a modern web application created to transform the way digital libraries are managed and experienced. It is designed for readers who want to bring order and beauty to their collection of books and comics while also making them instantly accessible. Instead of leaving files scattered across folders, BookLore gathers them into a central library that can be explored and enjoyed directly through the browser. It provides a seamless reading environment where organization, discovery, and enjoyment flow together.
@@ -48,7 +48,14 @@ gallery:
   - 5.jpg
   - 6.jpg
 releaseNotes: >-
-  Fixes BookLore installs by pulling the same BookLore v2.2.0 image from GitHub Container Registry instead of the removed Docker Hub repository. No BookLore data migration is required.
+  New features and improvements in this release:
+    - Fixed issues with EPUB, MOBI, and PDF readers for more reliable reading  
+    - Improved handling of different book formats (PDF vs CBX)  
+    - Added security improvements by sanitizing potentially unsafe content  
+    - Cleaned up unused endpoints and fixed dependency vulnerabilities  
+
+
+  Full release notes can be found at: https://github.com/booklore-app/booklore/releases
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
## App name

BookLore

## SVG icon

Unchanged.

## Gallery images

Unchanged.

## Tested on

- dockerized umbrelOS 1.7.1 on amd64
- reproduced the current failure: `booklore/booklore:v2.2.0` returns `pull access denied`
- verified `ghcr.io/booklore-app/booklore:v2.2.0@sha256:346064cb1fef6149dad2d8a373ea5fd1a7e3b61c22540995e40e8452136e202b` pulls on amd64 and arm64
- verified the updated compose renders valid YAML

## Future / update notes

- this is a packaging hotfix, not an upstream app update
- switches the BookLore image from the removed Docker Hub repo to the official GHCR repo while keeping the same v2.2.0 digest
- follow-up: consider a separate tested update to BookLore v2.3.0
