### PR TITLE
Update Public Pool UI image

### DIFF
--- a/public-pool/docker-compose.yml
+++ b/public-pool/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     stop_grace_period: 30s
     environment:
       - DOMAIN=$DEVICE_DOMAIN_NAME
+      # Intentionally empty so the UI uses same-origin /api routes via Umbrel's proxy.
       - PUBLIC_POOL_API_URL=
       - PUBLIC_POOL_STRATUM_URL=${DEVICE_DOMAIN_NAME}:2018
 

--- a/public-pool/docker-compose.yml
+++ b/public-pool/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - DOMAIN=$DEVICE_DOMAIN_NAME
       - PUBLIC_POOL_API_URL=
-      - PUBLIC_POOL_STRATUM_URL=:2018
+      - PUBLIC_POOL_STRATUM_URL=${DEVICE_DOMAIN_NAME}:2018
 
   server:
     image: ghcr.io/benjamin-wilson/public-pool:95565ee@sha256:3edffef3bbad23cbd46098904b22ba8a1c14c679ae90cf1e4d97ed98492bbab4

--- a/public-pool/docker-compose.yml
+++ b/public-pool/docker-compose.yml
@@ -8,11 +8,13 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   web:
-    image: ghcr.io/duckaxe/public-pool-ui:3c1289c@sha256:d916a72b2487c935468b894a89450e5ed688525500fcb81961061c3d7a7877e2
+    image: ghcr.io/benjamin-wilson/public-pool-ui:5f730f4@sha256:c1eaae042ee179eca87b273c04c54c8b1fba5ceb63a03411a21ec8ac6875be3d
     restart: on-failure
     stop_grace_period: 30s
     environment:
       - DOMAIN=$DEVICE_DOMAIN_NAME
+      - PUBLIC_POOL_API_URL=
+      - PUBLIC_POOL_STRATUM_URL=:2018
 
   server:
     image: ghcr.io/benjamin-wilson/public-pool:95565ee@sha256:3edffef3bbad23cbd46098904b22ba8a1c14c679ae90cf1e4d97ed98492bbab4

--- a/public-pool/umbrel-app.yml
+++ b/public-pool/umbrel-app.yml
@@ -28,7 +28,7 @@ gallery:
   - 3.jpg
 path: ""
 releaseNotes: >-
-  This update switches Public Pool to the upstream UI image and configures it through runtime environment variables so the app uses Umbrel's local proxy and displays the correct Stratum endpoint.
+  This update switches Public Pool to the official upstream web interface for better alignment with the project.
 defaultPassword: ""
 widgets:
   - id: "stats"

--- a/public-pool/umbrel-app.yml
+++ b/public-pool/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: public-pool
 category: bitcoin
 name: Public Pool
-version: "95565ee"
+version: "95565ee-ui5f730f4"
 tagline: Fully Open Source Solo Bitcoin Mining Pool
 description: >-
   Public Pool is an open-source, solo Bitcoin mining application that lets you run your own pool using your own node.
@@ -28,7 +28,7 @@ gallery:
   - 3.jpg
 path: ""
 releaseNotes: >-
-  This update migrates the latest Public Pool server improvements back to the SQLite-based Umbrel app, including Stratum reliability improvements, Bitcoin RPC updates, job handling fixes, and dependency updates.
+  This update switches Public Pool to the upstream UI image and configures it through runtime environment variables so the app uses Umbrel's local proxy and displays the correct Stratum endpoint.
 defaultPassword: ""
 widgets:
   - id: "stats"


### PR DESCRIPTION
## Summary

Updates Public Pool to use the upstream `benjamin-wilson/public-pool-ui` image with runtime configuration support instead of the Duckaxe UI image.

Refs https://github.com/getumbrel/umbrel-apps/pull/5726#issuecomment-4637177262

## Changes

- Switches the Public Pool web image to `ghcr.io/benjamin-wilson/public-pool-ui:5f730f4@sha256:c1eaae042ee179eca87b273c04c54c8b1fba5ceb63a03411a21ec8ac6875be3d`
- Sets `PUBLIC_POOL_API_URL=` so UI API calls use Umbrel's same-origin `/api/...` proxy
- Sets `PUBLIC_POOL_STRATUM_URL=:2018` so the UI displays `<device-hostname>:2018`
- Updates release notes for the UI runtime config change

## Verification

- `ruby -e 'require "yaml"; %w[public-pool/docker-compose.yml public-pool/umbrel-app.yml].each { |f| YAML.load_file(f); puts "OK #{f}" }'`
- `docker buildx imagetools inspect ghcr.io/benjamin-wilson/public-pool-ui:5f730f4`
- Confirmed `public-pool/data/proxy/nginx.conf` routes `/api/...` to the Public Pool server

Note: `docker compose config` cannot fully validate Umbrel apps locally because Umbrel's special `app_proxy` service has no image/build context outside umbrelOS.
