### PR TITLE
Update Alby Hub to v1.22.2

### DIFF
--- a/albyhub/docker-compose.yml
+++ b/albyhub/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       APP_HOST: albyhub_server_1
       APP_PORT: 8080
   server:
-    image: ghcr.io/getalby/hub:v1.21.6@sha256:dc05806a3384f57ded8aca2ba58d47ec93a0aeb213539b5faf32e7a3c71b5c32
+    image: ghcr.io/getalby/hub:v1.22.2@sha256:acf158edbb9348a8f84e02ffc97919692bc40280e7d28d501b1fc3d23d7ac266
     user: 1000:1000
     volumes:
       - ${APP_DATA_DIR}/data:/data
@@ -17,6 +17,7 @@ services:
       LND_MACAROON_FILE: ${APP_ALBYHUB_LND_MACAROON_FILE}
       WORK_DIR: "/data/albyhub"
       COOKIE_SECRET: ${APP_SEED}
+      HIDE_UPDATE_BANNER: "true"
       LOG_EVENTS: "true"
     restart: on-failure
     stop_grace_period: 3m

--- a/albyhub/umbrel-app.yml
+++ b/albyhub/umbrel-app.yml
@@ -3,7 +3,7 @@ id: albyhub
 name: Alby Hub ✨
 tagline: Self-custodial Lightning wallet with integrated node and app connections
 category: bitcoin
-version: "1.21.6"
+version: "1.22.2"
 port: 59000
 description: >-
   Alby Hub is an open-source, self-custodial Bitcoin Lightning wallet, with the easiest-to-use Lightning Network node for everyone.
@@ -40,13 +40,11 @@ gallery:
   - 4.jpg
 releaseNotes: >-
   Key changes in this release:
-    - Updated Boltz dependency for improved swap functionality
-    - Swap-outs (Lightning to on-chain) now only require 1 on-chain confirmation instead of 2
-    - Added Alby's referral program to the earn page
-    - Added Castamatic to the app store
-    - Increased default Alby Account budget from 150k to 250k sats
-    - Removed Bitcoin Maxi Mode
-    - Added a 404 page
+    - Added AI & Agents page
+    - Added integrated on-chain wallet mode
+    - Added custom user labels for transactions
+    - Redesigned settings pages and improved app connection budget selection
+    - Added Core Lightning backend support
     - Various bugfixes and minor improvements
 
 


### PR DESCRIPTION
Updates Alby Hub to v1.22.2.

Changes:
- Bumps `albyhub/umbrel-app.yml` version and release notes
- Bumps Docker image to `ghcr.io/getalby/hub:v1.22.2@sha256:acf158edbb9348a8f84e02ffc97919692bc40280e7d28d501b1fc3d23d7ac266`
- Sets `HIDE_UPDATE_BANNER=true` because Umbrel manages app updates

Upstream release: https://github.com/getAlby/hub/releases/tag/v1.22.2
Related Alby issue: https://github.com/getAlby/hub/issues/2282
