### PR TITLE
Update Alby Hub to v1.23.0

### DIFF
--- a/albyhub/docker-compose.yml
+++ b/albyhub/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       APP_HOST: albyhub_server_1
       APP_PORT: 8080
   server:
-    image: ghcr.io/getalby/hub:v1.22.2@sha256:acf158edbb9348a8f84e02ffc97919692bc40280e7d28d501b1fc3d23d7ac266
+    image: ghcr.io/getalby/hub:v1.23.0@sha256:03074e1cb7a1814fcecedfd6e2bf2b2fe8643b2891db03cfb634076252138962
     user: 1000:1000
     volumes:
       - ${APP_DATA_DIR}/data:/data

--- a/albyhub/umbrel-app.yml
+++ b/albyhub/umbrel-app.yml
@@ -3,7 +3,7 @@ id: albyhub
 name: Alby Hub ✨
 tagline: Self-custodial Lightning wallet with integrated node and app connections
 category: bitcoin
-version: "1.22.2"
+version: "1.23.0"
 port: 59000
 description: >-
   Alby Hub is an open-source, self-custodial Bitcoin Lightning wallet, with the easiest-to-use Lightning Network node for everyone.
@@ -40,11 +40,11 @@ gallery:
   - 4.jpg
 releaseNotes: >-
   Key changes in this release:
-    - Added AI & Agents page
-    - Added integrated on-chain wallet mode
-    - Added custom user labels for transactions
-    - Redesigned settings pages and improved app connection budget selection
-    - Added Core Lightning backend support
+    - Added Just-in-Time channels to automatically open inbound liquidity when needed
+    - Added a Cards page for one-click debit card top-ups
+    - Added an experimental Bark backend
+    - Redesigned the home page with stories and improved currency input
+    - Improved Core Lightning backend support
     - Various bugfixes and minor improvements
 
 


### PR DESCRIPTION
## Summary
- Update Alby Hub to v1.23.0
- Pin the GHCR image digest for `ghcr.io/getalby/hub:v1.23.0`
- Refresh Umbrel release notes for the v1.23.0 release

Upstream release: https://github.com/getAlby/hub/releases/tag/v1.23.0

## Verification
- Resolved GHCR digest via registry HEAD request: `sha256:03074e1cb7a1814fcecedfd6e2bf2b2fe8643b2891db03cfb634076252138962`
- Parsed `albyhub/docker-compose.yml` and `albyhub/umbrel-app.yml` as YAML
- Asserted v1.23.0 image, digest, app version, release notes, and `HIDE_UPDATE_BANNER: "true"`
- `git diff --check`
