### PR TITLE
Update BFFless to version 0.1.42

### DIFF
--- a/bffless/docker-compose.yml
+++ b/bffless/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   # PostgreSQL database
   postgres:
-    image: pgvector/pgvector:0.8.2-pg17@sha256:494dff7e67e7bc2c826b94c331364978d145ebb86fd338154138b084223b7f67
+    image: pgvector/pgvector:0.8.2-pg17@sha256:feb68f4f15446397d8cac7f4fe48fe4586de83160d1fc48b46283312d1a33966
     restart: on-failure
     stop_grace_period: 30s
     environment:

--- a/bffless/docker-compose.yml
+++ b/bffless/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   # Nginx reverse proxy - serves frontend, routes API calls
   # Uses custom umbrel image with baked-in config template and setup page
   nginx:
-    image: ghcr.io/bffless/ce-nginx:umbrel@sha256:ec260bef4370c6ca1c1b67b3df4f17616ef1cac06234d74a976222b873e675ab
+    image: ghcr.io/bffless/ce-nginx:umbrel@sha256:072dcdfa90e3a1a4f2b043ddc6ce11482776865b29e76f4954dd31a3128a54fa
     restart: on-failure
     stop_grace_period: 30s
     environment:
@@ -79,7 +79,7 @@ services:
   # NestJS backend API
   # Uses custom umbrel image with baked-in entrypoint that derives keys from APP_SEED
   backend:
-    image: ghcr.io/bffless/ce-backend:umbrel@sha256:fe74728afe8fd0c5a21d3a8c03c39ca19142045f56f8d8e1b28f70963271f5bc
+    image: ghcr.io/bffless/ce-backend:umbrel@sha256:2d7da55dd7410b93e81d4918b4b89f8569c9497f921001e7d85116603415b964
     restart: on-failure
     stop_grace_period: 30s
     depends_on:
@@ -136,7 +136,7 @@ services:
 
   # React frontend (serves static files)
   frontend:
-    image: ghcr.io/bffless/ce-frontend:umbrel@sha256:92ebbf3b45a758c09bed43bb8ee5f0903d6fc12b06201ce7490b24a322b3db1e
+    image: ghcr.io/bffless/ce-frontend:umbrel@sha256:cfafdf75c261f3fc0fc0b2b03a402ff40e9f8b8f710c02422ef4deb8902027a4
     restart: on-failure
     stop_grace_period: 30s
     volumes:

--- a/bffless/umbrel-app.yml
+++ b/bffless/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bffless
 category: developer
 name: BFFless
-version: '0.1.32'
+version: '0.1.42'
 tagline: Self-hosted static site hosting platform
 description: >-
   BFFless is a self-hosted platform for hosting static websites and build artifacts from CI/CD pipelines.
@@ -33,19 +33,24 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  Updates BFFless CE from v0.1.1 to v0.1.32.
+  Updates BFFless CE from v0.1.32 to v0.1.42.
 
 
   Highlights:
-    - Native Google Calendar integration with OAuth
-    - New Account / My Sites identity hub
-    - In-page auth endpoints
-    - Project-membership gating across auth and data routes
-    - New delay and improved http_request pipeline handlers
-    - nginx startup performance improvements and various auth/UX fixes
+    - Pluggable OIDC sign-in providers (Google, Okta, Azure AD, generic)
+    - Google integration credentials moved off system_config to a per-service table; legacy /oauth/google/* aliases removed
+    - Create deployments directly from the admin UI
+    - Auto-detect basePath in the Create Deployment UI
+    - github_api pipeline handler gains a dispatch action
+    - Reset "no SMTP provider" from the UI
+    - Aliases can be created with proxyRuleSetIds via repo-browser; auto-preview aliases excluded from repo stats
+    - Subdomains served over HTTPS when PROXY_MODE=cloudflare
+    - Setup wizard cache recommendations aligned with available Redis options
+    - Auth: 'guest' accepted as a valid requiredRole
+    - Embedded Umbrel setup walkthrough video on setup pages
 
 
-  Full release notes can be found at https://github.com/bffless/ce/releases/tag/v0.1.32
+  Full release notes can be found at https://github.com/bffless/ce/releases/tag/v0.1.42
 path: ''
 defaultUsername: ''
 deterministicPassword: false


### PR DESCRIPTION
Updates BFFless from v0.1.32 → v0.1.42.

## 📺 Umbrel-specific: setup walkthrough video

The post-install setup pages now embed a short Umbrel walkthrough video — https://youtu.be/TZzXtZk2wzE — so Umbrel users get guided through Cloudflare Tunnel configuration, first-run setup, and creating their first deployment without needing to leave the app. This was added specifically to smooth the on-Umbrel install experience after several users hit friction on first launch.

## 🔐 Auth

- **Pluggable OIDC sign-in providers** (v0.1.36) — Google, Okta, Azure AD, and a generic OIDC provider can all be wired up from the admin UI
- **Google integration creds migrated off \`system_config\`** (v0.1.37 → v0.1.38) — credentials now live in a dedicated per-service table; legacy \`/oauth/google/*\` aliases removed
- Accept \`guest\` as a valid \`requiredRole\` in auth DTOs (v0.1.35)

## 🚀 Deployments & Admin UI

- **Create deployments directly from the admin UI** (v0.1.33) — no CLI or GitHub Action required for one-off uploads
- **Auto-detect \`basePath\`** in the Create Deployment dialog (v0.1.39)
- Aliases accept \`proxyRuleSetIds\` when created via the repo-browser (v0.1.39)
- Auto-preview aliases excluded from repo stats counts (v0.1.39)

## ⚙️ Pipelines

- \`github_api\` pipeline handler gains a **dispatch** action for triggering workflows (v0.1.34)

## 🛠 Setup & UX

- Reset "no SMTP provider" from the UI (v0.1.39)
- Setup wizard cache recommendations aligned with available Redis options (v0.1.40)
- Embedded Umbrel setup walkthrough video on setup pages (v0.1.42)

## 🐛 Fixes

- Serve subdomains over HTTPS when \`PROXY_MODE=cloudflare\` (v0.1.41) — fixes mixed-content on Cloudflare-tunneled Umbrel instances

Full changelog: https://github.com/bffless/ce/releases/tag/v0.1.42