### PR TITLE
Update bolt12-pay to v0.2.105.1

### DIFF
--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.2.104@sha256:786001792ad4c46e53b22eef744ad99c09d52a9ecd8f4567d54685c062bb66f5
+    image: alex71btc/bolt12-pay:0.2.105@sha256:e853a126abf8873f2c0f4beb16eb4ddf199ce5bae31a6d4b6c8319d153740c06
     restart: on-failure
     depends_on:
       - lndk
@@ -45,7 +45,7 @@ services:
       - ${APP_LIGHTNING_NODE_DATA_DIR}:/lnd:ro
 
   lndk:
-    image: alex71btc/lndk:stable-good-20260401@sha256:ff16de59cacb5e5a9d53b76e879dcaaaa9b204537dc26697275b737c489f2939
+    image: alex71btc/lndk:amountless-fix@sha256:f7a237a131f4b1950e7650692954db865b42ec492348936726871f65b1c1d2e3
     restart: on-failure
     entrypoint:
       - /bin/sh

--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.2.105@sha256:df6dad5e2674da41e1db97988fe1fb7935cc6726ff4d665d4a6e14126af2eec9
+    image: alex71btc/bolt12-pay:0.2.105.1@sha256:7439069d9ad67ff86f2b5a95e9aef9defb732184d75719f9291947118376100d
     restart: on-failure
     depends_on:
       - lndk

--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.2.105@sha256:e853a126abf8873f2c0f4beb16eb4ddf199ce5bae31a6d4b6c8319d153740c06
+    image: alex71btc/bolt12-pay:0.2.105@sha256:df6dad5e2674da41e1db97988fe1fb7935cc6726ff4d665d4a6e14126af2eec9
     restart: on-failure
     depends_on:
       - lndk
@@ -45,7 +45,7 @@ services:
       - ${APP_LIGHTNING_NODE_DATA_DIR}:/lnd:ro
 
   lndk:
-    image: alex71btc/lndk:amountless-fix@sha256:f7a237a131f4b1950e7650692954db865b42ec492348936726871f65b1c1d2e3
+    image: alex71btc/lndk:amountless-fix-v2@sha256:dcace5e9c90c4dfe26c85979f373ecebfafdf0a56b494e22fd5abe7fb731987e
     restart: on-failure
     entrypoint:
       - /bin/sh

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.105
+version: 0.2.105.1
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.104
+version: 0.2.105
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
@@ -43,7 +43,13 @@ submitter: Alex71btc
 submission: https://github.com/getumbrel/umbrel-apps/pull/5429
 repo: https://github.com/Alex71btc/lndk-pay
 support: https://github.com/Alex71btc/lndk-pay/issues
-releaseNotes: ""
+releaseNotes: |
+  v0.2.105
+
+  - Added support for true amountless BOLT12 offers
+  - Improved compatibility with Ocean Mining payouts
+  - Improved compatibility with Phoenix Wallet
+  - Updated LNDK with amountless offer payment fixes
 dependencies:
   - lightning
 gallery:


### PR DESCRIPTION
Fix amountless BOLT12 offer payments.

Previously LNDK used the offer amount when creating invoices. For amountless offers this resulted in a zero-value invoice, causing blinded path creation to fail.

This change uses InvoiceRequest::amount_msats() instead, which correctly contains the payer-selected amount for amountless offers.

Tested successfully with Phoenix Wallet and amountless BOLT12 offers.