### PR TITLE
Update hashrate-autopilot to v1.14.0

### DIFF
--- a/hashrate-autopilot/docker-compose.yml
+++ b/hashrate-autopilot/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3010
 
   web:
-    image: ghcr.io/rdouma/hashrate-autopilot:1.13.0@sha256:2a90cf1a987d596d18013b7f8d5dc51ed8acce2b3a78397fe38e85e5893ac322
+    image: ghcr.io/rdouma/hashrate-autopilot:1.14.0@sha256:4b368ab62bd5ee7add7a3c935f24307ec5565977e02c9696a5cea0cbc6e8f621
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/hashrate-autopilot/umbrel-app.yml
+++ b/hashrate-autopilot/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: hashrate-autopilot
 category: bitcoin
 name: Hashrate Autopilot
-version: "1.13.0"
+version: "1.14.0"
 tagline: Autopilot for renting hashrate to mine on Ocean Mining
 
 description: >-
@@ -71,13 +71,16 @@ defaultPassword: ""
 submitter: Remco Douma
 submission: https://github.com/getumbrel/umbrel-apps/pull/5685
 releaseNotes: >-
-  v1.13.0 - first appearance in the official Umbrel App Store.
+  v1.14.0 - run-mode and bid-pause history with chart markers and idle bands.
 
 
-  Already running the community-store version (rdouma-hashrate-autopilot)? It installs side by side with this one. A one-time five-minute migration brings your full history across: https://github.com/rdouma/hashrate-autopilot/blob/main/docs/migrating-from-community-store.md
+  The autopilot now logs every run-mode switch and every Braiins-side bid pause or resume: filterable History rows with the underlying reason, always-visible price-chart markers, and hatched background bands over every span the autopilot was not actively trading - retroactive over your full history. All three marker colors are configurable.
 
 
-  Highlights in v1.13.0: configurable stats bar (pick your tiles from a catalogue, drag to reorder), dedicated History page with filters and a per-event detail drawer, synced crosshair across both charts, and the USD toggle now greys out with the reason when the BTC price oracle is unreachable instead of silently disappearing. Plus a sweep of mobile and reliability fixes. Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.13.0
+  Also new: click a History row for a detail drawer with a view-on-chart jump that scrolls to and rings the exact marker, click a chart legend entry to show or hide that series, speed-edit markers on the hashrate chart, and payout tracking now works (and says so) with any Electrum server - electrs, Fulcrum, or ElectrumX.
 
 
-  Safe to install fresh; no migrations.
+  Migrating from the community-store version (rdouma-hashrate-autopilot)? One-time five-minute guide: https://github.com/rdouma/hashrate-autopilot/blob/main/docs/migrating-from-community-store.md
+
+
+  Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.14.0


### PR DESCRIPTION
Updates Hashrate Autopilot from 1.13.0 to 1.14.0.

Highlights: the autopilot now logs run-mode switches and Braiins-side bid pause/resume events - shown as filterable History rows, always-visible chart markers, and hatched background bands over every span the autopilot wasn't actively trading (retroactive over stored history). Also a History detail drawer with view-on-chart jump, click-to-hide chart legend entries, and the payout-tracking backend relabeled to "Electrum server" (electrs / Fulcrum / ElectrumX all work).

Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.14.0

Image `ghcr.io/rdouma/hashrate-autopilot:1.14.0` is multi-arch (amd64 + arm64) and pinned by digest.
