### PR TITLE
Rollback RoboSats to v0.8.4-alpha

### DIFF
--- a/robosats/docker-compose.yml
+++ b/robosats/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 12596
 
   web:
-    image: recksato/robosats-client:v0.8.5-alpha@sha256:6aa0afea9f511d82faf8a7c953673d0d2a0a761f122ba1c86aa7d45ab914417e
+    image: recksato/robosats-client:v0.8.4-alpha@sha256:85bf9ace2eafbcd7c5c61f62d81423aea63ddf08375f5cbe1090392bb49e92f8
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: robosats
 category: bitcoin
 name: RoboSats
-version: "v0.8.5-alpha"
+version: "v0.8.4-alpha"
 tagline: Simple and Private Bitcoin P2P Exchange
 description: >-
   RoboSats is a simple and private app to exchange bitcoin for national currencies. 
@@ -34,25 +34,34 @@ description: >-
   You can join other cool Robots and get community support at https://t.me/robosats telegram group.
   
 releaseNotes: >-
+  Note for users who already updated to v0.8.5-alpha: v0.8.5-alpha was a pre-release, so this update returns RoboSats to v0.8.4-alpha, the latest regular release. It is safe to click update. This only changes the RoboSats app version that opens on Umbrel and does not reset your RoboSats data or require you to set up RoboSats again.
+
+
   Highlights:
 
-    - Users can now upload encrypted images in chat using the coordinator's Blossom server.
-    - Added visual warnings for orders with bonds below the default 3%.
-    - Added Doordash USA giftcard and Wero payment methods.
-    - Removed the Bitcoin Venetto and WhiteEyeSats coordinators.
-    - Library security updates.
+    - Multiple UI improvements and bug fixes.
+    - Payment methods input clears when switching to Swap.
+    - API errors are now displayed globally in toast messages.
+    - Orders are automatically sorted by premium when filtering by SELL / BUY type.
+    - Bond amount in sats is now estimated before order creation.
+    - Also includes v0.8.3-alpha additions such as new coordinators, Tor Browser configuration warning, and better order-form errors.
+
+
+  New payment methods:
+
+    - Binance Pay
+    - DANA
 
 
   Bugs:
 
-    - Infinite loading when reloading or renewing orders now properly catches up.
-    - Loading app paths other than the root no longer fails.
-    - Fixed a mobile crash when switching between Fiat and Swap modes with a payment method selected.
-    - Fixed coordinator rating count differences between list and detail views.
-    - Fixed bond and premium column overlap on some screen sizes.
-    - Successful order cancel now returns OK.
+    - Fixed typo in federation table.
+    - Fixed swap and range-order "You receive..." calculations.
+    - Fixed coordinator node app and Nostr values for WhiteEyeSats and Alice.
+    - Pin colors are now static in map view.
 
-  Full release notes are available at https://github.com/RoboSats/robosats/releases/tag/v0.8.5-alpha
+
+  Full release notes are available at https://github.com/RoboSats/robosats/releases/tag/v0.8.4-alpha
 developer: RoboSats
 website: https://learn.robosats.org
 dependencies: []


### PR DESCRIPTION
Rolls RoboSats back from the v0.8.5-alpha pre-release to v0.8.4-alpha.

This rollback only changes the RoboSats client version served by Umbrel; the app does not run a local RoboSats backend or database migration.