### PR TITLE
satsbook: bump to v2.0.0

### DIFF
--- a/satsbook/docker-compose.yml
+++ b/satsbook/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3017
 
   server:
-    image: ghcr.io/satsbook/satsbook:1.1.3@sha256:751e33b956a645c45e6faebf71fd54e24c979e9984a3f625362e18347d7c92b3
+    image: ghcr.io/satsbook/satsbook:2.0.0@sha256:70e752fe53adae9faa33994d6cb9cd4158b35ddb8454ad8d5a42cca117907b77
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/satsbook/umbrel-app.yml
+++ b/satsbook/umbrel-app.yml
@@ -2,14 +2,15 @@ manifestVersion: 1
 id: satsbook
 category: bitcoin
 name: Satsbook
-version: "1.1.3"
-tagline: Bitcoin node analytics and accounting for Lightning operators
+version: "2.0.0"
+tagline: Bitcoin accounting and tax export for Lightning node operators
 description: >-
-  Track routing fees, manage cost basis from exchange imports, and view
-  your full Bitcoin position — all on your own hardware. Satsbook connects
-  to your LND node and provides a privacy-first dashboard with fee
-  analytics, portfolio tracking, and CSV import from Strike, River,
-  Coinbase, and Swan. No cloud services required.
+  Track routing fees, import exchange transactions (Strike, River, Coinbase, Swan),
+  and view your full Bitcoin portfolio — all on your own hardware. Satsbook connects
+  to your LND node and provides a privacy-first dashboard with fee analytics,
+  interactive portfolio breakdown, unified transaction ledger, and transfer tagging.
+  Upgrade to Pro for FIFO/LIFO tax export (Form 8949), or Power
+  to sync your BTC holdings to Monarch Money. No cloud required.
 developer: brewgator
 website: https://github.com/satsbook/satsbook
 repo: https://github.com/satsbook/satsbook
@@ -26,6 +27,12 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
-releaseNotes: ""
+releaseNotes: >-
+  v2.0.0 — Major release with paid tiers and full accounting.
+  Free: interactive portfolio donut chart, unified transaction ledger,
+  transfer tagging (auto-detects channel opens/closes), 4 exchange
+  CSV imports (Strike, River, Coinbase, Swan), watched wallet tracking.
+  Pro: FIFO/LIFO cost basis engine, Form 8949 tax export.
+  Power: Monarch Money BTC holdings and transaction sync.
 submitter: brewgator
 submission: https://github.com/getumbrel/umbrel-apps/pull/5451


### PR DESCRIPTION
## App
**Satsbook** — Bitcoin accounting and tax export for Lightning node operators

## What's new in v2.0.0

**Free (complete):**
- Interactive portfolio donut chart with hover tooltips and click-to-drill source flows
- Unified transaction ledger — LND routing, invoices, payments, on-chain + all exchange imports
- Transfer tagging — auto-detects channel opens/closes; manual toggle with match suggestions
- 4 exchange CSV imports — Strike, River, Coinbase, Swan
- Watched wallet tracking — xpub/address balance via Electrum
- Transaction notes and net flows with period filtering

**Pro:**
- FIFO/LIFO cost basis engine
- Form 8949 CSV export (TurboTax-compatible)
- Tax summary dashboard

**Power:**
- Monarch Money BTC holdings and transaction sync

## Changes
- `umbrel-app.yml` — version 2.0.0, updated description, tagline, and release notes
- `docker-compose.yml` — image tag `ghcr.io/satsbook/satsbook:2.0.0@sha256:70e752fe53adae9faa33994d6cb9cd4158b35ddb8454ad8d5a42cca117907b77`

## Links
- GitHub release: https://github.com/satsbook/satsbook/releases/tag/v2.0.0
- Full changelog: https://github.com/satsbook/satsbook/compare/v1.1.3...v2.0.0
- Original submission: https://github.com/getumbrel/umbrel-apps/pull/5451