### PR TITLE
Add Ollama model dashboard

### DIFF
--- a/ollama/dashboard/catalog.json
+++ b/ollama/dashboard/catalog.json
@@ -1,0 +1,106 @@
+{
+  "cloud": [
+    {
+      "id": "glm-5.1:cloud",
+      "name": "GLM 5.1 Cloud",
+      "reasoning": true,
+      "contextWindow": 202752,
+      "maxTokens": 131072
+    },
+    {
+      "id": "glm-5:cloud",
+      "name": "GLM 5 Cloud",
+      "reasoning": true,
+      "contextWindow": 202752,
+      "maxTokens": 131072
+    },
+    {
+      "id": "kimi-k2.6:cloud",
+      "name": "Kimi K2.6 Cloud",
+      "reasoning": true,
+      "contextWindow": 256000,
+      "maxTokens": 128000
+    },
+    {
+      "id": "kimi-k2.5:cloud",
+      "name": "Kimi K2.5 Cloud",
+      "reasoning": true,
+      "contextWindow": 256000,
+      "maxTokens": 128000
+    },
+    {
+      "id": "minimax-m3:cloud",
+      "name": "MiniMax M3 Cloud",
+      "reasoning": true,
+      "contextWindow": 256000,
+      "maxTokens": 128000
+    },
+    {
+      "id": "minimax-m2.7:cloud",
+      "name": "MiniMax M2.7 Cloud",
+      "reasoning": true,
+      "contextWindow": 256000,
+      "maxTokens": 128000
+    }
+  ],
+  "local": [
+    {
+      "id": "llama3.2:3b",
+      "name": "Llama 3.2 3B",
+      "family": "llama",
+      "size": "2.0 GB",
+      "contextWindow": 131072
+    },
+    {
+      "id": "qwen2.5-coder:7b",
+      "name": "Qwen 2.5 Coder 7B",
+      "family": "qwen",
+      "size": "4.7 GB",
+      "contextWindow": 32768
+    },
+    {
+      "id": "qwen2.5:7b",
+      "name": "Qwen 2.5 7B",
+      "family": "qwen",
+      "size": "4.7 GB",
+      "contextWindow": 32768
+    },
+    {
+      "id": "gemma3:4b",
+      "name": "Gemma 3 4B",
+      "family": "gemma",
+      "size": "3.3 GB",
+      "contextWindow": 131072
+    },
+    {
+      "id": "deepseek-r1:7b",
+      "name": "DeepSeek R1 7B",
+      "family": "deepseek",
+      "size": "4.7 GB",
+      "contextWindow": 32768,
+      "reasoning": true
+    },
+    {
+      "id": "mistral:7b",
+      "name": "Mistral 7B",
+      "family": "mistral",
+      "size": "4.1 GB",
+      "contextWindow": 32768
+    },
+    {
+      "id": "phi4-mini:latest",
+      "name": "Phi 4 Mini",
+      "family": "phi",
+      "size": "2.5 GB",
+      "contextWindow": 131072
+    },
+    {
+      "id": "nomic-embed-text:latest",
+      "name": "Nomic Embed Text",
+      "family": "nomic",
+      "size": "274 MB",
+      "contextWindow": 8192,
+      "supportsChat": false
+    }
+  ]
+}

--- a/ollama/dashboard/public/app.js
+++ b/ollama/dashboard/public/app.js
@@ -14,8 +14,17 @@ const counts = {
 };
 
 let models = [];
+let remoteModels = [];
 let filter = "all";
 let saving = false;
+let searchTimer = null;
+let searchRequest = 0;
+
+function isCloudModel(id) {
+  const normalized = String(id || "").trim().toLowerCase();
+  const tag = normalized.includes(":") ? normalized.split(":").pop() : "";
+  return normalized.endsWith(":cloud") || tag.endsWith("-cloud");
+}
 
 function formatBytes(bytes) {
   if (!bytes) return "";
@@ -49,12 +58,22 @@ function detailText(model) {
   if (model.contextWindow) parts.push(`${Number(model.contextWindow).toLocaleString()} context`);
   if (model.reasoning) parts.push("reasoning");
   if (model.supportsChat === false) parts.push("embedding");
+  if (model.pulls) parts.push(`${model.pulls} pulls`);
+  if (model.description) parts.push(model.description);
   return parts.join(" / ") || model.source || "";
+}
+
+function allModels() {
+  const byId = new Map(models.map((model) => [model.id, model]));
+  for (const model of remoteModels) {
+    if (!byId.has(model.id)) byId.set(model.id, { ...model, remote: true });
+  }
+  return Array.from(byId.values());
 }
 
 function visibleModels() {
   const query = searchInput.value.trim().toLowerCase();
-  return models.filter((model) => {
+  return allModels().filter((model) => {
     if (filter === "cloud" && model.type !== "cloud") return false;
     if (filter === "local" && model.type !== "local") return false;
     if (filter === "enabled" && !model.enabled) return false;
@@ -113,8 +132,8 @@ function escapeHtml(value) {
   }[char]));
 }
 
-async function load() {
-  const response = await fetch("/api/dashboard/state", { cache: "no-store" });
+async function load(forceRefresh = false) {
+  const response = await fetch(`/api/dashboard/state${forceRefresh ? "?refresh=1" : ""}`, { cache: "no-store" });
   const state = await response.json();
   if (!response.ok) throw new Error(state.detail || state.error || "Failed to load state");
   models = state.models || [];
@@ -150,7 +169,21 @@ rows.addEventListener("change", (event) => {
   const input = event.target.closest("input[type='checkbox'][data-id]");
   if (!input) return;
   const model = models.find((item) => item.id === input.dataset.id);
-  if (model) model.enabled = input.checked;
+  if (model) {
+    model.enabled = input.checked;
+  } else if (input.checked) {
+    const remote = remoteModels.find((item) => item.id === input.dataset.id);
+    if (remote) {
+      models.push({
+        ...remote,
+        remote: undefined,
+        type: isCloudModel(remote.id) ? "cloud" : remote.type,
+        enabled: true,
+        installed: remote.installed || isCloudModel(remote.id),
+        downloadable: !isCloudModel(remote.id)
+      });
+    }
+  }
   render();
 });
 
@@ -162,8 +195,35 @@ segments.forEach((button) => {
   });
 });
 
-searchInput.addEventListener("input", render);
-refreshButton.addEventListener("click", () => load().catch((error) => {
+async function searchRemoteModels(query, requestId) {
+  if (query.trim().length < 2) {
+    remoteModels = [];
+    render();
+    return;
+  }
+  const response = await fetch(`/api/dashboard/search?q=${encodeURIComponent(query.trim())}`, { cache: "no-store" });
+  const payload = await response.json();
+  if (!response.ok) throw new Error(payload.detail || payload.error || "Model search failed");
+  if (requestId !== searchRequest) return;
+  remoteModels = payload.models || [];
+  render();
+}
+
+searchInput.addEventListener("input", () => {
+  render();
+  clearTimeout(searchTimer);
+  const query = searchInput.value;
+  const requestId = ++searchRequest;
+  searchTimer = setTimeout(() => {
+    searchRemoteModels(query, requestId).catch((error) => {
+      if (requestId !== searchRequest) return;
+      remoteModels = [];
+      statusEl.textContent = error.message;
+      render();
+    });
+  }, 250);
+});
+refreshButton.addEventListener("click", () => load(true).catch((error) => {
   statusEl.textContent = error.message;
 }));
 saveButton.addEventListener("click", () => {
@@ -177,10 +237,10 @@ addButton.addEventListener("click", () => {
   models.push({
     id,
     name: id,
-    type: id.endsWith(":cloud") ? "cloud" : "local",
-    enabled: id.endsWith(":cloud"),
-    installed: id.endsWith(":cloud"),
-    downloadable: !id.endsWith(":cloud"),
+    type: isCloudModel(id) ? "cloud" : "local",
+    enabled: isCloudModel(id),
+    installed: isCloudModel(id),
+    downloadable: !isCloudModel(id),
     source: "custom"
   });
   customInput.value = "";

--- a/ollama/dashboard/public/app.js
+++ b/ollama/dashboard/public/app.js
@@ -1,0 +1,201 @@
+const rows = document.querySelector("#models");
+const statusEl = document.querySelector("#status");
+const saveButton = document.querySelector("#save");
+const refreshButton = document.querySelector("#refresh");
+const searchInput = document.querySelector("#search");
+const customInput = document.querySelector("#custom-model");
+const addButton = document.querySelector("#add-model");
+const segments = Array.from(document.querySelectorAll(".segment"));
+const counts = {
+  enabled: document.querySelector("#enabled-count"),
+  cloud: document.querySelector("#cloud-count"),
+  local: document.querySelector("#local-count"),
+  pull: document.querySelector("#pull-count")
+};
+
+let models = [];
+let filter = "all";
+let saving = false;
+
+function formatBytes(bytes) {
+  if (!bytes) return "";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = Number(bytes);
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(value >= 10 || unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+function statusFor(model) {
+  if (model.pull?.status === "pulling" || model.pull?.status === "queued") {
+    const progress = model.pull.total ? ` ${Math.round((model.pull.completed / model.pull.total) * 100)}%` : "";
+    return { label: `${model.pull.message || "Pulling"}${progress}`, tone: "warn" };
+  }
+  if (model.pull?.status === "error") return { label: model.pull.message || "Pull failed", tone: "error" };
+  if (model.type === "cloud") return { label: "Cloud", tone: "cloud" };
+  if (model.installed) return { label: "Installed", tone: "local" };
+  return { label: "Downloadable", tone: "warn" };
+}
+
+function detailText(model) {
+  const parts = [];
+  if (model.family) parts.push(model.family);
+  if (model.parameterSize) parts.push(model.parameterSize);
+  if (model.quantization) parts.push(model.quantization);
+  if (model.size || model.sizeBytes) parts.push(model.size || formatBytes(model.sizeBytes));
+  if (model.contextWindow) parts.push(`${Number(model.contextWindow).toLocaleString()} context`);
+  if (model.reasoning) parts.push("reasoning");
+  if (model.supportsChat === false) parts.push("embedding");
+  return parts.join(" / ") || model.source || "";
+}
+
+function visibleModels() {
+  const query = searchInput.value.trim().toLowerCase();
+  return models.filter((model) => {
+    if (filter === "cloud" && model.type !== "cloud") return false;
+    if (filter === "local" && model.type !== "local") return false;
+    if (filter === "enabled" && !model.enabled) return false;
+    if (!query) return true;
+    return [model.id, model.name, model.family, model.source].filter(Boolean).join(" ").toLowerCase().includes(query);
+  });
+}
+
+function render() {
+  const enabled = models.filter((model) => model.enabled).length;
+  const cloud = models.filter((model) => model.type === "cloud").length;
+  const local = models.filter((model) => model.type === "local").length;
+  const pulling = models.filter((model) => model.pull && ["queued", "pulling"].includes(model.pull.status)).length;
+  counts.enabled.textContent = enabled;
+  counts.cloud.textContent = cloud;
+  counts.local.textContent = local;
+  counts.pull.textContent = pulling;
+
+  rows.innerHTML = "";
+  for (const model of visibleModels()) {
+    const tr = document.createElement("tr");
+    const state = statusFor(model);
+    tr.innerHTML = `
+      <td>
+        <label class="switch" title="Enable ${model.id}">
+          <input type="checkbox" ${model.enabled ? "checked" : ""} data-id="${escapeHtml(model.id)}">
+          <span class="slider"></span>
+        </label>
+      </td>
+      <td>
+        <div class="modelName">
+          <strong>${escapeHtml(model.name || model.id)}</strong>
+          <code>${escapeHtml(model.id)}</code>
+        </div>
+      </td>
+      <td><span class="badge ${model.type}">${model.type === "cloud" ? "Cloud" : "Local"}</span></td>
+      <td><span class="badge ${state.tone}">${escapeHtml(state.label)}</span></td>
+      <td class="details">${escapeHtml(detailText(model))}</td>
+    `;
+    rows.appendChild(tr);
+  }
+  if (!rows.children.length) {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `<td colspan="5" class="details">No models match the current filter.</td>`;
+    rows.appendChild(tr);
+  }
+}
+
+function escapeHtml(value) {
+  return String(value || "").replace(/[&<>"']/g, (char) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    "\"": "&quot;",
+    "'": "&#39;"
+  }[char]));
+}
+
+async function load() {
+  const response = await fetch("/api/dashboard/state", { cache: "no-store" });
+  const state = await response.json();
+  if (!response.ok) throw new Error(state.detail || state.error || "Failed to load state");
+  models = state.models || [];
+  statusEl.textContent = state.ollamaReachable
+    ? `Connected to ${state.ollamaBaseUrl}. Selection is persisted at ${state.configPath}.`
+    : `Ollama is not reachable: ${state.ollamaError || "unknown error"}`;
+  render();
+}
+
+async function save() {
+  saving = true;
+  saveButton.disabled = true;
+  saveButton.textContent = "Saving";
+  try {
+    const response = await fetch("/api/dashboard/config", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ models: models.map(({ id, enabled }) => ({ id, enabled })) })
+    });
+    const state = await response.json();
+    if (!response.ok) throw new Error(state.detail || state.error || "Save failed");
+    models = state.models || [];
+    statusEl.textContent = "Selection saved. Enabled local models will pull in the background.";
+    render();
+  } finally {
+    saving = false;
+    saveButton.disabled = false;
+    saveButton.textContent = "Save";
+  }
+}
+
+rows.addEventListener("change", (event) => {
+  const input = event.target.closest("input[type='checkbox'][data-id]");
+  if (!input) return;
+  const model = models.find((item) => item.id === input.dataset.id);
+  if (model) model.enabled = input.checked;
+  render();
+});
+
+segments.forEach((button) => {
+  button.addEventListener("click", () => {
+    filter = button.dataset.filter;
+    segments.forEach((item) => item.classList.toggle("active", item === button));
+    render();
+  });
+});
+
+searchInput.addEventListener("input", render);
+refreshButton.addEventListener("click", () => load().catch((error) => {
+  statusEl.textContent = error.message;
+}));
+saveButton.addEventListener("click", () => {
+  if (!saving) save().catch((error) => {
+    statusEl.textContent = error.message;
+  });
+});
+addButton.addEventListener("click", () => {
+  const id = customInput.value.trim();
+  if (!id || models.some((model) => model.id === id)) return;
+  models.push({
+    id,
+    name: id,
+    type: id.endsWith(":cloud") ? "cloud" : "local",
+    enabled: id.endsWith(":cloud"),
+    installed: id.endsWith(":cloud"),
+    downloadable: !id.endsWith(":cloud"),
+    source: "custom"
+  });
+  customInput.value = "";
+  render();
+});
+customInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") addButton.click();
+});
+
+load().catch((error) => {
+  statusEl.textContent = error.message;
+  render();
+});
+setInterval(() => {
+  if (!saving && models.some((model) => model.pull && ["queued", "pulling"].includes(model.pull.status))) {
+    load().catch(() => {});
+  }
+}, 5000);

--- a/ollama/dashboard/public/index.html
+++ b/ollama/dashboard/public/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Ollama Models</title>
+    <link rel="stylesheet" href="/styles.css">
+  </head>
+  <body>
+    <main class="shell">
+      <header class="topbar">
+        <div>
+          <h1>Ollama Models</h1>
+          <p id="status" class="muted">Loading model state</p>
+        </div>
+        <div class="actions">
+          <button id="refresh" class="iconButton" title="Refresh model list" aria-label="Refresh model list">Refresh</button>
+          <button id="save" class="primaryButton">Save</button>
+        </div>
+      </header>
+
+      <section class="toolbar" aria-label="Model filters">
+        <label class="search">
+          <span>Search</span>
+          <input id="search" type="search" placeholder="Model name or family">
+        </label>
+        <div class="segments" role="tablist" aria-label="Model type">
+          <button class="segment active" data-filter="all">All</button>
+          <button class="segment" data-filter="cloud">Cloud</button>
+          <button class="segment" data-filter="local">Local</button>
+          <button class="segment" data-filter="enabled">Enabled</button>
+        </div>
+      </section>
+
+      <section class="customModel" aria-label="Add custom model">
+        <input id="custom-model" type="text" spellcheck="false" placeholder="Add any Ollama model, for example llama3.2:1b">
+        <button id="add-model" class="secondaryButton">Add</button>
+      </section>
+
+      <section class="summary" aria-label="Model summary">
+        <div><strong id="enabled-count">0</strong><span>Enabled</span></div>
+        <div><strong id="cloud-count">0</strong><span>Cloud</span></div>
+        <div><strong id="local-count">0</strong><span>Local</span></div>
+        <div><strong id="pull-count">0</strong><span>Pulling</span></div>
+      </section>
+
+      <section class="tableWrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Enabled</th>
+              <th>Model</th>
+              <th>Type</th>
+              <th>Status</th>
+              <th>Details</th>
+            </tr>
+          </thead>
+          <tbody id="models"></tbody>
+        </table>
+      </section>
+    </main>
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/ollama/dashboard/public/styles.css
+++ b/ollama/dashboard/public/styles.css
@@ -1,0 +1,324 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f6f7f8;
+  --panel: #ffffff;
+  --text: #15191f;
+  --muted: #5c6673;
+  --line: #d8dde5;
+  --accent: #1d766f;
+  --accent-strong: #155f59;
+  --blue: #255f9b;
+  --amber: #936100;
+  --danger: #a33a2a;
+  --shadow: 0 8px 24px rgba(20, 26, 32, 0.08);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #101317;
+    --panel: #181d23;
+    --text: #eef2f6;
+    --muted: #a5afbc;
+    --line: #303843;
+    --accent: #42b3a9;
+    --accent-strong: #63cbc2;
+    --blue: #7eafe6;
+    --amber: #d0a24c;
+    --danger: #e27664;
+    --shadow: none;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.shell {
+  width: min(1180px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 28px 0 40px;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  align-items: flex-start;
+  margin-bottom: 20px;
+}
+
+h1 {
+  margin: 0 0 6px;
+  font-size: 30px;
+  line-height: 1.1;
+  letter-spacing: 0;
+}
+
+.muted {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.actions,
+.segments,
+.customModel {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.primaryButton,
+.secondaryButton,
+.iconButton,
+.segment {
+  min-height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 14px;
+  background: var(--panel);
+  color: var(--text);
+}
+
+.primaryButton {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #fff;
+  font-weight: 650;
+}
+
+.primaryButton:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
+.segment.active {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+  font-weight: 650;
+}
+
+.toolbar {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) auto;
+  gap: 12px;
+  align-items: end;
+  margin-bottom: 12px;
+}
+
+.search {
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+input {
+  width: 100%;
+  min-height: 40px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 12px;
+  background: var(--panel);
+  color: var(--text);
+}
+
+.customModel {
+  margin-bottom: 14px;
+}
+
+.summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.summary div {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+
+.summary strong {
+  display: block;
+  font-size: 22px;
+  line-height: 1.1;
+}
+
+.summary span {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.tableWrap {
+  overflow: auto;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 13px 14px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: middle;
+}
+
+th {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+tr:last-child td {
+  border-bottom: 0;
+}
+
+.modelName {
+  display: grid;
+  gap: 4px;
+}
+
+.modelName strong {
+  font-size: 15px;
+}
+
+.modelName code {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  border-radius: 999px;
+  padding: 0 9px;
+  background: color-mix(in srgb, var(--line), transparent 45%);
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.badge.cloud {
+  color: var(--blue);
+}
+
+.badge.local {
+  color: var(--accent-strong);
+}
+
+.badge.warn {
+  color: var(--amber);
+}
+
+.badge.error {
+  color: var(--danger);
+}
+
+.details {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.switch {
+  position: relative;
+  display: inline-flex;
+  width: 46px;
+  height: 26px;
+}
+
+.switch input {
+  position: absolute;
+  opacity: 0;
+}
+
+.slider {
+  position: absolute;
+  inset: 0;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--line), transparent 20%);
+}
+
+.slider::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--panel);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 140ms ease;
+}
+
+.switch input:checked + .slider {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.switch input:checked + .slider::after {
+  transform: translateX(20px);
+}
+
+@media (max-width: 760px) {
+  .shell {
+    width: min(100vw - 20px, 1180px);
+    padding-top: 18px;
+  }
+
+  .topbar,
+  .toolbar {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+
+  .actions,
+  .segments,
+  .customModel {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .actions > *,
+  .customModel button {
+    flex: 1;
+  }
+
+  .summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/ollama/dashboard/server.js
+++ b/ollama/dashboard/server.js
@@ -14,6 +14,14 @@ const CONFIG_PATH = path.join(CONFIG_DIR, "ollama-dashboard.json");
 const MANIFEST_PATH = path.join(CONFIG_DIR, "model-manifest.json");
 const DISABLED_MODELS_ENV_PATH = path.join(CONFIG_DIR, "disabled-models.env");
 const pullJobs = new Map();
+const searchCache = new Map();
+const cloudCatalogCache = { checkedAt: 0, models: [] };
+const OLLAMA_LIBRARY_BASE_URL = (process.env.OLLAMA_LIBRARY_BASE_URL || "https://ollama.com").replace(/\/+$/, "");
+const OLLAMA_CLOUD_CATALOG_ENABLED = !["0", "false", "no", "off"].includes(String(process.env.OLLAMA_CLOUD_CATALOG_ENABLED || "1").trim().toLowerCase());
+const OLLAMA_CLOUD_CATALOG_URL = process.env.OLLAMA_CLOUD_CATALOG_URL || `${OLLAMA_LIBRARY_BASE_URL}/search?c=cloud`;
+const OLLAMA_CLOUD_CATALOG_TTL_MS = Number(process.env.OLLAMA_CLOUD_CATALOG_TTL_SECONDS || 21600) * 1000;
+const OLLAMA_CLOUD_CATALOG_MAX_LIBRARIES = Number(process.env.OLLAMA_CLOUD_CATALOG_MAX_LIBRARIES || 200);
+const OLLAMA_CLOUD_CATALOG_MAX_PAGES = Number(process.env.OLLAMA_CLOUD_CATALOG_MAX_PAGES || 8);
 
 const contentTypes = {
   ".html": "text/html; charset=utf-8",
@@ -96,23 +104,159 @@ async function fetchTags() {
   }
 }
 
+async function fetchTextUrl(url, timeoutMs = 12000) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      headers: {
+        "accept": "text/html,application/json",
+        "user-agent": "ollama-umbrel-dashboard/ollama-cloud-discovery"
+      },
+      signal: controller.signal
+    });
+    if (!response.ok) throw new Error(`${url} returned HTTP ${response.status}`);
+    return await response.text();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 function normalizeModelId(value) {
   return String(value || "").trim();
 }
 
 function isCloudModel(id) {
-  return normalizeModelId(id).endsWith(":cloud");
+  const normalized = normalizeModelId(id).toLowerCase();
+  const tag = normalized.includes(":") ? normalized.split(":").pop() : "";
+  return normalized.endsWith(":cloud") || tag.endsWith("-cloud");
+}
+
+function modelTypeFor(id, entry = {}) {
+  const source = String(entry.source || "").toLowerCase();
+  if (entry.type === "cloud" || isCloudModel(id) || source === "ollama-cloud" || source === "cloud-catalog" || source === "saved-cloud") {
+    return "cloud";
+  }
+  return "local";
 }
 
 function modelName(entry) {
   return entry.name || entry.model || entry.id || "";
 }
 
-async function buildState() {
-  const [catalog, config, tags] = await Promise.all([
+function dedupeKeepOrder(items) {
+  const seen = new Set();
+  const ordered = [];
+  for (const item of items) {
+    if (!item || seen.has(item)) continue;
+    seen.add(item);
+    ordered.push(item);
+  }
+  return ordered;
+}
+
+function cloudModelMeta(id) {
+  const lower = String(id || "").toLowerCase();
+  const vision = ["gemini", "gemma4", "qwen3.5", "kimi-k2.5", "kimi-k2.6", "ministral", "devstral"].some((hint) => lower.includes(hint));
+  const nonTool = ["embed", "embedding", "ocr", "vision", "-vl", ":vl", "whisper", "tts"].some((hint) => lower.includes(hint));
+  return {
+    id,
+    name: id,
+    source: "ollama-cloud-catalog",
+    type: "cloud",
+    reasoning: ["deepseek", "qwen", "glm", "nemotron", "minimax", "kimi", "gemini", "gemma"].some((hint) => lower.includes(hint)),
+    contextWindow: 256000,
+    maxTokens: 128000,
+    supportsChat: true,
+    supportsTools: !nonTool,
+    supportsJson: true,
+    input: vision ? ["text", "image"] : ["text"],
+    supportsVision: vision
+  };
+}
+
+function parseLibraryLinks(html) {
+  const libraries = [];
+  const pattern = /href=["']\/library\/([a-zA-Z0-9_.-]+)["']/g;
+  let match;
+  while ((match = pattern.exec(html))) {
+    libraries.push(match[1].trim());
+  }
+  return dedupeKeepOrder(libraries);
+}
+
+function parseCloudTags(name, html) {
+  const tags = [];
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`href=["']/library/${escaped}:([^"']+)["']`, "g");
+  let match;
+  while ((match = pattern.exec(html))) {
+    const tag = decodeURIComponent(match[1]).trim();
+    if (tag && tag.toLowerCase().includes("cloud")) tags.push(tag);
+  }
+  if (!tags.length && html.toLowerCase().includes("cloud")) tags.push("cloud");
+  return dedupeKeepOrder(tags);
+}
+
+async function discoverCloudCatalogModels(force = false) {
+  if (!OLLAMA_CLOUD_CATALOG_ENABLED) return [];
+  const now = Date.now();
+  if (!force && cloudCatalogCache.models.length && now - cloudCatalogCache.checkedAt < OLLAMA_CLOUD_CATALOG_TTL_MS) {
+    return cloudCatalogCache.models.slice();
+  }
+
+  try {
+    const catalogUrl = new URL(OLLAMA_CLOUD_CATALOG_URL);
+    const libraries = [];
+    const maxPages = Math.max(1, OLLAMA_CLOUD_CATALOG_MAX_PAGES);
+    const maxLibraries = Math.max(1, OLLAMA_CLOUD_CATALOG_MAX_LIBRARIES);
+    for (let page = 1; page <= maxPages; page += 1) {
+      const pageUrl = new URL(catalogUrl);
+      if (page > 1) pageUrl.searchParams.set("p", String(page));
+      const before = libraries.length;
+      for (const library of parseLibraryLinks(await fetchTextUrl(pageUrl.toString()))) {
+        if (!libraries.includes(library)) libraries.push(library);
+        if (libraries.length >= maxLibraries) break;
+      }
+      if (libraries.length >= maxLibraries) break;
+      if (page > 1 && libraries.length === before) break;
+    }
+
+    const models = [];
+    let index = 0;
+    const workers = Array.from({ length: Math.min(6, libraries.length) }, async () => {
+      while (index < libraries.length) {
+        const name = libraries[index];
+        index += 1;
+        try {
+          const html = await fetchTextUrl(`${OLLAMA_LIBRARY_BASE_URL}/library/${encodeURIComponent(name)}`);
+          const tags = parseCloudTags(name, html);
+          for (const tag of tags) models.push(`${name}:${tag}`);
+        } catch {
+          models.push(`${name}:cloud`);
+        }
+      }
+    });
+    await Promise.all(workers);
+
+    const discovered = dedupeKeepOrder(models).filter(isCloudModel).map(cloudModelMeta);
+    if (discovered.length) {
+      cloudCatalogCache.checkedAt = now;
+      cloudCatalogCache.models = discovered;
+      return discovered.slice();
+    }
+  } catch {
+    return cloudCatalogCache.models.slice();
+  }
+  return cloudCatalogCache.models.slice();
+}
+
+async function buildState(options = {}) {
+  const [catalog, config, tags, cloudCatalog] = await Promise.all([
     readJson(CATALOG_PATH, { cloud: [], local: [] }),
     readJson(CONFIG_PATH, { version: 1, models: {} }),
-    fetchTags()
+    fetchTags(),
+    discoverCloudCatalogModels(Boolean(options.forceCloudCatalog))
   ]);
   const saved = config.models && typeof config.models === "object" ? config.models : {};
   const byId = new Map();
@@ -126,15 +270,19 @@ async function buildState() {
   for (const entry of catalog.cloud || []) {
     upsert(entry.id, { ...entry, source: "cloud-catalog", type: "cloud" });
   }
+  for (const entry of cloudCatalog) {
+    upsert(entry.id, { ...entry, source: "ollama-cloud-catalog", type: "cloud" });
+  }
   for (const entry of catalog.local || []) {
     upsert(entry.id, { ...entry, source: "local-catalog", type: "local", downloadable: true });
   }
   for (const tag of tags.models) {
     const id = normalizeModelId(tag.name || tag.model);
     const details = tag.details && typeof tag.details === "object" ? tag.details : {};
+    const cloud = isCloudModel(id);
     upsert(id, {
-      source: isCloudModel(id) ? "ollama-cloud" : "installed",
-      type: isCloudModel(id) ? "cloud" : "local",
+      source: cloud ? "ollama-cloud" : "installed",
+      type: cloud ? "cloud" : "local",
       installed: true,
       digest: tag.digest,
       modifiedAt: tag.modified_at,
@@ -146,15 +294,16 @@ async function buildState() {
     });
   }
   for (const [id, entry] of Object.entries(saved)) {
+    const type = modelTypeFor(id, entry);
     upsert(id, {
-      source: entry.source || (isCloudModel(id) ? "saved-cloud" : "saved-local"),
-      type: isCloudModel(id) ? "cloud" : "local"
+      source: entry.source || (type === "cloud" ? "saved-cloud" : "saved-local"),
+      type
     });
   }
 
   const models = Array.from(byId.values()).map((model) => {
     const savedEntry = saved[model.id];
-    const cloud = model.type === "cloud" || isCloudModel(model.id);
+    const cloud = modelTypeFor(model.id, model) === "cloud";
     const enabled = typeof savedEntry?.enabled === "boolean" ? savedEntry.enabled : cloud;
     return {
       id: model.id,
@@ -194,6 +343,12 @@ async function buildState() {
     configPath: CONFIG_PATH,
     manifestPath: MANIFEST_PATH,
     disabledModelsEnvPath: DISABLED_MODELS_ENV_PATH,
+    cloudCatalog: {
+      enabled: OLLAMA_CLOUD_CATALOG_ENABLED,
+      source: OLLAMA_CLOUD_CATALOG_URL,
+      checkedAt: cloudCatalogCache.checkedAt ? new Date(cloudCatalogCache.checkedAt).toISOString() : null,
+      discovered: cloudCatalog.length
+    },
     models,
     pullJobs: Object.fromEntries(pullJobs)
   };
@@ -228,12 +383,13 @@ async function persistSelection(selection) {
   const known = new Map(state.models.map((model) => [model.id, model]));
   for (const [id] of selected) {
     if (!known.has(id)) {
+      const type = modelTypeFor(id);
       known.set(id, {
         id,
         name: id,
-        type: isCloudModel(id) ? "cloud" : "local",
+        type,
         installed: false,
-        downloadable: !isCloudModel(id),
+        downloadable: type !== "cloud",
         supportsChat: true
       });
     }
@@ -276,6 +432,82 @@ async function isModelEnabled(modelId) {
   const saved = config.models && typeof config.models === "object" ? config.models : {};
   if (typeof saved[id]?.enabled === "boolean") return saved[id].enabled;
   return isCloudModel(id);
+}
+
+function decodeHtml(value) {
+  return String(value || "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, "\"")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+}
+
+function stripHtml(value) {
+  return decodeHtml(String(value || "").replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim());
+}
+
+function firstMatch(value, regex) {
+  const match = regex.exec(value);
+  return match ? stripHtml(match[1]) : "";
+}
+
+function parseOllamaSearch(html) {
+  const results = [];
+  const seen = new Set();
+  const itemPattern = /<li\b[^>]*x-test-model[^>]*>([\s\S]*?)<\/li>/g;
+  let item;
+  while ((item = itemPattern.exec(html))) {
+    const chunk = item[1];
+    const title = firstMatch(chunk, /<span\b[^>]*x-test-search-response-title[^>]*>([\s\S]*?)<\/span>/);
+    if (!title || seen.has(title)) continue;
+    seen.add(title);
+    const hrefMatch = /<a\s+href="([^"]+)"/.exec(chunk);
+    const href = hrefMatch ? decodeHtml(hrefMatch[1]) : "";
+    const description = firstMatch(chunk, /<p\b[^>]*>([\s\S]*?)<\/p>/);
+    const pulls = firstMatch(chunk, /<span\b[^>]*x-test-pull-count[^>]*>([\s\S]*?)<\/span>/);
+    const type = modelTypeFor(title);
+    results.push({
+      id: title,
+      name: title,
+      type,
+      source: "ollama.com",
+      installed: type === "cloud",
+      downloadable: type !== "cloud",
+      enabled: false,
+      description,
+      pulls,
+      url: href ? `${OLLAMA_LIBRARY_BASE_URL}${href}` : `${OLLAMA_LIBRARY_BASE_URL}/search`
+    });
+  }
+  return results.slice(0, 25);
+}
+
+async function searchOllamaModels(query) {
+  const normalized = String(query || "").trim();
+  if (normalized.length < 2) return [];
+  const key = normalized.toLowerCase();
+  const cached = searchCache.get(key);
+  if (cached && Date.now() - cached.timestamp < 5 * 60 * 1000) return cached.results;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+  try {
+    const response = await fetch(`${OLLAMA_LIBRARY_BASE_URL}/search?q=${encodeURIComponent(normalized)}`, {
+      headers: {
+        "accept": "text/html",
+        "user-agent": "ollama-umbrel-dashboard/1.0"
+      },
+      signal: controller.signal
+    });
+    if (!response.ok) throw new Error(`ollama.com search returned HTTP ${response.status}`);
+    const results = parseOllamaSearch(await response.text());
+    searchCache.set(key, { timestamp: Date.now(), results });
+    return results;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 function shouldEnforceModelSelection(method, pathname) {
@@ -396,7 +628,11 @@ const server = http.createServer(async (req, res) => {
   try {
     const url = new URL(req.url, "http://dashboard.local");
     if (req.method === "GET" && url.pathname === "/api/dashboard/state") {
-      sendJson(res, 200, await buildState());
+      sendJson(res, 200, await buildState({ forceCloudCatalog: url.searchParams.get("refresh") === "1" }));
+      return;
+    }
+    if (req.method === "GET" && url.pathname === "/api/dashboard/search") {
+      sendJson(res, 200, { models: await searchOllamaModels(url.searchParams.get("q")) });
       return;
     }
     if (req.method === "POST" && url.pathname === "/api/dashboard/config") {

--- a/ollama/dashboard/server.js
+++ b/ollama/dashboard/server.js
@@ -1,0 +1,439 @@
+const http = require("http");
+const https = require("https");
+const fs = require("fs");
+const fsp = require("fs/promises");
+const path = require("path");
+
+const PORT = Number(process.env.PORT || 3000);
+const OLLAMA_BASE_URL = (process.env.OLLAMA_BASE_URL || "http://ollama_ollama_1:11434").replace(/\/+$/, "");
+const OLLAMA_PROXY_TIMEOUT_MS = Number(process.env.OLLAMA_PROXY_TIMEOUT_MS || 300000);
+const CONFIG_DIR = process.env.CONFIG_DIR || "/config";
+const PUBLIC_DIR = path.join(__dirname, "public");
+const CATALOG_PATH = path.join(__dirname, "catalog.json");
+const CONFIG_PATH = path.join(CONFIG_DIR, "ollama-dashboard.json");
+const MANIFEST_PATH = path.join(CONFIG_DIR, "model-manifest.json");
+const DISABLED_MODELS_ENV_PATH = path.join(CONFIG_DIR, "disabled-models.env");
+const pullJobs = new Map();
+
+const contentTypes = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml"
+};
+
+async function ensureConfigDir() {
+  await fsp.mkdir(CONFIG_DIR, { recursive: true });
+}
+
+async function readJson(file, fallback) {
+  try {
+    return JSON.parse(await fsp.readFile(file, "utf8"));
+  } catch {
+    return fallback;
+  }
+}
+
+async function writeJsonAtomic(file, data) {
+  await ensureConfigDir();
+  const tmp = `${file}.tmp`;
+  await fsp.writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`);
+  await fsp.rename(tmp, file);
+}
+
+async function readBody(req) {
+  const raw = await readRawBody(req);
+  return raw.length ? JSON.parse(raw.toString("utf8")) : {};
+}
+
+async function readRawBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+function sendJson(res, status, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store"
+  });
+  res.end(body);
+}
+
+function sendError(res, status, error, detail) {
+  sendJson(res, status, { error, detail: detail ? String(detail) : undefined });
+}
+
+async function fetchOllamaJson(route, options = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs || 10000);
+  try {
+    const response = await fetch(`${OLLAMA_BASE_URL}${route}`, {
+      method: options.method || "GET",
+      headers: { "content-type": "application/json" },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+      signal: controller.signal
+    });
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : {};
+    if (!response.ok) {
+      throw new Error(data.error || data.message || `HTTP ${response.status}`);
+    }
+    return data;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function fetchTags() {
+  try {
+    const data = await fetchOllamaJson("/api/tags", { timeoutMs: 5000 });
+    return { ok: true, models: Array.isArray(data.models) ? data.models : [] };
+  } catch (error) {
+    return { ok: false, error: error.message, models: [] };
+  }
+}
+
+function normalizeModelId(value) {
+  return String(value || "").trim();
+}
+
+function isCloudModel(id) {
+  return normalizeModelId(id).endsWith(":cloud");
+}
+
+function modelName(entry) {
+  return entry.name || entry.model || entry.id || "";
+}
+
+async function buildState() {
+  const [catalog, config, tags] = await Promise.all([
+    readJson(CATALOG_PATH, { cloud: [], local: [] }),
+    readJson(CONFIG_PATH, { version: 1, models: {} }),
+    fetchTags()
+  ]);
+  const saved = config.models && typeof config.models === "object" ? config.models : {};
+  const byId = new Map();
+
+  function upsert(id, patch) {
+    const modelId = normalizeModelId(id);
+    if (!modelId) return;
+    byId.set(modelId, { ...(byId.get(modelId) || { id: modelId }), ...patch });
+  }
+
+  for (const entry of catalog.cloud || []) {
+    upsert(entry.id, { ...entry, source: "cloud-catalog", type: "cloud" });
+  }
+  for (const entry of catalog.local || []) {
+    upsert(entry.id, { ...entry, source: "local-catalog", type: "local", downloadable: true });
+  }
+  for (const tag of tags.models) {
+    const id = normalizeModelId(tag.name || tag.model);
+    const details = tag.details && typeof tag.details === "object" ? tag.details : {};
+    upsert(id, {
+      source: isCloudModel(id) ? "ollama-cloud" : "installed",
+      type: isCloudModel(id) ? "cloud" : "local",
+      installed: true,
+      digest: tag.digest,
+      modifiedAt: tag.modified_at,
+      sizeBytes: tag.size,
+      family: details.family,
+      families: details.families,
+      parameterSize: details.parameter_size,
+      quantization: details.quantization_level
+    });
+  }
+  for (const [id, entry] of Object.entries(saved)) {
+    upsert(id, {
+      source: entry.source || (isCloudModel(id) ? "saved-cloud" : "saved-local"),
+      type: isCloudModel(id) ? "cloud" : "local"
+    });
+  }
+
+  const models = Array.from(byId.values()).map((model) => {
+    const savedEntry = saved[model.id];
+    const cloud = model.type === "cloud" || isCloudModel(model.id);
+    const enabled = typeof savedEntry?.enabled === "boolean" ? savedEntry.enabled : cloud;
+    return {
+      id: model.id,
+      name: model.name || model.id,
+      type: cloud ? "cloud" : "local",
+      source: model.source,
+      enabled,
+      installed: Boolean(model.installed || cloud),
+      downloadable: !cloud,
+      pulling: pullJobs.has(model.id),
+      pull: pullJobs.get(model.id) || null,
+      digest: model.digest,
+      modifiedAt: model.modifiedAt,
+      size: model.size,
+      sizeBytes: model.sizeBytes,
+      family: model.family,
+      families: model.families,
+      parameterSize: model.parameterSize,
+      quantization: model.quantization,
+      reasoning: Boolean(model.reasoning),
+      supportsChat: model.supportsChat !== false,
+      supportsTools: model.supportsTools,
+      supportsJson: model.supportsJson,
+      contextWindow: model.contextWindow,
+      maxTokens: model.maxTokens
+    };
+  }).sort((a, b) => {
+    if (a.type !== b.type) return a.type === "cloud" ? -1 : 1;
+    if (a.installed !== b.installed) return a.installed ? -1 : 1;
+    return a.id.localeCompare(b.id);
+  });
+
+  return {
+    ollamaReachable: tags.ok,
+    ollamaError: tags.ok ? null : tags.error,
+    ollamaBaseUrl: OLLAMA_BASE_URL,
+    configPath: CONFIG_PATH,
+    manifestPath: MANIFEST_PATH,
+    disabledModelsEnvPath: DISABLED_MODELS_ENV_PATH,
+    models,
+    pullJobs: Object.fromEntries(pullJobs)
+  };
+}
+
+function manifestEntry(model) {
+  return {
+    id: model.id,
+    name: model.name || model.id,
+    servable: Boolean(model.enabled),
+    resident: Boolean(model.installed && model.type === "local"),
+    preferred: Boolean(model.enabled),
+    reasoning: Boolean(model.reasoning),
+    contextWindow: model.contextWindow,
+    maxTokens: model.maxTokens,
+    input: ["text"],
+    supportsChat: model.supportsChat !== false,
+    supportsTools: model.supportsTools,
+    supportsJson: model.supportsJson,
+    supportsStreaming: true,
+    reason: model.enabled ? "enabled in Ollama Umbrel dashboard" : "disabled in Ollama Umbrel dashboard"
+  };
+}
+
+async function persistSelection(selection) {
+  const state = await buildState();
+  const selected = new Map();
+  for (const item of selection) {
+    const id = normalizeModelId(item.id || item.model || item.name);
+    if (id) selected.set(id, Boolean(item.enabled));
+  }
+  const known = new Map(state.models.map((model) => [model.id, model]));
+  for (const [id] of selected) {
+    if (!known.has(id)) {
+      known.set(id, {
+        id,
+        name: id,
+        type: isCloudModel(id) ? "cloud" : "local",
+        installed: false,
+        downloadable: !isCloudModel(id),
+        supportsChat: true
+      });
+    }
+  }
+  const models = Array.from(known.values()).map((model) => ({
+    ...model,
+    enabled: selected.has(model.id) ? selected.get(model.id) : model.enabled
+  }));
+  const config = {
+    version: 1,
+    updatedAt: new Date().toISOString(),
+    models: Object.fromEntries(models.map((model) => [
+      model.id,
+      {
+        enabled: Boolean(model.enabled),
+        source: model.source || (model.type === "cloud" ? "cloud" : "local")
+      }
+    ]))
+  };
+  await writeJsonAtomic(CONFIG_PATH, config);
+  await writeJsonAtomic(MANIFEST_PATH, {
+    version: 1,
+    updatedAt: config.updatedAt,
+    models: models.map(manifestEntry)
+  });
+  const disabled = models.filter((model) => !model.enabled).map((model) => model.id).sort();
+  await fsp.writeFile(DISABLED_MODELS_ENV_PATH, `SAGE_ROUTER_DISABLED_MODELS=${disabled.join(",")}\n`);
+
+  for (const model of models) {
+    if (model.enabled && model.type === "local" && !model.installed) {
+      startPull(model.id);
+    }
+  }
+}
+
+async function isModelEnabled(modelId) {
+  const id = normalizeModelId(modelId);
+  if (!id) return true;
+  const config = await readJson(CONFIG_PATH, { version: 1, models: {} });
+  const saved = config.models && typeof config.models === "object" ? config.models : {};
+  if (typeof saved[id]?.enabled === "boolean") return saved[id].enabled;
+  return isCloudModel(id);
+}
+
+function shouldEnforceModelSelection(method, pathname) {
+  if (method !== "POST") return false;
+  return [
+    "/api/generate",
+    "/api/chat",
+    "/api/embed",
+    "/api/embeddings",
+    "/v1/chat/completions",
+    "/v1/completions",
+    "/v1/embeddings"
+  ].includes(pathname);
+}
+
+async function startPull(modelId) {
+  if (pullJobs.has(modelId)) return pullJobs.get(modelId);
+  const job = {
+    model: modelId,
+    status: "queued",
+    message: "Queued",
+    completed: 0,
+    total: 0,
+    startedAt: new Date().toISOString()
+  };
+  pullJobs.set(modelId, job);
+  runPull(modelId, job).catch((error) => {
+    Object.assign(job, {
+      status: "error",
+      message: error.message,
+      finishedAt: new Date().toISOString()
+    });
+  });
+  return job;
+}
+
+async function runPull(modelId, job) {
+  job.status = "pulling";
+  job.message = "Starting pull";
+  const response = await fetch(`${OLLAMA_BASE_URL}/api/pull`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ model: modelId, stream: true })
+  });
+  if (!response.ok || !response.body) {
+    const text = await response.text().catch(() => "");
+    throw new Error(text || `Ollama pull failed with HTTP ${response.status}`);
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const event = JSON.parse(line);
+        job.message = event.status || job.message;
+        job.digest = event.digest || job.digest;
+        job.completed = Number(event.completed || job.completed || 0);
+        job.total = Number(event.total || job.total || 0);
+      } catch {
+        job.message = line.trim();
+      }
+    }
+  }
+  job.status = "complete";
+  job.message = "Ready";
+  job.finishedAt = new Date().toISOString();
+  setTimeout(() => pullJobs.delete(modelId), 10 * 60 * 1000).unref();
+}
+
+function proxyOllama(req, res, bodyBuffer = null) {
+  const target = new URL(req.url, OLLAMA_BASE_URL);
+  const transport = target.protocol === "https:" ? https : http;
+  const headers = { ...req.headers, host: target.host };
+  if (bodyBuffer) headers["content-length"] = Buffer.byteLength(bodyBuffer);
+  const proxyReq = transport.request(target, { method: req.method, headers }, (proxyRes) => {
+    res.writeHead(proxyRes.statusCode || 502, proxyRes.headers);
+    proxyRes.pipe(res);
+  });
+  proxyReq.setTimeout(OLLAMA_PROXY_TIMEOUT_MS, () => {
+    proxyReq.destroy(new Error(`Ollama did not respond within ${OLLAMA_PROXY_TIMEOUT_MS}ms`));
+  });
+  proxyReq.on("error", (error) => sendError(res, 502, "ollama_proxy_failed", error.message));
+  if (bodyBuffer) {
+    proxyReq.end(bodyBuffer);
+  } else {
+    req.pipe(proxyReq);
+  }
+}
+
+async function serveStatic(req, res) {
+  const requestPath = decodeURIComponent(new URL(req.url, "http://dashboard.local").pathname);
+  const relative = requestPath === "/" ? "index.html" : requestPath.replace(/^\/+/, "");
+  const filePath = path.normalize(path.join(PUBLIC_DIR, relative));
+  if (filePath !== PUBLIC_DIR && !filePath.startsWith(`${PUBLIC_DIR}${path.sep}`)) {
+    sendError(res, 403, "forbidden");
+    return;
+  }
+  try {
+    const data = await fsp.readFile(filePath);
+    res.writeHead(200, {
+      "content-type": contentTypes[path.extname(filePath)] || "application/octet-stream",
+      "cache-control": filePath.endsWith("index.html") ? "no-store" : "public, max-age=300"
+    });
+    res.end(data);
+  } catch {
+    sendError(res, 404, "not_found");
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url, "http://dashboard.local");
+    if (req.method === "GET" && url.pathname === "/api/dashboard/state") {
+      sendJson(res, 200, await buildState());
+      return;
+    }
+    if (req.method === "POST" && url.pathname === "/api/dashboard/config") {
+      const body = await readBody(req);
+      await persistSelection(Array.isArray(body.models) ? body.models : []);
+      sendJson(res, 200, await buildState());
+      return;
+    }
+    if (url.pathname.startsWith("/api/") || url.pathname.startsWith("/v1/")) {
+      if (shouldEnforceModelSelection(req.method, url.pathname)) {
+        const bodyBuffer = await readRawBody(req);
+        const payload = bodyBuffer.length ? JSON.parse(bodyBuffer.toString("utf8")) : {};
+        if (!(await isModelEnabled(payload.model))) {
+          sendError(res, 403, "model_disabled", `${payload.model || "requested model"} is disabled in the Ollama dashboard`);
+          return;
+        }
+        proxyOllama(req, res, bodyBuffer);
+        return;
+      }
+      proxyOllama(req, res);
+      return;
+    }
+    if (req.method === "GET" || req.method === "HEAD") {
+      await serveStatic(req, res);
+      return;
+    }
+    sendError(res, 405, "method_not_allowed");
+  } catch (error) {
+    sendError(res, 500, "dashboard_error", error.message);
+  }
+});
+
+ensureConfigDir()
+  .then(() => server.listen(PORT, "0.0.0.0", () => {
+    console.log(`Ollama dashboard listening on ${PORT}, proxying ${OLLAMA_BASE_URL}`);
+  }))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/ollama/docker-compose.yml
+++ b/ollama/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   dashboard:
-    image: node:22-alpine
+    image: node:22-alpine@sha256:ab07539e0988b63558ff621f5fbe1077054c39d9809112974fb79993949d41cd
     command: ["node", "/app/server.js"]
     environment:
       PORT: "3000"

--- a/ollama/docker-compose.yml
+++ b/ollama/docker-compose.yml
@@ -3,9 +3,23 @@ version: '3.7'
 services:
   app_proxy:
     environment:
-      APP_HOST: ollama_ollama_1
-      APP_PORT: 11434
+      APP_HOST: ollama_dashboard_1
+      APP_PORT: 3000
       PROXY_AUTH_ADD: "false"
+
+  dashboard:
+    image: node:22-alpine
+    command: ["node", "/app/server.js"]
+    environment:
+      PORT: "3000"
+      OLLAMA_BASE_URL: "http://ollama_ollama_1:11434"
+      CONFIG_DIR: "/config"
+    volumes:
+      - ./dashboard:/app:ro
+      - ${APP_DATA_DIR}/data:/config
+    depends_on:
+      - ollama
+    restart: on-failure
 
   ollama:
     image: ollama/ollama:0.30.10@sha256:bfc9c6d53cc6989aa5131a6fde6b162b2802d4d337657f3253b5f69579bddeee

--- a/ollama/docker-compose.yml
+++ b/ollama/docker-compose.yml
@@ -4,14 +4,14 @@ services:
   app_proxy:
     environment:
       APP_HOST: ollama_dashboard_1
-      APP_PORT: 3000
+      APP_PORT: 11434
       PROXY_AUTH_ADD: "false"
 
   dashboard:
     image: node:22-alpine@sha256:ab07539e0988b63558ff621f5fbe1077054c39d9809112974fb79993949d41cd
     command: ["node", "/app/server.js"]
     environment:
-      PORT: "3000"
+      PORT: "11434"
       OLLAMA_BASE_URL: "http://ollama_ollama_1:11434"
       CONFIG_DIR: "/config"
     volumes:

--- a/ollama/exports.sh
+++ b/ollama/exports.sh
@@ -1,1 +1,2 @@
-export APP_OLLAMA_URL="http://ollama_ollama_1:11434"
+export APP_OLLAMA_URL="http://ollama_dashboard_1:3000"
+export APP_OLLAMA_RAW_URL="http://ollama_ollama_1:11434"

--- a/ollama/exports.sh
+++ b/ollama/exports.sh
@@ -1,2 +1,2 @@
-export APP_OLLAMA_URL="http://ollama_dashboard_1:3000"
+export APP_OLLAMA_URL="http://ollama_dashboard_1:11434"
 export APP_OLLAMA_RAW_URL="http://ollama_ollama_1:11434"

--- a/ollama/umbrel-app.yml
+++ b/ollama/umbrel-app.yml
@@ -4,7 +4,7 @@ name: Ollama
 tagline: Self-host open source AI models like DeepSeek-R1, Llama, and more
 category: ai
 version: "0.30.10"
-port: 3000
+port: 11434
 description: >-
   Ollama allows you to download and run advanced AI models directly on your own hardware. This Umbrel app includes a model dashboard for enabling Ollama Cloud models, selecting downloadable local models, and pulling enabled local models into the persistent Ollama volume.
 
@@ -14,7 +14,7 @@ description: >-
 
   **Getting Started:**
 
-  Open the app to manage model availability. Ollama Cloud models are enabled by default when discovered, while local downloadable models stay disabled until selected. Saving enabled local models starts the download in the background.
+  Open the app to manage model availability. Ollama Cloud models are discovered from Ollama's public catalog and enabled by default, while local downloadable models stay disabled until selected. Saving enabled local models starts the download in the background.
 
 
   **Advanced Setup:**
@@ -40,7 +40,8 @@ dependencies: []
 releaseNotes: >-
   Key highlights in this release:
     - Adds an Umbrel model dashboard for Ollama Cloud and local downloadable models
-    - Enables cloud models by default while leaving local models disabled until selected
+    - Auto-discovers Ollama Cloud models from Ollama's public catalog and enables them by default
+    - Leaves local models disabled until selected
     - Pulls newly enabled local models into the persistent Ollama volume
 
 

--- a/ollama/umbrel-app.yml
+++ b/ollama/umbrel-app.yml
@@ -4,9 +4,9 @@ name: Ollama
 tagline: Self-host open source AI models like DeepSeek-R1, Llama, and more
 category: ai
 version: "0.30.10"
-port: 11434
+port: 3000
 description: >-
-  Ollama allows you to download and run advanced AI models directly on your own hardware. Self-hosting AI models ensures full control over your data and protects your privacy.
+  Ollama allows you to download and run advanced AI models directly on your own hardware. This Umbrel app includes a model dashboard for enabling Ollama Cloud models, selecting downloadable local models, and pulling enabled local models into the persistent Ollama volume.
 
 
   ⚠️ Before running a model, make sure your device has enough free RAM to support it. Attempting to run a model that exceeds your available memory could cause your device to crash or become unresponsive. Always check the model requirements before downloading or starting it.
@@ -14,14 +14,14 @@ description: >-
 
   **Getting Started:**
 
-  The easiest way to get started with Ollama is to install the Open WebUI app from the Umbrel App Store. Open WebUI will automatically connect to your Ollama setup, allowing you to manage model downloads and chat with your AI models effortlessly.
+  Open the app to manage model availability. Ollama Cloud models are enabled by default when discovered, while local downloadable models stay disabled until selected. Saving enabled local models starts the download in the background.
 
 
   **Advanced Setup:**
 
   If you want to connect Ollama to other apps or devices, here's how:
-    - Apps running on UmbrelOS: Use ollama_ollama_1 as the host and 11434 as the port when configuring other apps to connect to Ollama. For example, the API Base URL would be: http://ollama_ollama_1:11434.
-    - Custom Integrations: Connect Ollama to third-party apps or your own code using your UmbrelOS local domain (e.g., http://umbrel.local:11434) or your device's IP address, which you can find in the UmbrelOS Settings page (e.g., http://192.168.4.74:11434).
+    - Apps running on UmbrelOS: Use the exported APP_OLLAMA_URL value so requests pass through the dashboard's enabled-model selection. Apps that intentionally need raw Ollama access can use APP_OLLAMA_RAW_URL.
+    - Custom Integrations: Open the app dashboard from Umbrel to manage model availability. API requests sent through the dashboard proxy are forwarded to Ollama after checking that the requested model is enabled.
 backupIgnore:
   - data/*
 developer: Ollama
@@ -39,9 +39,9 @@ defaultPassword: ""
 dependencies: []
 releaseNotes: >-
   Key highlights in this release:
-    - Command A and North family models now run on Apple Silicon with the MLX engine.
-    - Updated the underlying llama.cpp engine to build 9672.
-    - Fixed MLX build artifacts.
+    - Adds an Umbrel model dashboard for Ollama Cloud and local downloadable models
+    - Enables cloud models by default while leaving local models disabled until selected
+    - Pulls newly enabled local models into the persistent Ollama volume
 
 
   Full release notes are available at https://github.com/ollama/ollama/releases/


### PR DESCRIPTION
Adds a lightweight dashboard/proxy to the existing Ollama Umbrel app.

Changes:
- Routes the app proxy to a new Node dashboard on port 3000 while keeping raw Ollama on the internal service.
- Exports `APP_OLLAMA_URL` for dashboard/proxy access and `APP_OLLAMA_RAW_URL` for apps that intentionally need raw Ollama access.
- Adds a model catalog UI where cloud models are enabled by default and downloadable local models remain disabled until selected.
- Starts an Ollama pull when a newly enabled local model is saved, using the persistent Ollama data volume.
- Blocks proxied generation/chat/embedding requests for disabled models.

Validation:
- `node --check ollama/dashboard/server.js`
- `node --check ollama/dashboard/public/app.js`
- `git diff --check`
- `docker compose config` for `ollama/docker-compose.yml` with a dummy Umbrel `app_proxy` service
