### PR TITLE
canary: Update to v1.5.0

### DIFF
--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.5.0-test-db42e33@sha256:c12398726cebb1b651bda96ce46cf149c88008e921d761f639fbe6745ffb57df
+    image: schjonhaug/canary-backend:v1.5.0@sha256:e2a9646e70f2aa94db8aedfe5bfdf3b25cee0043cfd29336dc893d2ad90a11a8
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -26,7 +26,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.5.0-test-db42e33@sha256:72fc6f1def8d95a7df1614e1c143b274644010402d27a651da9062911e57b138
+    image: schjonhaug/canary-frontend:v1.5.0@sha256:565d0b07d22afafb2740be98e2598e194b9811989dc501029c3fc37a7ac5dbbc
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.4.0@sha256:daf6920e1f0ff781c526fa92ee0e39720dd1b18b5d7e1bcdd0aeff0cb76a68ad
+    image: schjonhaug/canary-backend:v1.5.0-test-db42e33@sha256:c12398726cebb1b651bda96ce46cf149c88008e921d761f639fbe6745ffb57df
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -20,11 +20,13 @@ services:
       CANARY_MODE: "self-hosted"
       CANARY_SYNC_INTERVAL: 60
       CANARY_MEMPOOL_PORT: ${APP_CANARY_MEMPOOL_PORT:-}
+      CANARY_SELF_HOSTED_ADMIN_PASSWORD: ${APP_PASSWORD}
+      JWT_SECRET: ${APP_SEED}
     volumes:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.4.0@sha256:5c273df8bf4dc16af0edc8f6d48519ecffb4a76b49ad8eb0cef99259c6188511
+    image: schjonhaug/canary-frontend:v1.5.0-test-db42e33@sha256:72fc6f1def8d95a7df1614e1c143b274644010402d27a651da9062911e57b138
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: canary
 category: bitcoin
 name: Canary
-version: "1.4.0"
+version: "1.5.0"
 tagline: Early warning system for Bitcoin cold storage
 description: >-
   A canary in the cold mine. When your bitcoins are in cold storage, you seldom check on them.
@@ -29,7 +29,7 @@ gallery:
 releaseNotes: >-
   Monitor individual Bitcoin addresses alongside HD wallets, with automatic transaction lookup via your local Mempool instance when installed on Umbrel. Added the ability to test your ntfy notification setup directly from the app.
 path: ""
-defaultUsername: ""
-defaultPassword: ""
+defaultUsername: "admin@local"
+deterministicPassword: true
 submitter: schjonhaug
 submission: https://github.com/getumbrel/umbrel-apps/pull/4117

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -44,6 +44,7 @@ releaseNotes: >-
 
 
   Full release notes can be found at https://github.com/schjonhaug/canary/releases
+path: ""
 defaultUsername: "admin@local"
 deterministicPassword: true
 submitter: schjonhaug

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -27,7 +27,7 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  Monitor individual Bitcoin addresses alongside HD wallets, with automatic transaction lookup via your local Mempool instance when installed on Umbrel. Added the ability to test your ntfy notification setup directly from the app.
+  This update fixes self-hosted sign-in, sign-out, auth token recovery, and session validation; adds transaction explorer selection and dark mode; improves wallet transaction performance, sync progress, mobile layouts, and accessibility; and fixes transaction list layout, translated API errors, and recurring donation configuration.
 path: ""
 defaultUsername: "admin@local"
 deterministicPassword: true

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -27,8 +27,23 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  This update fixes self-hosted sign-in, sign-out, auth token recovery, and session validation; adds transaction explorer selection and dark mode; improves wallet transaction performance, sync progress, mobile layouts, and accessibility; and fixes transaction list layout, translated API errors, and recurring donation configuration.
-path: ""
+  This release focuses on authentication fixes, UI enhancements, and performance improvements.
+
+
+  Key features and improvements:
+    - Fixed self-hosted sign-in and sign-out functionality
+    - Fixed auth token recovery and session validation
+    - Added transaction explorer selection feature
+    - Added dark mode support
+    - Improved wallet transaction performance
+    - Improved sync progress indicators
+    - Improved mobile layouts and accessibility
+    - Fixed transaction list layout issues
+    - Fixed translated API error messages
+    - Fixed recurring donation configuration
+
+
+  Full release notes can be found at https://github.com/schjonhaug/canary/releases
 defaultUsername: "admin@local"
 deterministicPassword: true
 submitter: schjonhaug


### PR DESCRIPTION
## Summary
- Update Canary to v1.5.0 with official backend/frontend image tags and digests
- Pass Umbrel's deterministic app password to Canary as `CANARY_SELF_HOSTED_ADMIN_PASSWORD`
- Derive `JWT_SECRET` from Umbrel's per-app seed so sessions survive restarts
- Show Umbrel-managed credentials with `admin@local` and `deterministicPassword: true`

## What's New
This update fixes self-hosted sign-in, sign-out, auth token recovery, and session validation; adds transaction explorer selection and dark mode; improves wallet transaction performance, sync progress, mobile layouts, and accessibility; and fixes transaction list layout, translated API errors, and recurring donation configuration.

## Test plan
- [x] Built and pushed official multi-arch Canary v1.5.0 backend/frontend images
- [x] Synced the patched Canary app package to a real Umbrel instance
- [x] Verified Umbrel displayed generated credentials
- [x] Verified login with `admin@local` and the Umbrel-generated password
- [x] Verified the same password still worked after restarting Canary
- [x] Verified upgrade from v1.4.0 to v1.5.0 on Umbrel
