### PR TITLE
canary: Update to v1.5.2

### DIFF
--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.5.1@sha256:30a0317f0965644e42b98cb59aa97c4ecff8efabb28411c0e95e7251951fe77d
+    image: schjonhaug/canary-backend:v1.5.2@sha256:a927448e881d6e1060736a844439dd57b84e4e3f8b89aeaf3dea48367c40fa55
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -28,7 +28,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.5.1@sha256:f0faa03991e7f9711af92835a9ef8b61c2b090a0d4739fa9d83cb9b0a81b603a
+    image: schjonhaug/canary-frontend:v1.5.2@sha256:72ecf65fcdc80613974c2ea603524b2edc053026fc9f93ba3198be9f89711a6c
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: canary
 category: bitcoin
 name: Canary
-version: "1.5.1"
+version: "1.5.2"
 tagline: Early warning system for Bitcoin cold storage
 description: >-
   A canary in the cold mine. When your bitcoins are in cold storage, you seldom check on them.

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -27,7 +27,10 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  Canary v1.5.1 improves self-hosted explorer and ntfy settings on Umbrel, with clearer endpoint selection, local platform labels, and better handling of Umbrel local integrations. It also fixes address-watch syncing edge cases and small self-hosted UI/build issues.
+  Canary v1.5.2 rejects non-derivable xpub descriptors with hardened account derivation after the xpub, returning a clear validation error instead of creating wallets that cannot sync correctly. It also adds recovery handling for failed or stuck wallet creation so broken wallet records can be deleted and recreated, and fixes Genesis wallet balance and coinbase address watch syncing.
+
+  
+  Full release notes can be found at https://github.com/schjonhaug/canary/releases/tag/v1.5.2
 path: ""
 deterministicPassword: true
 submitter: schjonhaug


### PR DESCRIPTION
## Summary
Update Canary Umbrel app to v1.5.2.

## Release summary
Canary v1.5.2 rejects invalid xpub descriptors before they can create wallets that cannot sync correctly, and adds recovery handling so failed or stuck wallet records can be deleted and recreated. It also fixes Genesis wallet and address-watch syncing edge cases.

## Upstream release
https://github.com/schjonhaug/canary/releases/tag/v1.5.2

## Test plan
- [x] Tested on local Umbrel
