### PR TITLE
Update bolt12-pay to v0.2.106

### DIFF
--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.2.105.1@sha256:7439069d9ad67ff86f2b5a95e9aef9defb732184d75719f9291947118376100d
+    image: alex71btc/bolt12-pay:0.2.106@sha256:a1099a93be1e3a0620caa78096e2a6316172d09d16933a8ff2074a37a20236a8
     restart: on-failure
     depends_on:
       - lndk

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.105.1
+version: 0.2.106
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
@@ -44,12 +44,13 @@ submission: https://github.com/getumbrel/umbrel-apps/pull/5429
 repo: https://github.com/Alex71btc/lndk-pay
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
-  v0.2.105
+  v0.2.106
 
-  - Added support for true amountless BOLT12 offers
-  - Improved compatibility with Ocean Mining payouts
-  - Improved compatibility with Phoenix Wallet
-  - Updated LNDK with amountless offer payment fixes
+  - Added optional Privacy Mode
+  - BOLT12 + BIP353 operation without LNURL fallback
+  - LNURL metadata and callback endpoints disabled in Privacy Mode
+  - Improved setup UI with payment mode selection
+  - BIP353-first public alias display
 dependencies:
   - lightning
 gallery:


### PR DESCRIPTION
Changes:

* Added optional Privacy Mode
* BOLT12 + BIP353 operation without LNURL fallback
* LNURL metadata and callback endpoints disabled in Privacy Mode
* Improved setup experience with payment mode selection
* Public alias pages now prioritize BIP353 addresses

Docker image:
alex71btc/bolt12-pay:0.2.106
