### PR TITLE
Update Bolt12 Pay to v0.2.108.1

### DIFF
--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.2.108@sha256:33df5203b894ef102b4e9823ee7005548e7304747b6466347cfc31a2c89a5910
+    image: alex71btc/bolt12-pay:0.2.109@sha256:681c1a2af8fb0f3b4f439f915f0ec04f8bf60ccfbc7f0ec761bb3eb5f59effb4
     restart: on-failure
     depends_on:
       - lndk

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.108
+version: 0.2.108.1
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
@@ -15,7 +15,7 @@ description: >-
   message support enabled.
 
 
-  In your LND configuration, add:
+  In your LND configuration file (Go to Files: Apps → lightning → data → lnd → lnd.conf), add:
 
     [protocol]
     protocol.custom-message=513
@@ -23,7 +23,7 @@ description: >-
     protocol.custom-init=39
 
 
-  Restart Lightning afterwards. Without this, BOLT12 functionality will not work.
+  Save and restart Lightning afterwards. Without this, BOLT12 functionality will not work.
 
 
   Domain setup guide:
@@ -36,7 +36,9 @@ description: >-
   and this app uses cutting-edge Lightning features.
 
 
-  Support ongoing development:
+  Support ongoing development by donating to this project:
+
+
   https://geyser.fund/project/bolt12pay
 
 
@@ -49,12 +51,17 @@ repo: https://github.com/Alex71btc/lndk-pay
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
 
- - Publish BIP353 Lightning Addresses directly from Offer History
- - Create private Lightning Addresses for customers, events, or temporary use
- - Automatic DNS cleanup when deleting history entries or clearing history
- - Improved Offer History management with server-side persistence
- - Extends the Privacy Mode features introduced in v0.2.106
+  Bugfix release for the v0.2.108 Privacy Mode update.
 
+   - Improved reliability of BOLT12 offer creation
+   - Automatically retries transient LNDK TLS connection failures
+   - Prevents occasional first-attempt offer creation errors observed on some Umbrel systems
+
+  Includes all features from v0.2.108:
+   - Privacy Mode
+   - Private BIP353 Lightning Addresses
+   - Offer History BIP353 Publishing
+   - Automatic DNS Cleanup
 
 dependencies:
   - lightning


### PR DESCRIPTION
## Type

App update

## App

App ID: bolt12-pay
Upstream project: https://github.com/Alex71btc/lndk-pay
Version: 0.2.108.1

## Summary

Bugfix release for v0.2.108.

Improved reliability of BOLT12 offer creation by automatically retrying transient LNDK TLS connection failures that have been observed on some Umbrel systems after startup.

Also adds a Geyser funding link to the app description for users who would like to support ongoing development.

## Verification

Umbrel testing performed:

Environment tested:
- [x] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64

Known lint warnings or caveats:
- None

## Notes

Includes all features introduced in v0.2.108:

- Privacy Mode
- Private BIP353 Lightning Addresses
- Offer History BIP353 publishing
- Automatic DNS cleanup

This release only adds a reliability fix and funding metadata.