### PR TITLE
bffless: update to v0.1.53

### DIFF
--- a/bffless/docker-compose.yml
+++ b/bffless/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   # Nginx reverse proxy - serves frontend, routes API calls
   # Uses custom umbrel image with baked-in config template and setup page
   nginx:
-    image: ghcr.io/bffless/ce-nginx:umbrel@sha256:072dcdfa90e3a1a4f2b043ddc6ce11482776865b29e76f4954dd31a3128a54fa
+    image: ghcr.io/bffless/ce-nginx:umbrel@sha256:c49cbce6626ba73ccf296d7e39d4e192996fb613fb11d4ff7994ef8e7115afc4
     restart: on-failure
     stop_grace_period: 30s
     environment:
@@ -79,7 +79,7 @@ services:
   # NestJS backend API
   # Uses custom umbrel image with baked-in entrypoint that derives keys from APP_SEED
   backend:
-    image: ghcr.io/bffless/ce-backend:umbrel@sha256:2d7da55dd7410b93e81d4918b4b89f8569c9497f921001e7d85116603415b964
+    image: ghcr.io/bffless/ce-backend:umbrel@sha256:c974e83fd5f1cfea84b2c35db4417f3250a2ef322af476704aef93b61176cc0c
     restart: on-failure
     stop_grace_period: 30s
     depends_on:
@@ -136,7 +136,7 @@ services:
 
   # React frontend (serves static files)
   frontend:
-    image: ghcr.io/bffless/ce-frontend:umbrel@sha256:cfafdf75c261f3fc0fc0b2b03a402ff40e9f8b8f710c02422ef4deb8902027a4
+    image: ghcr.io/bffless/ce-frontend:umbrel@sha256:f31234703e2a5baa4d913b30a26ea39077ac2283f5f0f3f90cdaab0133e91a97
     restart: on-failure
     stop_grace_period: 30s
     volumes:

--- a/bffless/umbrel-app.yml
+++ b/bffless/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bffless
 category: developer
 name: BFFless
-version: '0.1.42'
+version: '0.1.53'
 tagline: Self-hosted static site hosting platform
 description: >-
   BFFless is a self-hosted platform for hosting static websites and build artifacts from CI/CD pipelines.
@@ -33,24 +33,22 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  Updates BFFless CE from v0.1.32 to v0.1.42.
+  Updates BFFless CE from v0.1.42 to v0.1.53.
 
 
   Highlights:
-    - Pluggable OIDC sign-in providers (Google, Okta, Azure AD, generic)
-    - Google integration credentials moved off system_config to a per-service table; legacy /oauth/google/* aliases removed
-    - Create deployments directly from the admin UI
-    - Auto-detect basePath in the Create Deployment UI
-    - github_api pipeline handler gains a dispatch action
-    - Reset "no SMTP provider" from the UI
-    - Aliases can be created with proxyRuleSetIds via repo-browser; auto-preview aliases excluded from repo stats
-    - Subdomains served over HTTPS when PROXY_MODE=cloudflare
-    - Setup wizard cache recommendations aligned with available Redis options
-    - Auth: 'guest' accepted as a valid requiredRole
-    - Embedded Umbrel setup walkthrough video on setup pages
+    - Accept multiple proxy rule sets when creating a deployment
+    - Choose 301 or 302 status for redirect-type domains
+    - Custom-domain sign-ups now relay back to the target domain
+    - Pipeline string response bodies served verbatim instead of JSON-encoded
+    - Stronger authorization: global Admin treated as project Owner consistently, role lanes enforced when granting project permissions, and global admin honored on the repo feed and project settings
+    - Create Deployment button and proxy-rule actions hidden/disabled for viewers
+    - Fixed Azure Blob Storage upload and its setup wizard step
+    - Surface storage migration errors with a force-switch recovery path
+    - Include redirectType in the domain response DTO and SSL renewal regeneration
 
 
-  Full release notes can be found at https://github.com/bffless/ce/releases/tag/v0.1.42
+  Full release notes can be found at https://github.com/bffless/ce/releases/tag/v0.1.53
 path: ''
 defaultUsername: ''
 deterministicPassword: false


### PR DESCRIPTION
Updates the BFFless app from CE v0.1.42 to v0.1.53.

### Highlights
- Accept multiple proxy rule sets when creating a deployment
- Choose 301 or 302 status for redirect-type domains
- Custom-domain sign-ups now relay back to the target domain
- Pipeline string response bodies served verbatim instead of JSON-encoded
- Stronger authorization: global Admin treated as project Owner consistently, role lanes enforced when granting project permissions, and global admin honored on the repo feed and project settings
- Create Deployment button and proxy-rule actions hidden/disabled for viewers
- Fixed Azure Blob Storage upload and its setup wizard step
- Surface storage migration errors with a force-switch recovery path
- Include redirectType in the domain response DTO and SSL renewal regeneration

Full release notes: https://github.com/bffless/ce/releases/tag/v0.1.53