### PR TITLE
Add PearCircle Seeder

### DIFF
--- a/pearcircle-seeder/docker-compose.yml
+++ b/pearcircle-seeder/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: pearcircle-seeder_app_1
+      APP_PORT: 8730
+
+  app:
+    image: ghcr.io/peerloomllc/pearcircle-seeder:0.1.7@sha256:7b2ac94ec51428e5ebb324aa28ad65ac27f8195bf06b46ac568b6520cab14a51
+    restart: on-failure
+    stop_grace_period: 1m
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      SEEDER_HOST: 0.0.0.0
+      SEEDER_PORT: "8730"
+      SEEDER_NO_AUTH: "1"
+    volumes:
+      # Seeder identity, per-circle enrollments, retention state, logs.
+      - ${APP_DATA_DIR}/data:/data

--- a/pearcircle-seeder/docker-compose.yml
+++ b/pearcircle-seeder/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8730
 
   app:
-    image: ghcr.io/peerloomllc/pearcircle-seeder:0.1.7@sha256:7b2ac94ec51428e5ebb324aa28ad65ac27f8195bf06b46ac568b6520cab14a51
+    image: ghcr.io/peerloomllc/pearcircle-seeder:1.0.17@sha256:305485b61dea25507b245066b9d8fd8405b0841132ed8a3b9d3b6e6991198f20
     restart: on-failure
     stop_grace_period: 1m
     security_opt:

--- a/pearcircle-seeder/docker-compose.yml
+++ b/pearcircle-seeder/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       SEEDER_HOST: 0.0.0.0
       SEEDER_PORT: "8730"
       SEEDER_NO_AUTH: "1"
+      SEEDER_NO_UPDATE_CHECK: "1"
     volumes:
       # Seeder identity, per-circle enrollments, retention state, logs.
       - ${APP_DATA_DIR}/data:/data

--- a/pearcircle-seeder/umbrel-app.yml
+++ b/pearcircle-seeder/umbrel-app.yml
@@ -33,7 +33,11 @@ dependencies: []
 repo: https://github.com/peerloomllc/pearcircle
 support: https://github.com/peerloomllc/pearcircle/issues
 port: 8731
-gallery: []
+gallery:
+  - 1.webp
+  - 2.webp
+  - 3.webp
+  - 4.webp
 path: ""
 defaultUsername: ""
 defaultPassword: ""

--- a/pearcircle-seeder/umbrel-app.yml
+++ b/pearcircle-seeder/umbrel-app.yml
@@ -1,0 +1,41 @@
+manifestVersion: 1
+id: pearcircle-seeder
+category: networking
+name: PearCircle Seeder
+version: "0.1.7"
+tagline: Keep your PearCircle circles online 24/7
+description: >-
+  Run a blind seeder for your PearCircle circles on your Umbrel so their
+  history stays in sync even when every phone is offline.
+
+
+  PearCircle is a peer-to-peer location-sharing app with no accounts and no
+  servers: a circle's data lives only on its members' devices and syncs
+  directly between them. That means a circle is only reachable while at least
+  one member's phone is online. This app runs the PearCircle seed-mode worklet
+  as an always-on background service that replicates each enrolled circle's
+  encrypted blocks, so members stay caught up regardless of who's online.
+
+
+  It is a "blind" seeder: the blocks it stores and serves stay encrypted, so
+  your Umbrel keeps a circle's data available without ever being able to read
+  the locations, places, or members inside it. Circle members stay in control —
+  they admit the seeder when it enrolls and can revoke it at any time, and each
+  circle has its own retention window (forever, 30 days, 7 days, or 24 hours).
+
+
+  To enroll a circle: open the seeder dashboard, then in the PearCircle phone
+  app mint a seed invite for the circle and paste it in.
+releaseNotes: ""
+developer: PeerLoom
+website: https://peerloomllc.com
+dependencies: []
+repo: https://github.com/peerloomllc/pearcircle
+support: https://github.com/peerloomllc/pearcircle/issues
+port: 8731
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: PeerLoom
+submission: https://github.com/getumbrel/umbrel-apps/pull/REPLACE_WITH_PR_NUMBER

--- a/pearcircle-seeder/umbrel-app.yml
+++ b/pearcircle-seeder/umbrel-app.yml
@@ -38,4 +38,4 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: PeerLoom
-submission: https://github.com/getumbrel/umbrel-apps/pull/REPLACE_WITH_PR_NUMBER
+submission: https://github.com/getumbrel/umbrel-apps/pull/5761

--- a/pearcircle-seeder/umbrel-app.yml
+++ b/pearcircle-seeder/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: pearcircle-seeder
 category: networking
 name: PearCircle Seeder
-version: "0.1.7"
+version: "1.0.17"
 tagline: Keep your PearCircle circles online 24/7
 description: >-
   Run a blind seeder for your PearCircle circles on your Umbrel so their


### PR DESCRIPTION
## PearCircle Seeder

An always-on "blind" seeder for [PearCircle](https://github.com/peerloomllc/pearcircle), a peer-to-peer, serverless location-sharing app. A circle's data lives only on members' phones and syncs directly between them, so it's only reachable while a phone is online. This app runs the PearCircle seed-mode worklet 24/7 to replicate each enrolled circle's **encrypted** blocks - the seeder never receives the encryption key, so it keeps a circle available without ever being able to read the locations, places, or members inside it.

  - **App / version:** pearcircle-seeder 0.1.7
  - **Upstream (open source):** https://github.com/peerloomllc/pearcircle
  - **Image:** `ghcr.io/peerloomllc/pearcircle-seeder` - public, multi-arch (linux/amd64 + linux/arm64), pinned to the manifest-list digest. Built from `seeder-launcher/umbrel/Dockerfile` in the upstream repo.

  ### Web UI
Opens to a dashboard: seeder status, replicated bytes, enroll a circle (paste a seed invite minted in the PearCircle phone app), per-circle retention controls. Not headless.

  ### Credentials / setup
No app-level credentials - access is gated by Umbrel's login via `app_proxy` (the container disables the in-app token, `SEEDER_NO_AUTH=1`); `defaultUsername`/`defaultPassword` are empty. 
Setup: open the app → in the PearCircle phone app mint a seed invite → paste it into the dashboard → members approve the seeder on their phones.

  ### Host access
None beyond the app data dir. No host Docker socket, no privileged mode, no host mounts, no host networking. State persists under `${APP_DATA_DIR}/data`. `security_opt: no-new-privileges:true` is defensive hardening (the seeder needs no privilege escalation) - this is the lone linter warning, justified here.

  ### Networking
Peer-to-peer over Hyperswarm/HyperDHT (UDP with NAT hole-punching) - validated replicating through Docker's bridge NAT with no host networking. Internal web port 8730; app_proxy host port 8731.

  ### Testing performed
- Installed on umbrelOS (x86_64); opens to the dashboard behind `app_proxy`.
- Enrolled a circle from a seed invite; confirmed encrypted-block replication with two phone members.
- Restart + data persistence verified (identity + enrollments survive).
- arm64 image built + published; not yet smoke-tested on physical arm64 hardware.

 ### Screenshots
<img width="914" height="882" alt="umbrel_seeder_dashboard" src="https://github.com/user-attachments/assets/faac3208-e3c0-489a-9826-3b4757474612" />

 ### Logo
<img width="1024" height="1024" alt="icon" src="https://github.com/user-attachments/assets/7b01a4c1-81e9-401f-b1e3-8881045c73bc" />
