### PR TITLE
Update outline to v1.8.1

### DIFF
--- a/outline/data/config/config.yaml.template
+++ b/outline/data/config/config.yaml.template
@@ -11,7 +11,7 @@ web:
 staticClients:
   - id: outline
     redirectURIs:
-      - 'http://${DEVICE_DOMAIN_NAME}:${APP_OUTLINE_PORT}/auth/oidc.callback'
+      - 'https://${DEVICE_DOMAIN_NAME}:${APP_OUTLINE_PORT}/auth/oidc.callback'
     name: 'Outline'
     secret: ${APP_SEED}
 

--- a/outline/docker-compose.yml
+++ b/outline/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   web:
-    image: outlinewiki/outline:1.7.1@sha256:361df7040e6f0d7abac768b99f40122197921626a7e69501aabb5fcb496fc1b4
+    image: outlinewiki/outline:1.8.1@sha256:e224dcbe34670bdae8835c32d5abc692d3560dfa262b72fb7232f4d87185aebd
     user: "1000:1000"
     restart: on-failure
     depends_on:
@@ -22,7 +22,7 @@ services:
       DATABASE_URL: postgres://outline:outlinepass@outline_db_1:5432/outline
       PGSSLMODE: disable
       REDIS_URL: redis://outline_redis_1:6379
-      URL: "http://${DEVICE_DOMAIN_NAME}:${APP_OUTLINE_PORT}"
+      URL: "https://${DEVICE_DOMAIN_NAME}:${APP_OUTLINE_PORT}"
       PORT: 3000
       FILE_STORAGE: local
       FILE_STORAGE_LOCAL_ROOT_DIR: /var/lib/outline/data

--- a/outline/umbrel-app.yml
+++ b/outline/umbrel-app.yml
@@ -3,7 +3,7 @@ id: outline
 name: Outline
 tagline: A modern team knowledge base and wiki
 category: files
-version: "1.7.1"
+version: "1.8.1"
 port: 8942
 description: >-
   Outline is a modern, fast, and collaborative knowledge base for growing teams. It combines the best of wikis, documents, and tasks into one beautiful interface that your team will actually want to use.
@@ -37,24 +37,15 @@ gallery:
   - 4.jpg
 releaseNotes: >-
   New features and improvements in this release:
-    - Per-share branding lets you override the title and logo on individual public shares
-    - MCP responses now include breadcrumbs, summaries, and title guidance
-    - Added delete_document and delete_collection tools to MCP
-    - Self-hosted instances can now tune rate limiting with the new RATE_LIMITER_MULTIPLIER option
-    - Default model creation rate limits raised from 10/min to 25/min
-    - Added a UI element to clear search highlights when navigating to a document from search results
-    - Improved table-of-contents positioning on shared documents
-    - Improved sidebar performance
-    - Shift-Tab on a list item inside a toggle block no longer outdents the entire block
-    - Code blocks now expand correctly when printing
-    - API keys created with global read/write scope are now saved correctly
-    - Republishing a document now correctly updates the last modified user
-    - Suspended users are no longer counted toward the cached group member count
-    - Post-login redirects with invalid paths are now handled correctly in Firefox
-    - Autofocus now works inside lazy-loaded modals and popovers
+    - Members can now request access to documents they do not have permission to view
+    - Image lightboxes now support comments, and code blocks can be used inside comments
+    - MCP and API improvements include inline comment management, signed attachment URL access, full URL responses, and aligned document creation permissions
+    - The command menu, sidebar, search, editor, tables, printing, and imports received usability and performance improvements
+    - Self-hosted instances can now use HTTP webhook URLs, and OAuth/OIDC and file-storage configuration handling is more resilient
+    - Drag-and-drop, mobile layouts, admin avatar controls, search highlights, access requests, comments, Mermaid diagrams, and document history all received fixes and polish
 
 
-  Full release notes can be found at https://github.com/outline/outline
+  Full release notes can be found at https://github.com/outline/outline/compare/v1.7.1...v1.8.1
 dependencies: []
 path: ""
 defaultUsername: "umbrel@umbrel.local"


### PR DESCRIPTION
Updates Outline to v1.8.1 and switches its public URL/OIDC callback to HTTPS, pending umbrelOS HTTPS-by-default support (coming real soon).