### PR TITLE
Add Geyser funding link

### DIFF
--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -36,6 +36,10 @@ description: >-
   and this app uses cutting-edge Lightning features.
 
 
+  Support ongoing development:
+  https://geyser.fund/project/bolt12pay
+
+
   Made for sovereign Bitcoin users.
 developer: Alex71btc
 website: https://github.com/Alex71btc


### PR DESCRIPTION
Type:
Metadata only

App ID:
bolt12-pay

Upstream project:
https://github.com/Alex71btc/lndk-pay

Version:
0.2.108

Summary:

Adds a link to the BOLT12 Pay Geyser funding page in the app description.

This allows users to support ongoing open-source development and maintenance.

No functional changes.

Verification:

Environment tested:
[x] Umbrel device

Architecture tested:
[x] amd64