### PR TITLE
Update rusty-kaspad to v2.0.1

### DIFF
--- a/rusty-kaspad/docker-compose.yml
+++ b/rusty-kaspad/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - kaspad
 
   kaspad:
-    image: kaspanet/rusty-kaspad:v2.0.0@sha256:cbd449bc19cde32218d0fa82825659c99006d5ce838774618961fa25a907a051
+    image: kaspanet/rusty-kaspad:v2.0.1@sha256:db36449e2f41cf33ab7c26683ce390cb71bdea9c403eefd2e740a7d5605bcd8b
     restart: on-failure
     stop_grace_period: 3m
     volumes:

--- a/rusty-kaspad/umbrel-app.yml
+++ b/rusty-kaspad/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: rusty-kaspad
 category: crypto
 name: Rusty Kaspad
-version: "v2.0.0"
+version: "v2.0.1"
 tagline: A Rust implementation of a Kaspa full node
 description: |
   Rusty Kaspad is a Rust implementation of a Kaspa full node. This node software provides essential Kaspa network services including peer-to-peer networking and RPC functionality.
@@ -25,21 +25,22 @@ gallery:
   - 1.jpg
   - 2.jpg
 releaseNotes: >-
-  ⚠️ This release updates Rusty Kaspa to v2.0.0 for the Toccata hardfork. The hardfork is scheduled to activate on mainnet at DAA score 474,165,565, around June 30, 2026 at 16:15 UTC.
+  This release updates Rusty Kaspa to v2.0.1, a drop-in maintenance update for v2.0.0 nodes.
 
 
   Key highlights in this release:
-    - Toccata hardfork support, including the new P2P protocol version 10
-    - Native L1 covenant programming support and infrastructure for based ZK applications
-    - Updated transaction handling for Toccata transaction fields
-    - Higher minimum standard fee policy for RPC-submitted transactions ahead of activation
-    - Compatibility updates for gRPC/protobuf integrators, miners, pools, explorers, and wallets
+    - New RPC support for Toccata seq-commit state and lane proofs
+    - Wallet/core and Wasm notifications for SMT sync progress
+    - SMT database inspection tooling for operators and developers
+    - Improved transaction-generation tooling for user-lane workflows
+    - Node sync and error-reporting refinements
+    - Refined covenant binding handling across client and wallet components
 
 
   Full release notes can be found at https://github.com/kaspanet/rusty-kaspa/releases
 
 
-  Starting 24 hours before activation, nodes will only connect to peers using P2P protocol version 10. The node database upgrade is one-way; downgrading to an older node version requires resyncing.
+  All mainnet operators are encouraged to upgrade from v2.0.0 to v2.0.1.
 submitter: Luke Dunshea
 submission: https://github.com/getumbrel/umbrel-apps/pull/2060
 backupIgnore:


### PR DESCRIPTION
## Summary

Updates Rusty Kaspad from v2.0.0 to v2.0.1.

This is a drop-in maintenance update for v2.0.0 nodes, with RPC and Wasm SDK improvements, operational tooling, and general node maintenance.

## Changes

- Bumps `kaspanet/rusty-kaspad` to `v2.0.1`
- Pins the Docker image to the v2.0.1 multi-arch digest
- Updates the Umbrel app version to `v2.0.1`
- Refreshes release notes for the v2.0.1 maintenance release

## Validation

- Parsed `rusty-kaspad/umbrel-app.yml` and `rusty-kaspad/docker-compose.yml` as YAML
- Ran `git diff --check`
- Confirmed the pinned Docker digest is the multi-arch image index for `kaspanet/rusty-kaspad:v2.0.1`
- Confirmed the image includes `linux/amd64` and `linux/arm64`