### PR TITLE
Update Nostr VPN to v4.0.42

### DIFF
--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 38080
 
   daemon:
-    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.40@sha256:3759602d62d5cafbde33be38bcdce9e7df43731fa33d2c3e743d9c8159c27dd3
+    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.42@sha256:161b80642cf6016bcb5cdc02a660a5b2d5bec95d6d6940427605f645f22f3284
     restart: on-failure
     stop_grace_period: 1m
     network_mode: "host"
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   web:
-    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.40@sha256:3759602d62d5cafbde33be38bcdce9e7df43731fa33d2c3e743d9c8159c27dd3
+    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.42@sha256:161b80642cf6016bcb5cdc02a660a5b2d5bec95d6d6940427605f645f22f3284
     restart: on-failure
     stop_grace_period: 1m
     depends_on:

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -30,6 +30,11 @@ gallery:
   - 1.webp
   - 2.webp
   - 3.webp
-releaseNotes: ""
+releaseNotes: >-
+  This update includes several invite and settings improvements:
+    - Fixed joining by invite on fresh installs so Nostr VPN reuses the starter network instead of creating a duplicate "Network 1"
+    - Automatically selects the joined network after importing an invite
+    - Preserves pasted iOS WireGuard upstream configs during background refreshes
+    - Clarifies public .fips routing settings and separates them from core FIPS peer settings
 submitter: mmalmi
 submission: https://github.com/getumbrel/umbrel-apps/pull/5678

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: nostr-vpn
 category: networking
 name: Nostr VPN
-version: "v4.0.40"
+version: "v4.0.42"
 tagline: Invite-only mesh VPN over Nostr
 description: >-
   Nostr VPN turns your Umbrel into a private mesh VPN node for your own devices


### PR DESCRIPTION
Updates Nostr VPN to v4.0.42.

Changes:
- Fixes joining by invite on a fresh Umbrel install: the app now uses the existing empty starter network instead of creating another "Network 1" entry.
- Selects the joined network after invite import.
- Clarifies public `.fips` routing settings and groups them separately from core FIPS peer settings.
- Preserves pasted iOS WireGuard upstream configs during background state refreshes.
- Uses the final multi-arch image: `ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.42@sha256:161b80642cf6016bcb5cdc02a660a5b2d5bec95d6d6940427605f645f22f3284`.

Tested:
- Built and pushed the multi-arch image.
- `just release-gate` passed locally, including CLI update e2e and Docker FIPS e2e.
- Web check/build, Linux cargo check, macOS debug build, and Windows build passed.
- Installed this app definition on Umbrel after deleting existing app data; containers run the pinned v4.0.42 digest, `/api/health` returns `ok`, and `nvpn version` reports `4.0.42`.