### PR TITLE
Add WebCheck release notes link

### DIFF
--- a/webcheck/umbrel-app.yml
+++ b/webcheck/umbrel-app.yml
@@ -48,6 +48,9 @@ releaseNotes: >-
     - Fixed screenshot API behavior and broken footer links
     - Improved security by replacing shell command execution with safer command handling
     - Improved handling of non-JSON API responses and security.txt checks
+
+
+  Full release notes can be found at https://github.com/Lissy93/web-check/releases/
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
## Summary

Adds the upstream WebCheck 2.1.0 release notes link to the bottom of the app update notes.