### PR TITLE
Update Public Pool server image

### DIFF
--- a/public-pool/docker-compose.yml
+++ b/public-pool/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - DOMAIN=$DEVICE_DOMAIN_NAME
 
   server:
-    image: ghcr.io/sethforprivacy/public-pool:9938a05@sha256:96347cbbc2ec6f27ec1b282e8353e41197fad6ca56e011873e69e7c3b6555b14
+    image: ghcr.io/benjamin-wilson/public-pool:95565ee@sha256:3edffef3bbad23cbd46098904b22ba8a1c14c679ae90cf1e4d97ed98492bbab4
     restart: on-failure
     stop_grace_period: 30s
     ports:

--- a/public-pool/umbrel-app.yml
+++ b/public-pool/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: public-pool
 category: bitcoin
 name: Public Pool
-version: "3c1289c"
+version: "95565ee"
 tagline: Fully Open Source Solo Bitcoin Mining Pool
 description: >-
   Public Pool is an open-source, solo Bitcoin mining application that lets you run your own pool using your own node.
@@ -28,7 +28,7 @@ gallery:
   - 3.jpg
 path: ""
 releaseNotes: >-
-  This small update resolves an issue that prevented the Public Pool UI from being accessed when intentionally exposed to the public internet (e.g., via Cloudflare Tunnel or similar methods).
+  This update migrates the latest Public Pool server improvements back to the SQLite-based Umbrel app, including Stratum reliability improvements, Bitcoin RPC updates, job handling fixes, and dependency updates.
 defaultPassword: ""
 widgets:
   - id: "stats"


### PR DESCRIPTION
### App
Public Pool

### Summary
- Updates the Public Pool server image from the sethforprivacy fork to the maintained benjamin-wilson/public-pool image.
- Keeps the existing Duckaxe UI image unchanged.
- Bumps the app version to 95565ee and updates release notes.

### Image
`ghcr.io/benjamin-wilson/public-pool:95565ee@sha256:3edffef3bbad23cbd46098904b22ba8a1c14c679ae90cf1e4d97ed98492bbab4`

### Validation
- Upstream image build completed successfully: https://github.com/benjamin-wilson/public-pool/actions/runs/27022260615
- Confirmed image index is multi-arch for linux/amd64 and linux/arm64.
- Ran `git diff --check` for the app-store changes.