### PR TITLE
Update Nostr VPN to v4.0.62

### DIFF
--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -1,14 +1,13 @@
-version: "3.7"
-
 services:
   app_proxy:
+    restart: unless-stopped
     environment:
       APP_HOST: nostr-vpn_web_1
       APP_PORT: 38080
 
   daemon:
-    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.58@sha256:cf51622fcc1a794ac80e1962fce0855f21575b1d3f69750cb90de82ee3fb52b5
-    restart: on-failure
+    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.62@sha256:e11c4be353bd6922d1829d9a61073cba3960a985294cafb34869bf2efd5012e1
+    restart: unless-stopped
     stop_grace_period: 1m
     network_mode: "host"
     cap_add:
@@ -29,8 +28,8 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   web:
-    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.58@sha256:cf51622fcc1a794ac80e1962fce0855f21575b1d3f69750cb90de82ee3fb52b5
-    restart: on-failure
+    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.62@sha256:e11c4be353bd6922d1829d9a61073cba3960a985294cafb34869bf2efd5012e1
+    restart: unless-stopped
     stop_grace_period: 1m
     depends_on:
       - daemon

--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 38080
 
   daemon:
-    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.47@sha256:36948ae2717dd299e534e3762a8b1b73ec33eb643264efe2b7387c060445798a
+    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.58@sha256:cf51622fcc1a794ac80e1962fce0855f21575b1d3f69750cb90de82ee3fb52b5
     restart: on-failure
     stop_grace_period: 1m
     network_mode: "host"
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   web:
-    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.47@sha256:36948ae2717dd299e534e3762a8b1b73ec33eb643264efe2b7387c060445798a
+    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.58@sha256:cf51622fcc1a794ac80e1962fce0855f21575b1d3f69750cb90de82ee3fb52b5
     restart: on-failure
     stop_grace_period: 1m
     depends_on:

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: nostr-vpn
 category: networking
 name: Nostr VPN
-version: "v4.0.47"
+version: "v4.0.58"
 tagline: Invite-only mesh VPN over Nostr
 description: >-
   Nostr VPN turns your Umbrel into a private mesh VPN node for your own devices
@@ -31,15 +31,12 @@ gallery:
   - 2.webp
   - 3.webp
 releaseNotes: >-
-  Changes since v4.0.42:
-    - New installs can find peers more reliably: public bootstrap routing now starts enabled with IPv4, IPv6, UDP, and TCP fallback support.
-    - Fixed a bug where UDP connection errors could make busy nodes waste CPU instead of backing off cleanly.
-    - Improved fairness when many peers connect at once, so overloaded bootstrap or server nodes keep serving peers more evenly.
-    - Turning bootstrap routing off now stays off after config reloads.
-    - Fixed Add Network join request handling, including keeping "Join request sent" visible until the Add Network screen closes.
-    - Improved relay discovery and public routing settings labels so the controls describe what they actually change.
-    - Improved stability for large or saturated meshes, including safer connection cleanup and config reload behavior.
-    - Admin roster updates are now signed and verified before acceptance.
-    - Fixed route refresh error text and added stronger release dependency checks.
+  Changes since v4.0.47:
+    - Fixed first-run Umbrel setup so the admin network, local `.nvpn` name, device invites, and self device appear correctly while the daemon is starting.
+    - Improved direct FIPS connections: mesh/relay is now only fallback transport, while direct UDP keeps retrying in the background.
+    - Fixed network-change cases where stale private addresses or brief hotspot liveness failures could leave peers stuck on mesh/relay.
+    - Improved FIPS status output so `nvpn status --json` can show fallback transport and direct probing separately.
+    - Improved FIPS rekey, liveness, and failover handling under load and during changing network conditions.
+    - Startup and network-refresh failures now show clearer daemon status instead of stale "Turning VPN on" states.
 submitter: mmalmi
 submission: https://github.com/getumbrel/umbrel-apps/pull/5678

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: nostr-vpn
 category: networking
 name: Nostr VPN
-version: "v4.0.58"
+version: "v4.0.62"
 tagline: Invite-only mesh VPN over Nostr
 description: >-
   Nostr VPN turns your Umbrel into a private mesh VPN node for your own devices
@@ -32,11 +32,9 @@ gallery:
   - 3.webp
 releaseNotes: >-
   Changes since v4.0.47:
-    - Fixed first-run Umbrel setup so the admin network, local `.nvpn` name, device invites, and self device appear correctly while the daemon is starting.
-    - Improved direct FIPS connections: mesh/relay is now only fallback transport, while direct UDP keeps retrying in the background.
-    - Fixed network-change cases where stale private addresses or brief hotspot liveness failures could leave peers stuck on mesh/relay.
-    - Improved FIPS status output so `nvpn status --json` can show fallback transport and direct probing separately.
-    - Improved FIPS rekey, liveness, and failover handling under load and during changing network conditions.
-    - Startup and network-refresh failures now show clearer daemon status instead of stale "Turning VPN on" states.
+    - Fixed first-run Umbrel setup so the admin network, local `.nvpn` name, device invites, and self device appear reliably while the daemon starts.
+    - Improved direct peer connectivity: mesh/relay is now fallback transport while direct UDP keeps probing and can recover after hotspot or NAT changes.
+    - Avoided stale private/hotspot endpoints and brief liveness timeouts leaving peers stuck on mesh.
+    - Improved daemon liveness, rekey, and failover behavior under load, with clearer startup and network-refresh status.
 submitter: mmalmi
 submission: https://github.com/getumbrel/umbrel-apps/pull/5678


### PR DESCRIPTION
## Summary
- Updates Nostr VPN from v4.0.47 to v4.0.62.
- Points both Umbrel services at the pinned v4.0.62 multi-arch image digest.
- Switches the app services to `restart: unless-stopped` and removes the obsolete Compose `version` field.

## Changes since the previous Umbrel release
- Fixed first-run Umbrel setup so the admin network, local `.nvpn` name, device invites, and self device appear reliably while the daemon starts.
- Improved direct peer connectivity: mesh/relay is now fallback transport while direct UDP keeps probing and can recover after hotspot or NAT changes.
- Avoided stale private/hotspot endpoints and brief liveness timeouts leaving peers stuck on mesh.
- Improved daemon liveness, rekey, and failover behavior under load, with clearer startup and network-refresh status.

## Test plan
- Verified the v4.0.62 image manifest includes linux/amd64 and linux/arm64.
- Ran the Umbrel pinned-image Docker web E2E against `ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.62@sha256:e11c4be353bd6922d1829d9a61073cba3960a985294cafb34869bf2efd5012e1` (4 browser/API tests passed).
- YAML parsed cleanly and `git diff --check` passed.
