### PR TITLE
Update Bolt12 Pay to v0.2.108

### DIFF
--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.2.106@sha256:a1099a93be1e3a0620caa78096e2a6316172d09d16933a8ff2074a37a20236a8
+    image: alex71btc/bolt12-pay:0.2.108@sha256:33df5203b894ef102b4e9823ee7005548e7304747b6466347cfc31a2c89a5910
     restart: on-failure
     depends_on:
       - lndk

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.106
+version: 0.2.108
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
@@ -44,13 +44,17 @@ submission: https://github.com/getumbrel/umbrel-apps/pull/5429
 repo: https://github.com/Alex71btc/lndk-pay
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
-  v0.2.106
 
-  - Added optional Privacy Mode
-  - BOLT12 + BIP353 operation without LNURL fallback
-  - LNURL metadata and callback endpoints disabled in Privacy Mode
-  - Improved setup UI with payment mode selection
-  - BIP353-first public alias display
+  - Migrated offer history from browser localStorage to server-side SQLite
+  - Offer history now syncs across devices and browser sessions
+  - Added direct BIP353 publishing from offer history
+  - Added Lightning Address tracking for history entries
+  - Added Lightning Address deletion with automatic Cloudflare DNS cleanup
+  - Deleting offers now removes associated BIP353 records and DNS entries
+  - Clearing history now removes all associated BIP353 records and DNS entries
+  - New Lightning Addresses appear instantly in history without page refresh
+
+
 dependencies:
   - lightning
 gallery:

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -44,17 +44,13 @@ submission: https://github.com/getumbrel/umbrel-apps/pull/5429
 repo: https://github.com/Alex71btc/lndk-pay
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
-  v0.2.108
 
-  - Added optional Privacy Mode
-  - BOLT12 + BIP353 operation without LNURL fallback
-  - LNURL metadata and callback endpoints disabled in Privacy Mode
-  - Improved setup UI with payment mode selection
-  - BIP353-first public alias display
-  - Publish BIP353 Lightning Addresses directly from Offer History
-  - Automatic DNS cleanup when deleting history entries
-  - Automatic DNS cleanup when clearing offer history
-  - Create private BIP353 addresses without exposing them on the public alias page
+ - Publish BIP353 Lightning Addresses directly from Offer History
+ - Create private Lightning Addresses for customers, events, or temporary use
+ - Automatic DNS cleanup when deleting history entries or clearing history
+ - Improved Offer History management with server-side persistence
+ - Extends the Privacy Mode features introduced in v0.2.106
+
 
 dependencies:
   - lightning

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -44,16 +44,17 @@ submission: https://github.com/getumbrel/umbrel-apps/pull/5429
 repo: https://github.com/Alex71btc/lndk-pay
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
+  v0.2.108
 
-  - Migrated offer history from browser localStorage to server-side SQLite
-  - Offer history now syncs across devices and browser sessions
-  - Added direct BIP353 publishing from offer history
-  - Added Lightning Address tracking for history entries
-  - Added Lightning Address deletion with automatic Cloudflare DNS cleanup
-  - Deleting offers now removes associated BIP353 records and DNS entries
-  - Clearing history now removes all associated BIP353 records and DNS entries
-  - New Lightning Addresses appear instantly in history without page refresh
-
+  - Added optional Privacy Mode
+  - BOLT12 + BIP353 operation without LNURL fallback
+  - LNURL metadata and callback endpoints disabled in Privacy Mode
+  - Improved setup UI with payment mode selection
+  - BIP353-first public alias display
+  - Publish BIP353 Lightning Addresses directly from Offer History
+  - Automatic DNS cleanup when deleting history entries
+  - Automatic DNS cleanup when clearing offer history
+  - Create private BIP353 addresses without exposing them on the public alias page
 
 dependencies:
   - lightning


### PR DESCRIPTION
## What's new in v0.2.108

This release adds BIP353 publishing directly from Offer History.

Users can now create BIP353 Lightning Addresses from previously generated offers without creating a public alias entry.

Key benefits:

* Publish BIP353 addresses directly from Offer History
* Automatic Cloudflare DNS record creation
* Automatic DNS cleanup when deleting history entries
* Automatic DNS cleanup when clearing Offer History
* Create private BIP353 Lightning Addresses that are not exposed on the public alias page
* Useful for temporary payment requests, customer-specific addresses, testing, and privacy-focused workflows

This release also includes the recently added Privacy Mode, allowing pure BOLT12/BIP353 operation without LNURL fallback.
