### PR TITLE
Update miner-sentinel to version 1.0.3

### DIFF
--- a/miner-sentinel/docker-compose.yml
+++ b/miner-sentinel/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       retries: 5
 
   backend:
-    image: dcbert/minersentinel-backend:1.0.2@sha256:156183bdecc521e2fe1c17625d5a5c2c22978b42cec622ed0b6ff093b74870ba
+    image: dcbert/minersentinel-backend:v1.0.3@sha256:a890925f66df5b3f80334fe9d00c02f027e282d77015613a5b08925adfa5523b
     restart: on-failure
     stop_grace_period: 1m
     depends_on:
@@ -57,7 +57,7 @@ services:
       "
 
   frontend:
-    image: dcbert/minersentinel-frontend:1.0.2@sha256:5d59cff18ab6014c9373255395a9004ac84f443915b254274a816838ca4a8adf
+    image: dcbert/minersentinel-frontend:v1.0.3@sha256:e4ac190cbf5cdb9c6959b59bdff70d6135c34c18bf492b6b0303bbfd75489e59
     restart: on-failure
     stop_grace_period: 1m
     depends_on:
@@ -66,7 +66,7 @@ services:
       VITE_API_URL: "http://${DEVICE_DOMAIN_NAME}:3080"
 
   data-service:
-    image: dcbert/minersentinel-data-service:1.0.2@sha256:941a5b16f13cfc1e7c4b2333ed6a06331ab20531019038021841ee0e240cd214
+    image: dcbert/minersentinel-data-service:v1.0.3@sha256:ce4b2a955dc70e5c3fd897c910e8a7a525b6133ff37e49f0a7f7a7f6239b5bc4
     restart: on-failure
     stop_grace_period: 1m
     depends_on:

--- a/miner-sentinel/umbrel-app.yml
+++ b/miner-sentinel/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: miner-sentinel
 category: bitcoin
 name: MinerSentinel
-version: "1.0.2"
+version: "1.0.3"
 tagline: Unified monitoring dashboard for Bitaxe and Avalon Bitcoin miners
 description: >-
   MinerSentinel is a self-hosted monitoring solution designed for Bitcoin home miners running Bitaxe and Avalon Nano 3s ASIC devices. It provides a centralized dashboard to track performance, health, and profitability metrics across your entire mining fleet.
@@ -48,12 +48,10 @@ description: >-
   Designed for Umbrel with Docker containerization for easy deployment and updates.
 
 releaseNotes: >-
-  Best difficulty conversion now correctly scales up to Terahash (T) range – fixes Issue #13
-  Health bar no longer crashes when displaying certain minor values
-  More reliable online/offline status detection in Settings page
-  Enhanced best difficulty display logic in Overview Analytics
-  Avalon collectors now use stable 5-second hashrate instead of total average value
-  Frontend dependencies updated for security and performance
+  Avalon Nano 3 Support — Resolved compatibility issues with Avalon Nano 3 devices (#16)
+  UI Date Display — Fixed "Invalid Date" appearing in the interface (#17)
+  Device Stability — Fixed devices getting stuck in "Pending" state (#18)
+  Notifications — Added Discord webhook support for alerts and events (#19)
 developer: Davide Bert
 website: https://github.com/dcbert/miner-sentinel
 dependencies: []


### PR DESCRIPTION
### Summary
This PR updates miner-sentinel to version 1.0.3, bringing several important fixes and new features for better device compatibility, stability, and notifications.

### Changes

**feat**: Add Discord webhook support — Users can now receive alerts and events via Discord in addition to Telegram (#19)
**fix**: Avalon Nano 3 compatibility — Resolved connection and data collection issues with Avalon Nano 3 devices (#16)
**fix**: Invalid Date in UI — Fixed date display errors throughout the interface (#17)
**fix**: Devices stuck in "Pending" state — Improved connection handling and state management to prevent devices from getting stuck (#18)

### Technical Notes

Enhanced notification system with flexible webhook support (Discord + existing Telegram)
Improved device polling and state recovery logic for more reliable monitoring
Better frontend date formatting and error handling

_No breaking changes. These updates focus on stability, hardware compatibility, and user experience for Bitaxe and Avalon Nano users._