### PR TITLE
Add Bison Wallet v1.0.5

### DIFF
--- a/dcrdex/docker-compose.yml
+++ b/dcrdex/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  app_proxy:
+    environment:
+      APP_HOST: dcrdex_web_1
+      APP_PORT: 5758
+      # Bison Wallet has its own password-based authentication
+      PROXY_AUTH_ADD: "false"
+
+  web:
+    image: decred/dcrdex:v1.0.5@sha256:5d010b92fbb452c9df6e0205d9bb0c8f8c446e011d69501c1e0a9b1fc4abd792
+    user: "1000:1000"
+    restart: on-failure
+    # When a trade is being settled, the DEX client requires time
+    # to shut down cleanly due to the time sensitive nature of atomic
+    # swaps, hence the long stop_grace_period value.
+    stop_grace_period: 15m
+    volumes:
+      - ${APP_DATA_DIR}/data:/dex/.dexc
+    entrypoint: ["/bin/sh", "-c", "exec ./bisonw --webaddr $(hostname -I|cut -d\\  -f1 ):5758"]

--- a/dcrdex/docker-compose.yml
+++ b/dcrdex/docker-compose.yml
@@ -16,4 +16,5 @@ services:
     stop_grace_period: 15m
     volumes:
       - ${APP_DATA_DIR}/data:/dex/.dexc
+    # Bind to the container's private IP so bisonw stays in HTTP mode for Umbrel's app proxy.
     entrypoint: ["/bin/sh", "-c", "exec ./bisonw --webaddr $(hostname -I|cut -d\\  -f1 ):5758"]

--- a/dcrdex/umbrel-app.yml
+++ b/dcrdex/umbrel-app.yml
@@ -24,4 +24,4 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: peterzen
-submission: https://github.com/peterzen/umbrel-apps/pull/1
+submission: https://github.com/getumbrel/umbrel-apps/pull/5746

--- a/dcrdex/umbrel-app.yml
+++ b/dcrdex/umbrel-app.yml
@@ -1,0 +1,27 @@
+manifestVersion: 1
+id: dcrdex
+category: crypto
+name: Bison Wallet
+version: "1.0.5"
+tagline: Multi-asset cryptocurrency wallet with integrated DEX
+description: >-
+  Bison Wallet is a multi-asset, non-custodial cryptocurrency wallet with a built-in decentralized exchange.
+
+
+  Trade Bitcoin, USDC, Ethereum, Decred, Dogecoin, Zcash and more peer-to-peer using atomic swaps.
+
+
+  No trading fees. No KYC. You stay in control of your assets throughout the entire trading process.
+releaseNotes: ""
+developer: The Decred Developers
+website: https://dex.decred.org
+dependencies: []
+repo: https://github.com/decred/dcrdex
+support: https://github.com/decred/dcrdex/issues
+port: 5758
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: peterzen
+submission: https://github.com/peterzen/umbrel-apps/pull/1

--- a/dcrdex/umbrel-app.yml
+++ b/dcrdex/umbrel-app.yml
@@ -19,7 +19,11 @@ dependencies: []
 repo: https://github.com/decred/dcrdex
 support: https://github.com/decred/dcrdex/issues
 port: 5758
-gallery: []
+gallery:
+  - 1.webp
+  - 2.webp
+  - 3.webp
+  - 4.webp
 path: ""
 defaultUsername: ""
 defaultPassword: ""


### PR DESCRIPTION
# App Submission

### App name
Bison Wallet

Bison Wallet is a multi-asset, non-custodial cryptocurrency wallet with a built-in decentralized exchange. Trade Bitcoin, USDC, Ethereum, Decred, Dogecoin, Zcash and more peer-to-peer using atomic swaps — no trading fees, no KYC, and you stay in control of your assets throughout the entire trading process.

- Developer: The Decred Developers — https://dex.decred.org
- Image: `decred/dcrdex:v1.0.5`, pinned by digest, multi-arch (amd64/arm64)
- Bison Wallet uses its own password-based authentication, so `PROXY_AUTH_ADD` is disabled
- A long `stop_grace_period` (15m) gives in-flight atomic swaps time to settle on shutdown

### Brand assets

- Icon (SVG, no rounded corners): https://raw.githubusercontent.com/decred/dcrdex/master/dcrdex-umbrel/images/bison.svg
- Gallery screenshots:
  - https://raw.githubusercontent.com/decred/dcrdex/master/dcrdex-umbrel/images/screenshot_1.jpg
  - https://raw.githubusercontent.com/decred/dcrdex/master/dcrdex-umbrel/images/screenshot_2.jpg
  - https://raw.githubusercontent.com/decred/dcrdex/master/dcrdex-umbrel/images/screenshot_3.jpg
  - https://raw.githubusercontent.com/decred/dcrdex/master/dcrdex-umbrel/images/screenshot_4.jpg

### Notes

- The `submission:` field in `umbrel-app.yml` points to this PR, as required by the linter; set it to the upstream PR URL when submitting against getumbrel/umbrel-apps.

### I have tested my app on:
- [X] umbrelOS on a Raspberry Pi
- [ ] umbrelOS on an Umbrel Home
- [X] umbrelOS on Linux VM

