### PR TITLE
Update Core Lightning to 26.04.1

### DIFF
--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_HOST: $APP_CORE_LIGHTNING_IP
       APP_PORT: $APP_CORE_LIGHTNING_PORT
   app:
-    image: ghcr.io/elementsproject/cln-application:25.07.3@sha256:af22cebd21e1175651049d09cf2dd547da569fddd55e4c7766e5956bd47e91fa
+    image: ghcr.io/elementsproject/cln-application:26.04@sha256:78f92a973be7e756ad6b3325262ff689512bd2711c80fd5aac5e7f56eb9fb6d7
     command: npm run start
     restart: on-failure
     volumes:
@@ -19,6 +19,8 @@ services:
       BITCOIN_NETWORK: ${APP_CORE_LIGHTNING_BITCOIN_NETWORK}
       LIGHTNING_HOST: ${APP_CORE_LIGHTNING_DAEMON_IP}
       LIGHTNING_TOR_HOST: ${APP_CORE_LIGHTNING_HIDDEN_SERVICE}
+      LIGHTNING_WS_HOST: ${APP_CORE_LIGHTNING_DAEMON_IP}
+      LIGHTNING_WS_TOR_HOST: ${APP_CORE_LIGHTNING_HIDDEN_SERVICE}
       APP_CONNECT: COMMANDO
       APP_MODE: ${APP_MODE}
       LIGHTNING_DATA_DIR: ${CORE_LIGHTNING_PATH}
@@ -47,7 +49,7 @@ services:
       default:
         ipv4_address: ${APP_CORE_LIGHTNING_IP}
   lightningd:
-    image: elementsproject/lightningd:v25.09.3@sha256:ca95610b7db23a8fad5cf6e36044ecd4ff9124dcc7dae50bd151084d39feaf70
+    image: elementsproject/lightningd:v26.04.1@sha256:29a2b1df82d04675be289656d0fe681b587acd38bb8e203d00f226cad84ef73d
     restart: on-failure
     ports:
       - ${APP_CORE_LIGHTNING_DAEMON_PORT}:9735

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: core-lightning
 category: bitcoin
 name: Core Lightning
-version: "25.09.3-hotfix.1"
+version: "26.04.1"
 tagline: Run your personal Core Lightning node
 description: >-
   Get started with the Lightning network today with Core Lightning - a
@@ -32,34 +32,19 @@ defaultPassword: ""
 submitter: Blockstream
 submission: https://github.com/getumbrel/umbrel-apps/pull/475
 releaseNotes: >-
-  This hotfix release fixes an issue where users were unable to connect external wallet clients to their Core Lightning node.
-  If you were previously unable to connect a wallet, please go to "Settings" in the top right > Connect wallet > and select your desired connection method to see corrected connection details.
+  This updates Core Lightning to v26.04.1 and CLN Application to v26.04.
 
 
-  **Previous release notes:**
+  **CLN Application v26.04:**
+    - Adds custom fee rates for channel opening and withdrawals.
+    - Adds Bookkeeper filtering and SQL terminal result display improvements.
+    - Improves channel pending-state tooltips and close-channel handling.
+    - Fixes withdrawal fee animation, responsive layout issues, and request parameter typing.
 
 
-  This updates cln-application to v25.07.3, lightningd to v25.09.3, and replaces the legacy c-lightning-rest service with the built-in REST interface of lightningd.
-
-
-  **CLN Application v25.07.3:**
-    - Proactive mitigation against a widespread npm ecosystem threat involving malicious code in popular packages.
-    - Updated and streamlined environment variables for improved configuration and usability
-    - Added support for running Commando over secure WebSocket (eg. wss-proxy) connections
-    - Removed version and commit suffix from node aliases for a cleaner display
-    - Updated BKPR date format from YYYY-MM-DD to UI standard DD MMM, YYYY
-    - Added infinite scroll support for BTC Transactions, CLN Offers, and CLN Transactions
-
-  **CLN v25.09.3:**
-    - Bookkeeper has been migrated into core lightning, allowing visibility into payments, fees and channel activities.
-    - xpay can now directly pay BIP353 addresses (like ₿cln@blockstream.com) and simple offers without extra steps.
-    - Better feedback when channel creation fails due to capacity limits.
-    - Now limiting the number of parts a payment can be split on xpay and askrene
-    - Reckless now supports the modern uv package manager for Python plugins.
-    - Improvements to the rate of feasible solutions found in the main loop of the solver on askrene
-    - Splicing improvements allow for better compatibility with Eclair and continuous routing during channel modifications.
-    - Improve security by ensuring all peers must support channel type.
-    - Payment secrets now mandatory in BOLT11 invoices for better payment protection.
+  **Core Lightning v26.04.1:**
+    - Fixes malformed gossip channel announcement handling.
+    - Fixes build and protocol correctness issues found after v26.04, including ARM build fixes.
 
 backupIgnore:
   - data/lightningd/bitcoin/lightningd.sqlite3


### PR DESCRIPTION
Updates Core Lightning to `26.04.1` and the CLN Application to `26.04`.

Tested on an amd64 Umbrel device with Bitcoin Node. Core Lightning started cleanly, opened through Umbrel, and basic on-chain and Lightning wallet functionality worked as expected.

Startup logs looked normal, and the app did not hit the websocket localhost connection issue that can happen without the explicit websocket host env vars.
