### PR TITLE
Update Nostr VPN to v4.0.67

### DIFF
--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 38080
 
   daemon:
-    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.58@sha256:cf51622fcc1a794ac80e1962fce0855f21575b1d3f69750cb90de82ee3fb52b5
+    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.67@sha256:b01f4a62f6b093bed74db7f9feaa77325668bb64bd36147ff6a40f97a542db91
     restart: on-failure
     stop_grace_period: 1m
     network_mode: "host"
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   web:
-    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.58@sha256:cf51622fcc1a794ac80e1962fce0855f21575b1d3f69750cb90de82ee3fb52b5
+    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.67@sha256:b01f4a62f6b093bed74db7f9feaa77325668bb64bd36147ff6a40f97a542db91
     restart: on-failure
     stop_grace_period: 1m
     depends_on:

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: nostr-vpn
 category: networking
 name: Nostr VPN
-version: "v4.0.58"
+version: "v4.0.67"
 tagline: Invite-only mesh VPN over Nostr
 description: >-
   Nostr VPN turns your Umbrel into a private mesh VPN node for your own devices
@@ -31,12 +31,10 @@ gallery:
   - 2.webp
   - 3.webp
 releaseNotes: >-
-  Changes since v4.0.47:
-    - Fixed first-run Umbrel setup so the admin network, local `.nvpn` name, device invites, and self device appear correctly while the daemon is starting.
-    - Improved direct FIPS connections: mesh/relay is now only fallback transport, while direct UDP keeps retrying in the background.
-    - Fixed network-change cases where stale private addresses or brief hotspot liveness failures could leave peers stuck on mesh/relay.
-    - Improved FIPS status output so `nvpn status --json` can show fallback transport and direct probing separately.
-    - Improved FIPS rekey, liveness, and failover handling under load and during changing network conditions.
-    - Startup and network-refresh failures now show clearer daemon status instead of stale "Turning VPN on" states.
+  Changes since v4.0.58:
+    - Keeps VPN traffic flowing over mesh fallback when direct UDP is marked link-dead, while direct probing continues and can recover.
+    - Fixes stale or freshly reconnected UDP paths suppressing better fallback routes after hotspot/NAT changes.
+    - Prevents fallback transit loops after direct-path loss.
+    - Warms established sessions after fresh fallback discovery, reducing stalls after liveness timeouts.
 submitter: mmalmi
 submission: https://github.com/getumbrel/umbrel-apps/pull/5678


### PR DESCRIPTION
## Summary
- Update Nostr VPN from v4.0.58 to v4.0.67.
- Pin the daemon and web containers to the pushed multi-arch v4.0.67 image digest.
- Refresh the Umbrel release notes with the networking fixes since the previous Umbrel release.

## Changes since v4.0.58
- Keeps VPN traffic flowing over mesh fallback when direct UDP is marked link-dead, while direct probing continues and can recover.
- Fixes stale or freshly reconnected UDP paths suppressing better fallback routes after hotspot/NAT changes.
- Prevents fallback transit loops after direct-path loss.
- Warms established sessions after fresh fallback discovery, reducing stalls after liveness timeouts.

## Testing
- Parsed `nostr-vpn/umbrel-app.yml` and `nostr-vpn/docker-compose.yml` as YAML.
- Confirmed the pinned image digest is multi-arch for `linux/amd64` and `linux/arm64`.
- Tested on Umbrel Pi: daemon and web containers ran v4.0.67, the web UI responded through the app proxy, and VPN status reported active.
