### PR TITLE
Update Nostr VPN to v4.0.58

### DIFF
--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 38080
 
   daemon:
-    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.47@sha256:36948ae2717dd299e534e3762a8b1b73ec33eb643264efe2b7387c060445798a
+    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.58@sha256:cf51622fcc1a794ac80e1962fce0855f21575b1d3f69750cb90de82ee3fb52b5
     restart: on-failure
     stop_grace_period: 1m
     network_mode: "host"
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   web:
-    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.47@sha256:36948ae2717dd299e534e3762a8b1b73ec33eb643264efe2b7387c060445798a
+    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.58@sha256:cf51622fcc1a794ac80e1962fce0855f21575b1d3f69750cb90de82ee3fb52b5
     restart: on-failure
     stop_grace_period: 1m
     depends_on:

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: nostr-vpn
 category: networking
 name: Nostr VPN
-version: "v4.0.47"
+version: "v4.0.58"
 tagline: Invite-only mesh VPN over Nostr
 description: >-
   Nostr VPN turns your Umbrel into a private mesh VPN node for your own devices
@@ -31,15 +31,12 @@ gallery:
   - 2.webp
   - 3.webp
 releaseNotes: >-
-  Changes since v4.0.42:
-    - New installs can find peers more reliably: public bootstrap routing now starts enabled with IPv4, IPv6, UDP, and TCP fallback support.
-    - Fixed a bug where UDP connection errors could make busy nodes waste CPU instead of backing off cleanly.
-    - Improved fairness when many peers connect at once, so overloaded bootstrap or server nodes keep serving peers more evenly.
-    - Turning bootstrap routing off now stays off after config reloads.
-    - Fixed Add Network join request handling, including keeping "Join request sent" visible until the Add Network screen closes.
-    - Improved relay discovery and public routing settings labels so the controls describe what they actually change.
-    - Improved stability for large or saturated meshes, including safer connection cleanup and config reload behavior.
-    - Admin roster updates are now signed and verified before acceptance.
-    - Fixed route refresh error text and added stronger release dependency checks.
+  Changes since v4.0.47:
+    - Fixed first-run Umbrel setup so the admin network, local `.nvpn` name, device invites, and self device appear correctly while the daemon is starting.
+    - Improved direct FIPS connections: mesh/relay is now only fallback transport, while direct UDP keeps retrying in the background.
+    - Fixed network-change cases where stale private addresses or brief hotspot liveness failures could leave peers stuck on mesh/relay.
+    - Improved FIPS status output so `nvpn status --json` can show fallback transport and direct probing separately.
+    - Improved FIPS rekey, liveness, and failover handling under load and during changing network conditions.
+    - Startup and network-refresh failures now show clearer daemon status instead of stale "Turning VPN on" states.
 submitter: mmalmi
 submission: https://github.com/getumbrel/umbrel-apps/pull/5678


### PR DESCRIPTION
## Summary

Updates Nostr VPN from `v4.0.47` to `v4.0.58`.

This supersedes the open `v4.0.57` update and includes the `v4.0.58` follow-up direct-path fallback fixes.

## Changes since the previous Umbrel release

- Fixed first-run Umbrel setup so the admin network, local `.nvpn` name, device invites, and self device appear correctly while the daemon is starting.
- Improved direct FIPS connections: mesh/relay is now only fallback transport, while direct UDP keeps retrying in the background.
- Fixed network-change cases where stale private addresses or brief hotspot liveness failures could leave peers stuck on mesh/relay.
- Improved FIPS status output so `nvpn status --json` can show fallback transport and direct probing separately.
- Improved FIPS rekey, liveness, and failover handling under load and during changing network conditions.
- Startup and network-refresh failures now show clearer daemon status instead of stale "Turning VPN on" states.

## Validation

- Verified published image digest: `ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.58@sha256:cf51622fcc1a794ac80e1962fce0855f21575b1d3f69750cb90de82ee3fb52b5`.
- Verified image index includes `linux/amd64` and `linux/arm64`.
- Parsed `nostr-vpn/umbrel-app.yml` and `nostr-vpn/docker-compose.yml`.
- Ran `git diff --check`.
- Tested the `v4.0.58` image on Umbrel OS on a Raspberry Pi 4: daemon and web containers started, health and web endpoints returned 200, and `nvpn status --json` reported binary version `4.0.58`.
