### PR TITLE
Update Bitcoin Node to 1.3.0

### DIFF
--- a/bitcoin/docker-compose.yml
+++ b/bitcoin/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   app:
-    image: ghcr.io/getumbrel/umbrel-bitcoin:v1.2.2@sha256:bc72c7fe705c582b8be1740c52449ac82de4d40b0e91ea090513aac6d4fc9393
+    image: ghcr.io/getumbrel/umbrel-bitcoin:v1.3.0@sha256:a684213f37985b987c07a4d10cc9d04396eb2eb2a25f6b210052bb102950d7fe
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 15m30s
@@ -22,10 +22,11 @@ services:
       # BITCOIN_DIR: bitcoin-dir-override
       # APP_STATE_DIR: app-state-dir-override
 
-      # BITCOIND BINARY SETTINGS
+      # BITCOIN CORE BINARY SETTINGS
       # BITCOIND_BIN: bitcoind-binary-path-override
-      # BITCOIND_EXTRA_ARGS is a comma-delimited list of extra startup flags to pass to bitcoind
-      # We can remove depratedrpc=create_bdb in a future update once Jam (JoinMarket) implements descriptor wallet support
+      # BITCOIN_BIN: bitcoin-wrapper-binary-path-override
+      # BITCOIND_EXTRA_ARGS is a comma-delimited list of extra startup flags to pass to Bitcoin Core
+      # We can remove deprecatedrpc=create_bdb in a future update once Jam (JoinMarket) implements descriptor wallet support
       # Bitcoin Core v30 no longer supports legacy bdb wallets, so Jam users will need to run v29.2 for compatibility
       BITCOIND_EXTRA_ARGS: '-deprecatedrpc=create_bdb'
 

--- a/bitcoin/exports.sh
+++ b/bitcoin/exports.sh
@@ -23,7 +23,17 @@ export APP_BITCOIN_ZMQ_HASHTX_PORT="28336"
 # NETWORK
 export APP_BITCOIN_NETWORK="mainnet" 
 
-# Check for an existing settings.json file to override APP_BITCOIN_NETWORK with user's choice
+# IPC
+# Consumers should mount APP_BITCOIN_DATA_DIR read-only, for example:
+#   ${APP_BITCOIN_DATA_DIR}:/root/.bitcoin:ro
+# Then resolve the socket inside that mount:
+#   /root/.bitcoin/${APP_BITCOIN_IPC_SOCKET_RELATIVE_PATH}
+# Do not bind-mount the socket directly because Docker may create a directory
+# at the source path if the socket does not exist yet.
+export APP_BITCOIN_IPC_ENABLED="false"
+export APP_BITCOIN_IPC_SOCKET_RELATIVE_PATH="node.sock"
+
+# Check for an existing settings.json file to override exports with the user's saved settings
 {
 	BITCOIN_APP_CONFIG_FILE="${EXPORTS_APP_DIR}/data/app/settings.json"
 	if [[ -f "${BITCOIN_APP_CONFIG_FILE}" ]]
@@ -45,8 +55,27 @@ export APP_BITCOIN_NETWORK="mainnet"
 					echo "Warning (${EXPORTS_APP_ID}): Invalid network '${bitcoin_app_network}' in settings.json. Exporting APP_BITCOIN_NETWORK as default 'mainnet'."
 				fi;;
 		esac
+
+		bitcoin_app_ipc=$(jq -r '.ipc // false' "${BITCOIN_APP_CONFIG_FILE}")
+		if [[ "$bitcoin_app_ipc" == "true" ]]; then
+			APP_BITCOIN_IPC_ENABLED="true"
+		fi
 	fi
 } > /dev/null || true
+
+case $APP_BITCOIN_NETWORK in
+	"testnet")
+		APP_BITCOIN_IPC_SOCKET_RELATIVE_PATH="testnet3/node.sock";;
+	"testnet4")
+		APP_BITCOIN_IPC_SOCKET_RELATIVE_PATH="testnet4/node.sock";;
+	"signet")
+		APP_BITCOIN_IPC_SOCKET_RELATIVE_PATH="signet/node.sock";;
+	"regtest")
+		APP_BITCOIN_IPC_SOCKET_RELATIVE_PATH="regtest/node.sock";;
+esac
+
+export APP_BITCOIN_IPC_ENABLED
+export APP_BITCOIN_IPC_SOCKET_RELATIVE_PATH
 
 # .env file to persist the rpc username and password
 BITCOIN_ENV_FILE="${EXPORTS_APP_DIR}/.env"

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bitcoin
 category: bitcoin
 name: Bitcoin Node
-version: "1.2.2"
+version: "1.3.0"
 tagline: Run your personal node powered by Bitcoin Core
 description: >-
   Run your Bitcoin node, powered by Bitcoin Core. Independently store and validate every Bitcoin transaction.
@@ -36,7 +36,7 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This update fixes an issue that could cause the Bitcoin Node app to crash and restart unexpectedly.
+  This update adds Bitcoin Core v31.0 and an optional IPC mining interface for Stratum V2 apps.
 widgets:
   - id: "stats"
     type: "four-stats"

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -37,6 +37,9 @@ path: ""
 defaultPassword: ""
 releaseNotes: >-
   This update adds Bitcoin Core v31.0 and an optional IPC mining interface for Stratum V2 apps.
+
+
+  Note: If you have previously selected a specific Bitcoin Core version in the app settings, your node will continue using that selected version and will not automatically switch to v31.0. You can switch to v31.0 from the settings at any time.
 widgets:
   - id: "stats"
     type: "four-stats"


### PR DESCRIPTION
Updates Bitcoin Node to `v1.3.0`, adding Bitcoin Core `v31.0` and IPC exports for Stratum V2 apps. This is a draft PR for testing.