### PR TITLE
Update Arcane image version to v2.0.2

### DIFF
--- a/arcane/docker-compose.yml
+++ b/arcane/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - ${APP_DATA_DIR}/data/docker:/data
 
   arcane:
-    image: ghcr.io/getarcaneapp/arcane:v2.0.1@sha256:c28e5397669ee06376a9f4838922c438133be315fdedfa419a30076e34180f1e
+    image: ghcr.io/getarcaneapp/arcane:v2.0.2@sha256:4923ed580990dd48c5f8875065dc04765e032c0fde72b8d85e3b1c38cdcc0526
     depends_on:
       - docker
     restart: on-failure

--- a/arcane/umbrel-app.yml
+++ b/arcane/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: arcane
 category: developer
 name: Arcane
-version: "2.0.1"
+version: "2.0.2"
 tagline: An easy and modern Docker management platform
 description: >-
   ⚠️ Make sure to only use named Docker volumes for your containers and projects. Data in bind-mounted volumes will be lost when the Arcane app is restarted or updated.
@@ -48,13 +48,13 @@ path: ""
 defaultUsername: "arcane"
 defaultPassword: "arcane-admin"
 releaseNotes: >-
-  Arcane 2.0.1 is a follow-up to the recent Arcane 2.0 major update. If you're updating from a pre-2.0 version, back up your Arcane data first and review the v2 migration guide if you use OIDC, API keys/automation, Edge mTLS remote environments, Apprise notifications, or deprecated prune/GitOps settings.
+  Arcane 2.0.2 is a minor release update. If you're updating from a pre-2.0 version, back up your Arcane data first and review the v2 migration guide if you use OIDC, API keys/automation, Edge mTLS remote environments, Apprise notifications, or deprecated prune/GitOps settings.
 
 
-  If you're already on Arcane 2.0.0, this update fixes notification token decryption and updates Arcane's internal Go modules to the v2 module path.
+  If you're already on Arcane 2.0.1, this update fixes Git sync issues.
 
 
-  Full release notes can be found at https://github.com/getarcaneapp/arcane/releases/tag/v2.0.1
+  Full release notes can be found at https://github.com/getarcaneapp/arcane/releases/tag/v2.0.2
 permissions:
   - GPU
 developer: Arcane


### PR DESCRIPTION
Bumped version to v2.0.2. This release fixes broken git sync in Arcane.