### PR TITLE
Update Monero daemon to v0.18.5.0

### DIFF
--- a/monero/docker-compose.yml
+++ b/monero/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     restart: unless-stopped
     stop_grace_period: 15m
     command: "${APP_MONERO_COMMAND}"
-    image: ghcr.io/sethforprivacy/simple-monerod:v0.18.4.6@sha256:ed9299d73634a13f10de85e63d104276bf5e4ce5175ee4cc16f64f4bbeacbbd4
+    image: ghcr.io/sethforprivacy/simple-monerod:v0.18.5.0@sha256:54b68cae321119c794930af32e4fec6772d9bd9e5a2b1a2e2b8efcf49ae68d8f
     ports:
       - "${APP_MONERO_P2P_PORT}:${APP_MONERO_P2P_PORT}"
       - "${APP_MONERO_RPC_PORT}:${APP_MONERO_RPC_PORT}"

--- a/monero/umbrel-app.yml
+++ b/monero/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: monero
 category: crypto
 name: Monero Node
-version: "0.18.4.6"
+version: "0.18.5.0"
 tagline: Run a monero node
 description: >-
   Run your monero node and independently store and validate every single Monero transaction with it.
@@ -23,14 +23,29 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This is the v0.18.4.6 release of the Monero software. This release contains bug fixes.
+  This is the v0.18.5.0 release of the Monero software.
+  This recommended release adds SOCKS v5 support, removes UPnP support, and includes a large number of bug fixes.
 
 
 
   Some highlights of this release are:
-    - Daemon: fix bug in peer list filter
-    - Daemon: p2p connection bug fixes
-    - Multisig: fix key exchange failure in monero-gen-trusted-multisig
-    - Minor bug fixes and improvements
+    - Add SOCKS v5 support to daemon and wallet
+    - Daemon: remove UPnP support
+    - Daemon: fix shutdown hangs
+    - Daemon: improve exception handling
+    - Daemon: speed up transaction pool get_complement() for large requests
+    - Daemon: restrict add_aux_pow RPC
+    - ZMQ: add restricted RPC mode
+    - ZMQ: fix txpool transaction reporting for stem-phase transactions
+    - ZMQ: notify txpool event when stem transaction bumps to fluff
+    - Wallet: improve proof validation
+    - Wallet: add option to skip refresh after multisig import
+    - Wallet: add change address sanity check
+    - Wallet RPC: add source info to describe_transfer
+    - Wallet RPC: fix set_daemon allowed SSL fingerprints parsing
+    - Wallet RPC: restrict sensitive methods in --restricted-rpc mode
+    - Harden HTTP client authentication handling
+    - Add LoongArch build support
+    - Various bug fixes and improvements
 
-  Further details can be found at https://www.getmonero.org/2026/03/04/monero-0.18.4.6-released.html
+  For more details navigate to https://www.getmonero.org/2026/05/11/monero-0.18.5.0-released.html


### PR DESCRIPTION
This is the v0.18.5.0 release of the Monero software.
This recommended release adds SOCKS v5 support, removes UPnP support, and includes a large number of bug fixes.

Reference: https://github.com/monero-project/monero/releases/tag/v0.18.5.0