### PR TITLE
bolt12-pay: add domain setup documentation link

### DIFF
--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -25,7 +25,9 @@ description: >-
 
   Restart Lightning afterwards. Without this, BOLT12 functionality will not work.
 
-  For detailed BIP353, LNURL and Cloudflare DNS setup instructions, see:
+
+  Domain setup guide:
+
 
   https://github.com/Alex71btc/lndk-pay/blob/main/README.md#-domain-configuration-bip353-vs-lnurl
 

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -25,6 +25,10 @@ description: >-
 
   Restart Lightning afterwards. Without this, BOLT12 functionality will not work.
 
+  For detailed BIP353, LNURL and Cloudflare DNS setup instructions, see:
+
+  https://github.com/Alex71btc/lndk-pay/blob/main/README.md#-domain-configuration-bip353-vs-lnurl
+
 
   BOLT12 support on LND is still evolving, wallet compatibility may vary,
   and this app uses cutting-edge Lightning features.


### PR DESCRIPTION
## Summary

Add a direct link to the BOLT12 Pay domain configuration guide in the app description.

This helps users correctly configure:

* BIP353 Lightning Addresses
* LNURL addresses
* Cloudflare DNS automation
* Root domain vs subdomain usage

The guide covers common setup mistakes and should reduce support requests related to domain configuration.
