### PR TITLE
App Submission: Readeck

### DIFF
--- a/readeck/docker-compose.yml
+++ b/readeck/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: readeck_web_1
+      APP_PORT: 8000
+      PROXY_AUTH_ADD: "true"
+  
+  web:
+    image: codeberg.org/readeck/readeck:0.22.3@sha256:ed1c513f8e1d59b1d38fda324ac279eeb65afd0327907e498061ec9fd2f31c15
+    restart: on-failure
+    stop_grace_period: 1m
+    volumes:
+      - ${APP_DATA_DIR}/data:/readeck
+    environment:
+      READECK_LOG_LEVEL: info
+      READECK_SERVER_HOST: "0.0.0.0"
+      READECK_SERVER_PORT: 8000
+      READECK_LOG_FORMAT: text
+      READECK_SECRET_KEY: ${APP_SEED}
+    healthcheck:
+      test: ["CMD", "/bin/readeck", "healthcheck", "-config", "config.toml"]
+      interval: 30s
+      timeout: 2s
+      retries: 3

--- a/readeck/docker-compose.yml
+++ b/readeck/docker-compose.yml
@@ -9,6 +9,7 @@ services:
   
   web:
     image: codeberg.org/readeck/readeck:0.22.3@sha256:ed1c513f8e1d59b1d38fda324ac279eeb65afd0327907e498061ec9fd2f31c15
+    user: 1000:1000
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/readeck/umbrel-app.yml
+++ b/readeck/umbrel-app.yml
@@ -1,0 +1,48 @@
+manifestVersion: 1
+id: readeck
+category: files
+name: Readeck
+version: "0.22.3"
+tagline: Save web pages to read and keep forever
+description: >-
+  Readeck is a simple web application that lets you save the precious readable content of web pages you like and want to keep forever. See it as a bookmark manager and a read later tool.
+
+
+  **Features**
+
+  - **🔖 Bookmarks** - Like a page you're reading? Paste the link in Readeck and you're done!
+  
+  - **📸 Articles, pictures and videos** - Readeck saves the readable content of web pages for you to read later. It also detects when a page is an image or a video and adapts its process accordingly.
+  
+  - **⭐ Labels, favorites, archives** - Move bookmarks to archives or favorites and add as many labels as you want.
+  
+  - **🖍️ Highlights** - Highlight the important content of your bookmarks to easily find it later.
+  
+  - **🗃️ Collections** - If you need a dedicated section with all your bookmarks from the past 2 weeks labeled with "cat", Readeck lets you save this search query into a collection so you can access it later.
+  
+  - **🧩 Browser Extension** - Want to keep something for later while browsing? No need to copy and paste a link. Install the browser extension and save bookmarks in one click!
+  
+  - **📖 E-Book export** - What's better than reading your collected articles on your e-reader? You can export any article to an e-book file (EPUB). You can even export a collection to a single book!
+
+    On top of that, you can directly access Readeck's catalog and collections from your e-reader if it supports OPDS.
+  
+  - **🔎 Full text search** - Whether you need to find a vague piece of text from an article, or all the articles with a specific label or from a specific website, we've got you covered!
+  
+  - **🚀 Fast!** - Readeck is a modern take on so-called boring, but proven, technology pieces. It guarantees very quick response times and a smooth user experience.
+  
+  - **🔒 Built for your privacy and long term archival** - Will this article you like be online next year? In 10 year? Maybe not; maybe it's all gone, text and images. For this reason, and for your privacy, text and images are all stored in your Readeck instance the moment you save a link.
+
+    With the exception of videos, not a single request is made from your browser to an external website.
+releaseNotes: ""
+developer: Readeck
+website: https://readeck.org
+dependencies: []
+repo: https://codeberg.org/readeck/readeck
+support: https://readeck.org/en/docs/faq
+port: 8000
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: vitto4
+submission: https://github.com/getumbrel/umbrel-apps/pull/TODO

--- a/readeck/umbrel-app.yml
+++ b/readeck/umbrel-app.yml
@@ -45,4 +45,4 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: vitto4
-submission: https://github.com/getumbrel/umbrel-apps/pull/TODO
+submission: https://github.com/getumbrel/umbrel-apps/pull/5580

--- a/readeck/umbrel-app.yml
+++ b/readeck/umbrel-app.yml
@@ -39,7 +39,7 @@ website: https://readeck.org
 dependencies: []
 repo: https://codeberg.org/readeck/readeck
 support: https://readeck.org/en/docs/faq
-port: 8000
+port: 8026
 gallery: []
 path: ""
 defaultUsername: ""

--- a/readeck/umbrel-app.yml
+++ b/readeck/umbrel-app.yml
@@ -40,7 +40,11 @@ dependencies: []
 repo: https://codeberg.org/readeck/readeck
 support: https://readeck.org/en/docs/faq
 port: 8026
-gallery: []
+gallery:
+  - 1.webp
+  - 2.webp
+  - 3.webp
+  - 4.webp
 path: ""
 defaultUsername: ""
 defaultPassword: ""


### PR DESCRIPTION
# App Submission

### App name
Readeck

### 256x256 SVG icon
https://codeberg.org/readeck/readeck/src/branch/main/web/media/logo.svg

### Gallery images
https://codeberg.org/readeck/readeck/src/branch/main/screenshots/bookmark-list.webp
https://codeberg.org/readeck/readeck.org/src/branch/main/src/en/blog/202602-readeck-22/bookmark-edit.webp
https://codeberg.org/readeck/readeck.org/src/branch/main/src/en/blog/202402-readeck-12/fonts.webp
https://codeberg.org/readeck/readeck.org/src/branch/main/src/media/img/highlights.webp
https://codeberg.org/readeck/readeck.org/src/branch/main/src/media/img/label-list.webp

### Notes
- I believe port `8000` clashes with _ZeroNote_, so it might be better to change it ?
- For the category I wasn't too sure, is `file` ok ? (same as _Karakeep_)
- The tagline from the official repo (`Readeck is a simple web application that lets you save the precious readable content of web pages you like and want to keep forever.`) felt a bit long by Umbrel app store standards, so I tried to shorten it.
- Readeck's [configuration page](https://readeck.org/en/docs/configuration) recommends :
  > If you're running Readeck and a reverse proxy on the same host, you can set `trusted_proxies` to ["127.0.0.1"].

  But if I'm not mistaken, the Umbrel app proxy operates on `10.0.0.0/8`, which is included in readeck's default, so I left it unchanged.
- First time packaging for umbrelOS, hopefully I got it right hehe

### I have tested my app on:
- [x] umbrelOS on a Raspberry Pi
- [ ] umbrelOS on an Umbrel Home
- [ ] umbrelOS on Linux VM