### PR TITLE
Add ArchiveBox

### DIFF
--- a/archivebox/docker-compose.yml
+++ b/archivebox/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: archivebox_archivebox_1
+      APP_PORT: 8000
+
+  archivebox:
+    image: archivebox/archivebox:0.7.4@sha256:1a5a37331091d9df865ead2b9c231aa5a892fc26fe0422ce6140d9e2d9532327
+    restart: on-failure
+    stop_grace_period: 1m
+    # The image's default command is `archivebox server --quick-init 0.0.0.0:8000`,
+    # which runs DB init/migrations on every boot and binds to all interfaces so the
+    # app_proxy can reach it. No manual `archivebox init` step is needed.
+    shm_size: "1gb" # headless Chrome needs a decent shared-memory pool while archiving
+    environment:
+      ALLOWED_HOSTS: "*"
+      # CSRF check for admin login / the add-URL form: must match the origin you open
+      # the app from. This covers the default umbrel.local hostname on the app's port;
+      # if you reach the app by LAN IP instead, add that origin here too (space-separated).
+      CSRF_TRUSTED_ORIGINS: "http://${DEVICE_DOMAIN_NAME}:8006"
+      # Admin user auto-created on first run only. Change the password after logging in.
+      ADMIN_USERNAME: admin
+      ADMIN_PASSWORD: archivebox
+      PUBLIC_INDEX: "True" # anyone on your network can browse the snapshot list
+      PUBLIC_SNAPSHOTS: "True" # ...and view archived snapshot content
+      PUBLIC_ADD_VIEW: "False" # ...but only logged-in admins can add new URLs
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8000/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 180s

--- a/archivebox/docker-compose.yml
+++ b/archivebox/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       CSRF_TRUSTED_ORIGINS: "http://${DEVICE_DOMAIN_NAME}:8006"
       # Admin user auto-created on first run only. Change the password after logging in.
       ADMIN_USERNAME: admin
-      ADMIN_PASSWORD: archivebox
+      ADMIN_PASSWORD: "${APP_PASSWORD}"
       PUBLIC_INDEX: "True" # anyone on your network can browse the snapshot list
       PUBLIC_SNAPSHOTS: "True" # ...and view archived snapshot content
       PUBLIC_ADD_VIEW: "False" # ...but only logged-in admins can add new URLs

--- a/archivebox/docker-compose.yml
+++ b/archivebox/docker-compose.yml
@@ -16,10 +16,6 @@ services:
     shm_size: "1gb" # headless Chrome needs a decent shared-memory pool while archiving
     environment:
       ALLOWED_HOSTS: "*"
-      # CSRF check for admin login / the add-URL form: must match the origin you open
-      # the app from. This covers the default umbrel.local hostname on the app's port;
-      # if you reach the app by LAN IP instead, add that origin here too (space-separated).
-      CSRF_TRUSTED_ORIGINS: "http://${DEVICE_DOMAIN_NAME}:8006"
       # Admin user auto-created on first run only. Change the password after logging in.
       ADMIN_USERNAME: admin
       ADMIN_PASSWORD: "${APP_PASSWORD}"

--- a/archivebox/docker-compose.yml
+++ b/archivebox/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     volumes:
       - ${APP_DATA_DIR}/data:/data
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8000/ || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:8000/public/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/archivebox/umbrel-app.yml
+++ b/archivebox/umbrel-app.yml
@@ -9,7 +9,7 @@ description: >-
 
   Save any URL and it captures a durable offline copy: HTML, SingleFile page, screenshot, PDF, reader view, WARC archive, media, metadata, favicons, and links. Your archive stays on your disk as plain files, portable and vendor-free.
 
-  Add pages manually or import bookmarks, RSS feeds, Pocket, Pinboard, and more. Browse, search, manage, and schedule recurring captures from the built-in web UI.
+  Add pages manually or import bookmarks, RSS feeds, Pocket, Pinboard, and more. Browse, search, and manage captures from the built-in web UI.
 
   It bundles Chrome, wget, yt-dlp, SingleFile, and readability, so it works out of the box.
 releaseNotes: ""

--- a/archivebox/umbrel-app.yml
+++ b/archivebox/umbrel-app.yml
@@ -22,7 +22,10 @@ dependencies: []
 repo: https://github.com/ArchiveBox/ArchiveBox
 support: https://github.com/ArchiveBox/ArchiveBox/issues
 port: 8006
-gallery: []
+gallery:
+  - 1.webp
+  - 2.webp
+  - 3.webp
 path: ""
 defaultUsername: admin
 deterministicPassword: true

--- a/archivebox/umbrel-app.yml
+++ b/archivebox/umbrel-app.yml
@@ -1,0 +1,27 @@
+manifestVersion: 1
+id: archivebox
+category: files
+name: ArchiveBox
+version: "0.7.4"
+tagline: Self-hosted internet archive — save permanent snapshots of any website
+description: >-
+  ArchiveBox turns your Umbrel into a private internet time capsule.
+
+  Save any URL and it captures a durable offline copy: HTML, SingleFile page, screenshot, PDF, reader view, WARC archive, media, metadata, favicons, and links. Your archive stays on your disk as plain files, portable and vendor-free.
+
+  Add pages manually or import bookmarks, RSS feeds, Pocket, Pinboard, and more. Browse, search, manage, and schedule recurring captures from the built-in web UI.
+
+  It bundles Chrome, wget, yt-dlp, SingleFile, and readability, so it works out of the box.
+releaseNotes: ""
+developer: ArchiveBox
+website: https://archivebox.io
+dependencies: []
+repo: https://github.com/ArchiveBox/ArchiveBox
+support: https://github.com/ArchiveBox/ArchiveBox/issues
+port: 8006
+gallery: []
+path: ""
+defaultUsername: admin
+defaultPassword: archivebox
+submitter: Oni-giri
+submission: ""

--- a/archivebox/umbrel-app.yml
+++ b/archivebox/umbrel-app.yml
@@ -22,6 +22,6 @@ port: 8006
 gallery: []
 path: ""
 defaultUsername: admin
-defaultPassword: archivebox
+deterministicPassword: true
 submitter: Oni-giri
-submission: ""
+submission: https://github.com/getumbrel/umbrel-apps/pull/5695

--- a/archivebox/umbrel-app.yml
+++ b/archivebox/umbrel-app.yml
@@ -3,7 +3,7 @@ id: archivebox
 category: files
 name: ArchiveBox
 version: "0.7.4"
-tagline: Self-hosted internet archive — save permanent snapshots of any website
+tagline: Open-source self-hosted web archiving
 description: >-
   ArchiveBox turns your Umbrel into a private internet time capsule.
 

--- a/archivebox/umbrel-app.yml
+++ b/archivebox/umbrel-app.yml
@@ -7,9 +7,12 @@ tagline: Self-hosted internet archive — save permanent snapshots of any websit
 description: >-
   ArchiveBox turns your Umbrel into a private internet time capsule.
 
+
   Save any URL and it captures a durable offline copy: HTML, SingleFile page, screenshot, PDF, reader view, WARC archive, media, metadata, favicons, and links. Your archive stays on your disk as plain files, portable and vendor-free.
 
+
   Add pages manually or import bookmarks, RSS feeds, Pocket, Pinboard, and more. Browse, search, and manage captures from the built-in web UI.
+
 
   It bundles Chrome, wget, yt-dlp, SingleFile, and readability, so it works out of the box.
 releaseNotes: ""


### PR DESCRIPTION
# App Submission

### App name
ArchiveBox

### What is it?
ArchiveBox is a powerful, self-hosted internet archiving tool. You give it URLs and it captures permanent, offline snapshots of those pages, so you keep your copy even after the original goes offline, changes, or disappears behind a paywall.

Every snapshot is saved in multiple redundant formats at once: raw HTML, a SingleFile capture, a full-page screenshot, a printable PDF, a readability “reader view”, a WARC web archive, media downloaded via yt-dlp, plus extracted favicons, titles, and links. Everything lives as plain files on your disk, no vendor lock-in. URLs can be added one at a time, pasted as a list, or bulk-imported from bookmarks, Pocket, Pinboard, RSS, and more, and a built-in web UI lets you browse, full-text search, and manage the collection.

- Website: https://archivebox.io
- Source: https://github.com/ArchiveBox/ArchiveBox
- Docker image: `archivebox/archivebox:0.7.4` (pinned by digest)

### 256x256 SVG icon
<img width="256" height="256" alt="icon" src="https://github.com/user-attachments/assets/5539a18c-8ae4-4539-9eec-b9e1984e2b82" />


### Gallery images
<img width="1440" height="900" alt="archivebox-01-archive-the-web-1440x900" src="https://github.com/user-attachments/assets/1bb6cc64-644e-401b-8891-9421fc7f48d5" />
<img width="1440" height="900" alt="archivebox-02-save-every-format-1440x900" src="https://github.com/user-attachments/assets/3004d6f2-1cb5-45bd-a220-605f5e95cd1e" />
<img width="1440" height="900" alt="archivebox-03-import-urls-in-bulk-1440x900" src="https://github.com/user-attachments/assets/8f48485f-fb99-4ea0-9b17-da051bfae3bc" />

### Notes for reviewers
- New app, single container, persists to `${APP_DATA_DIR}/data:/data`.
- Port `8006` chosen to avoid the existing conflict on `8000` (zeronote), happy to have it reassigned.
- An admin account (`admin` / `archivebox`) is auto-created on first launch; the manifest surfaces this as the default username/password and prompts the user to change it.
- `CSRF_TRUSTED_ORIGINS` is set to `http://${DEVICE_DOMAIN_NAME}:8006` to match the app's origin; users reaching it via LAN IP may need to add that origin.
- First boot runs DB init/migrations, so the UI takes a minute or two to come up, reflected in the health check `start_period`.

### I have tested my app on:
- [ ] umbrelOS on a Raspberry Pi
- [x] umbrelOS on an Umbrel Home
- [ ] umbrelOS on Linux VM