### PR TITLE
Update core-lightning to v26.06

### DIFF
--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       default:
         ipv4_address: ${APP_CORE_LIGHTNING_IP}
   lightningd:
-    image: elementsproject/lightningd:v26.04.1@sha256:29a2b1df82d04675be289656d0fe681b587acd38bb8e203d00f226cad84ef73d
+    image: elementsproject/lightningd:v26.06@sha256:a78b06d5143db242fa3acdb059433886fc00918ad90267571e4282c4af255977
     restart: on-failure
     ports:
       - ${APP_CORE_LIGHTNING_DAEMON_PORT}:9735

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: core-lightning
 category: bitcoin
 name: Core Lightning
-version: "26.04.1"
+version: "26.06"
 tagline: Run your personal Core Lightning node
 description: >-
   Get started with the Lightning network today with Core Lightning - a
@@ -32,19 +32,15 @@ defaultPassword: ""
 submitter: Blockstream
 submission: https://github.com/getumbrel/umbrel-apps/pull/475
 releaseNotes: >-
-  This updates Core Lightning to v26.04.1 and CLN Application to v26.04.
+  This updates Core Lightning to v26.06. CLN Application remains on v26.04.
 
 
-  **CLN Application v26.04:**
-    - Adds custom fee rates for channel opening and withdrawals.
-    - Adds Bookkeeper filtering and SQL terminal result display improvements.
-    - Improves channel pending-state tooltips and close-channel handling.
-    - Fixes withdrawal fee animation, responsive layout issues, and request parameter typing.
-
-
-  **Core Lightning v26.04.1:**
-    - Fixes malformed gossip channel announcement handling.
-    - Fixes build and protocol correctness issues found after v26.04, including ARM build fixes.
+  **Core Lightning v26.06:**
+    - Adds the `graceful`, `sendamount`, and `xkeysend` commands.
+    - Improves `xpay`, which now handles `pay` by default and supports labels and local invoice request IDs.
+    - Makes gossip handling more robust against channel update spam.
+    - Adds BOLT 12 payment proof support and updates protocol behavior, including longer channel-close waits.
+    - Deprecates several older JSON-RPC fields and commands ahead of the v27.03 `xpay` transition.
 
 backupIgnore:
   - data/lightningd/bitcoin/lightningd.sqlite3


### PR DESCRIPTION
Hey @ShahanaFarooqui, this updates Core Lightning to use lightningd 26.06. Are we good to go live with this, or are there any cln-application changes you'd like us to wait for.