### PR TITLE
Update rusty-kaspad to v2.0.0

### DIFF
--- a/rusty-kaspad/docker-compose.yml
+++ b/rusty-kaspad/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - kaspad
 
   kaspad:
-    image: kaspanet/rusty-kaspad:v1.1.0@sha256:150ffa0c0dcc6497951f9199d1ba3e48c7d91ef958846b28c9fb5045459a2dca
+    image: kaspanet/rusty-kaspad:v2.0.0@sha256:cbd449bc19cde32218d0fa82825659c99006d5ce838774618961fa25a907a051
     restart: on-failure
     stop_grace_period: 3m
     volumes:

--- a/rusty-kaspad/umbrel-app.yml
+++ b/rusty-kaspad/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: rusty-kaspad
 category: crypto
 name: Rusty Kaspad
-version: "v1.1.0-1"
+version: "v2.0.0"
 tagline: A Rust implementation of a Kaspa full node
 description: |
   Rusty Kaspad is a Rust implementation of a Kaspa full node. This node software provides essential Kaspa network services including peer-to-peer networking and RPC functionality.
@@ -25,25 +25,21 @@ gallery:
   - 1.jpg
   - 2.jpg
 releaseNotes: >-
-  ⚠️ This release upgrades the database schema to version 6. Downgrading to an older node version after upgrading may require deleting the database.
+  ⚠️ This release updates Rusty Kaspa to v2.0.0 for the Toccata hardfork. The hardfork is scheduled to activate on mainnet at DAA score 474,165,565, around June 30, 2026 at 16:15 UTC.
 
 
   Key highlights in this release:
-    - New VSPC API v2 (`GetVirtualChainFromBlockV2`) makes integrating Kaspa simpler by returning chain updates and accepted transaction data in a single call
-    - Faster and more reliable initial sync and catchup behavior, with smoother recovery under real-world conditions
-    - Significant storage and performance improvements, including up to ~3x faster header-stage sync on some machines
-    - Lower storage usage, reduced write overhead, and faster header and pruning processing
-    - Improved pruning proof stability and correctness
-    - RocksDB preset system added for archive and HDD use cases, with WAL-directory support and cache controls
-    - In-house Rusty Kaspa Stratum Bridge released as BETA
+    - Toccata hardfork support, including the new P2P protocol version 10
+    - Native L1 covenant programming support and infrastructure for based ZK applications
+    - Updated transaction handling for Toccata transaction fields
+    - Higher minimum standard fee policy for RPC-submitted transactions ahead of activation
+    - Compatibility updates for gRPC/protobuf integrators, miners, pools, explorers, and wallets
 
 
   Full release notes can be found at https://github.com/kaspanet/rusty-kaspa/releases
 
 
-  Note: the `-1` suffix in this Umbrel app version indicates a frontend/package-only revision and is not a new Rusty Kaspa node release.
-
-  On some older installs, this update may cause the node to re-sync.
+  Starting 24 hours before activation, nodes will only connect to peers using P2P protocol version 10. The node database upgrade is one-way; downgrading to an older node version requires resyncing.
 submitter: Luke Dunshea
 submission: https://github.com/getumbrel/umbrel-apps/pull/2060
 backupIgnore:


### PR DESCRIPTION
## Summary

Updates Rusty Kaspad from v1.1.0 to v2.0.0.

This is the Toccata hardfork release. It updates the node image, app version, and release notes.

## Changes

- Bumps `kaspanet/rusty-kaspad` to `v2.0.0`
- Pins the Docker image to the v2.0.0 multi-arch digest
- Updates the Umbrel app version to `v2.0.0`
- Refreshes release notes for the Toccata hardfork

## Validation

- Parsed `rusty-kaspad/umbrel-app.yml` and `rusty-kaspad/docker-compose.yml` as YAML
- Ran `git diff --check`
- Confirmed the pinned Docker digest is the multi-arch image index for `kaspanet/rusty-kaspad:v2.0.0`
- Confirmed the image includes `linux/amd64` and `linux/arm64`