### PR TITLE
Update Lightning Node to v0.21.0-beta

### DIFF
--- a/lightning/docker-compose.yml
+++ b/lightning/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
   lnd:
     hostname: "${DEVICE_DOMAIN_NAME}" # Needed so LND can generate a valid cert
-    image: lightninglabs/lnd:v0.21.0-beta@sha256:60fca3f409cf3d500db1d15c9965678a4b5a60758ff30863d52b02529c18be8b
+    image: lightninglabs/lnd:v0.21.1-beta@sha256:4af8f9bbf98c8b86b0e54b065d6ea45d1387256a43fa9270c11ef849511abae0
     command: "${APP_LIGHTNING_COMMAND}"
     user: 1000:1000
     restart: unless-stopped

--- a/lightning/docker-compose.yml
+++ b/lightning/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3006
 
   app:
-    image: getumbrel/umbrel-lightning:v1.2.2@sha256:61694e8abe448f407af0596387ef964c2687376e5083b602616a123e2d88e32d
+    image: getumbrel/umbrel-lightning:v1.3.1@sha256:94090ec616210f427cd8ab3ea95dad02b52fa0a82a62d72cb4a7987b4b7b1367
     restart: on-failure
     volumes:
       - "${APP_LIGHTNING_NODE_DATA_DIR}:/data/.lnd"
@@ -42,7 +42,7 @@ services:
 
   lnd:
     hostname: "${DEVICE_DOMAIN_NAME}" # Needed so LND can generate a valid cert
-    image: lightninglabs/lnd:v0.20.1-beta@sha256:f0a2bdc4b8bc89cb3b31b6e12d6b16ac5145defd916d8152cf0c1c07d8697cff
+    image: lightninglabs/lnd:v0.21.0-beta@sha256:60fca3f409cf3d500db1d15c9965678a4b5a60758ff30863d52b02529c18be8b
     command: "${APP_LIGHTNING_COMMAND}"
     user: 1000:1000
     restart: unless-stopped

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -114,4 +114,6 @@ widgets:
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/commit/576ecd2bef8d625abceed0f67ec9c487da9b2b1b
 backupIgnore:
-  - data/graph/mainnet/channel.db
+  - data/lnd/data/graph/*/channel.db
+  - data/lnd/data/graph/*/wtclient.db
+  - data/lnd/data/watchtower/*/*/watchtower.db

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: lightning
 category: bitcoin
 name: Lightning Node
-version: "0.20.1-beta"
+version: "0.21.0-beta"
 tagline: Run your personal Lightning Network node
 description: >-
   Run your personal Lightning Network node, and join the future of Bitcoin today.
@@ -22,10 +22,22 @@ description: >-
 
   An official app from Umbrel.
 releaseNotes: >-
-  This update includes the latest version of LND (v0.20.1-beta) and improves the Connect Wallet QR codes so they scan more reliably in Zeus and other mobile wallets.
+  ⚠️ Important for users who manually changed LND protocol settings: if you previously added `protocol.custom-nodeann=39` or `protocol.custom-init=39` for BOLT 12/LNDK integrations, remove those lines before updating. LND v0.21.0-beta now advertises onion messaging itself, and leaving those custom feature-bit settings in place can prevent LND from starting.
 
 
-  Full LND release notes can be found at https://github.com/lightningnetwork/lnd/releases/tag/v0.20.1-beta
+  This update includes LND v0.21.0-beta along with the latest improvements to the Lightning Node app experience on Umbrel.
+
+
+  LND v0.21.0-beta adds onion messaging support, production taproot channel support, safer channel-close confirmation handling, and performance improvements.
+
+
+  Lightning Node on Umbrel now includes dark mode, a fiat currency selector for balances, improved QR code scanning in dark mode, improved automatic backup and channel recovery handling, plus bug fixes and improvements.
+
+
+  Power users: LND v0.21.0-beta removes deprecated payment RPCs and rejects manually configured Tor v2 onion addresses. Lightning Node on Umbrel already uses Tor v3 by default. Review the upstream release notes if you use custom scripts, external integrations, or custom LND advanced settings.
+
+
+  Full LND release notes can be found at https://github.com/lightningnetwork/lnd/releases/tag/v0.21.0-beta
 developer: Umbrel
 website: https://umbrel.com
 dependencies:

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: lightning
 category: bitcoin
 name: Lightning Node
-version: "0.21.0-beta"
+version: "0.21.1-beta"
 tagline: Run your personal Lightning Network node
 description: >-
   Run your personal Lightning Network node, and join the future of Bitcoin today.
@@ -22,22 +22,22 @@ description: >-
 
   An official app from Umbrel.
 releaseNotes: >-
-  ⚠️ Important for users who manually changed LND protocol settings: if you previously added `protocol.custom-nodeann=39` or `protocol.custom-init=39` for BOLT 12/LNDK integrations, remove those lines before updating. LND v0.21.0-beta now advertises onion messaging itself, and leaving those custom feature-bit settings in place can prevent LND from starting.
+  ⚠️ Important for users who manually changed LND protocol settings: if you previously added `protocol.custom-nodeann=39` or `protocol.custom-init=39` for BOLT 12/LNDK integrations, remove those lines before updating. LND v0.21.1-beta now advertises onion messaging itself, and leaving those custom feature-bit settings in place can prevent LND from starting.
 
 
-  This update includes LND v0.21.0-beta along with the latest improvements to the Lightning Node app experience on Umbrel.
+  This update includes LND v0.21.1-beta along with the latest improvements to the Lightning Node app experience on Umbrel.
 
 
-  LND v0.21.0-beta adds onion messaging support, production taproot channel support, safer channel-close confirmation handling, and performance improvements.
+  LND v0.21.1-beta adds onion messaging support, production taproot channel support, safer channel-close confirmation handling, and performance improvements.
 
 
   Lightning Node on Umbrel now includes dark mode, a fiat currency selector for balances, improved QR code scanning in dark mode, improved automatic backup and channel recovery handling, plus bug fixes and improvements.
 
 
-  Power users: LND v0.21.0-beta removes deprecated payment RPCs and rejects manually configured Tor v2 onion addresses. Lightning Node on Umbrel already uses Tor v3 by default. Review the upstream release notes if you use custom scripts, external integrations, or custom LND advanced settings.
+  Power users: LND v0.21.1-beta removes deprecated payment RPCs and rejects manually configured Tor v2 onion addresses. Lightning Node on Umbrel already uses Tor v3 by default. Review the upstream release notes if you use custom scripts, external integrations, or custom LND advanced settings.
 
 
-  Full LND release notes can be found at https://github.com/lightningnetwork/lnd/releases/tag/v0.21.0-beta
+  Full LND release notes can be found at https://github.com/lightningnetwork/lnd/blob/v0.21.1-beta/docs/release-notes/release-notes-0.21.1.md
 developer: Umbrel
 website: https://umbrel.com
 dependencies:


### PR DESCRIPTION
Updates Lightning Node:
- LND v0.21.0-beta.
- Improvements to Umbrel app
- Added a warning for users who previously added manual BOLT12/LNDK protocol settings, since two old settings can prevent LND from starting on v0.21.

**Currently waiting on this:**
LND `v0.21.0-beta` has a fresh-install Tor v3 issue that was fixed upstream in lightningnetwork/lnd#10907 but is not yet in a tagged release. Depending on `v0.21.1-beta` timing, I may either wait for the new image or include a small pre-start workaround.

---------

Pinging @Alex71btc

Hey, heads up for the LND 0.21 update. I think BOLT12-Pay probably needs an update too.

In LND 0.21, `protocol.custom-nodeann=39` and `protocol.custom-init=39` break LND startup because LND already advertises onion messaging itself. I tested it and LND fails after wallet unlock with:

```
feature bit: 39 already set
```

So users need to remove those two lines before updating Lightning Node.

I added a warning in these Lightning Node release notes your instructions currently tell users to add:

```ini
protocol.custom-message=513
protocol.custom-nodeann=39
protocol.custom-init=39
```

Hopefully not needing those will make setup a lot simpler, but right now any of your users who update LND will be temporarily offline until they figure out what's wrong