### PR TITLE
Update Nostr VPN to v4.0.47

### DIFF
--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 38080
 
   daemon:
-    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.42@sha256:161b80642cf6016bcb5cdc02a660a5b2d5bec95d6d6940427605f645f22f3284
+    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.47@sha256:36948ae2717dd299e534e3762a8b1b73ec33eb643264efe2b7387c060445798a
     restart: on-failure
     stop_grace_period: 1m
     network_mode: "host"
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   web:
-    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.42@sha256:161b80642cf6016bcb5cdc02a660a5b2d5bec95d6d6940427605f645f22f3284
+    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.47@sha256:36948ae2717dd299e534e3762a8b1b73ec33eb643264efe2b7387c060445798a
     restart: on-failure
     stop_grace_period: 1m
     depends_on:

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: nostr-vpn
 category: networking
 name: Nostr VPN
-version: "v4.0.42"
+version: "v4.0.47"
 tagline: Invite-only mesh VPN over Nostr
 description: >-
   Nostr VPN turns your Umbrel into a private mesh VPN node for your own devices
@@ -31,10 +31,15 @@ gallery:
   - 2.webp
   - 3.webp
 releaseNotes: >-
-  This update includes several invite and settings improvements:
-    - Fixed joining by invite on fresh installs so Nostr VPN reuses the starter network instead of creating a duplicate "Network 1"
-    - Automatically selects the joined network after importing an invite
-    - Preserves pasted iOS WireGuard upstream configs during background refreshes
-    - Clarifies public .fips routing settings and separates them from core FIPS peer settings
+  Changes since v4.0.42:
+    - New installs can find peers more reliably: public bootstrap routing now starts enabled with IPv4, IPv6, UDP, and TCP fallback support.
+    - Fixed a bug where UDP connection errors could make busy nodes waste CPU instead of backing off cleanly.
+    - Improved fairness when many peers connect at once, so overloaded bootstrap or server nodes keep serving peers more evenly.
+    - Turning bootstrap routing off now stays off after config reloads.
+    - Fixed Add Network join request handling, including keeping "Join request sent" visible until the Add Network screen closes.
+    - Improved relay discovery and public routing settings labels so the controls describe what they actually change.
+    - Improved stability for large or saturated meshes, including safer connection cleanup and config reload behavior.
+    - Admin roster updates are now signed and verified before acceptance.
+    - Fixed route refresh error text and added stronger release dependency checks.
 submitter: mmalmi
 submission: https://github.com/getumbrel/umbrel-apps/pull/5678


### PR DESCRIPTION
## Summary
- Updates Nostr VPN from v4.0.42 to v4.0.47.
- Pins daemon and web images to ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.47@sha256:36948ae2717dd299e534e3762a8b1b73ec33eb643264efe2b7387c060445798a.
- Adds release notes covering the changes since v4.0.42.

## Testing
- Verified the pushed multi-arch image exists for linux/amd64 and linux/arm64.
- Pulled the pinned image onto an arm64 Umbrel and recreated the Nostr VPN daemon/web services.
- Confirmed /api/health returned ok.
- Confirmed /api/tick reported appVersion 4.0.47, daemonBinaryVersion 4.0.47, meshReady true, and 7 connected peers.
- Confirmed nvpn version inside the web container reported 4.0.47.
- Observed low CPU after startup: daemon about 2.8%, web 0%.