### PR TITLE
Add LND 0.21 compatibility notice

### DIFF
--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,46 +3,50 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.108.1
+version: 0.2.109
 port: 8367
 description: >-
-  BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
-  It supports BOLT12 Offers, Lightning Address (BIP353), LNURL, and BOLT11 fallback,
-  with optional Nostr identity features such as NIP-05 and Zaps.
+BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
+It supports BOLT12 Offers, Lightning Address (BIP353), LNURL, and BOLT11 fallback,
+with optional Nostr identity features such as NIP-05 and Zaps.
 
+IMPORTANT: Current releases of BOLT12 Pay depend on LNDK, which is currently
+compatible with LND v0.20.x only.
 
-  This app currently depends on a custom LND build with BOLT12-related custom
-  message support enabled.
+LND v0.21 introduced native onion messaging and is currently incompatible with
+the version of LNDK used by this app. If your Lightning node is upgraded to
+LND v0.21, BOLT12 Offer payments may stop working until LNDK is updated for
+the new API.
 
+If you want to continue using BOLT12 Pay, remain on LND v0.20.x for now.
 
-  In your LND configuration file (Go to Files: Apps → lightning → data → lnd → lnd.conf), add:
+In your LND configuration file (Go to Files: Apps → lightning → data → lnd → lnd.conf), add:
 
-    [protocol]
-    protocol.custom-message=513
-    protocol.custom-nodeann=39
-    protocol.custom-init=39
+```
+[protocol]
+protocol.custom-message=513
+protocol.custom-nodeann=39
+protocol.custom-init=39
+```
 
+Save and restart Lightning afterwards. Without this, BOLT12 functionality will not work.
 
-  Save and restart Lightning afterwards. Without this, BOLT12 functionality will not work.
+Note: These protocol settings are only required for LND v0.20.x and should
+not be used with future native BOLT12/onion messaging implementations.
 
+Domain setup guide:
 
-  Domain setup guide:
+https://github.com/Alex71btc/lndk-pay/blob/main/README.md#-domain-configuration-bip353-vs-lnurl
 
+BOLT12 support on LND is still evolving, wallet compatibility may vary,
+and this app uses cutting-edge Lightning features.
 
-  https://github.com/Alex71btc/lndk-pay/blob/main/README.md#-domain-configuration-bip353-vs-lnurl
+Support ongoing development by donating to this project:
 
+https://geyser.fund/project/bolt12pay
 
-  BOLT12 support on LND is still evolving, wallet compatibility may vary,
-  and this app uses cutting-edge Lightning features.
+Made for sovereign Bitcoin users.
 
-
-  Support ongoing development by donating to this project:
-
-
-  https://geyser.fund/project/bolt12pay
-
-
-  Made for sovereign Bitcoin users.
 developer: Alex71btc
 website: https://github.com/Alex71btc
 submitter: Alex71btc
@@ -51,17 +55,24 @@ repo: https://github.com/Alex71btc/lndk-pay
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
 
-  Bugfix release for the v0.2.108 Privacy Mode update.
+Compatibility notice:
 
-   - Improved reliability of BOLT12 offer creation
-   - Automatically retries transient LNDK TLS connection failures
-   - Prevents occasional first-attempt offer creation errors observed on some Umbrel systems
+* LND v0.21 is currently incompatible with the LNDK version used by BOLT12 Pay.
+* Users who rely on BOLT12 Offers should remain on LND v0.20.x until LNDK support for LND v0.21 is available.
+* Upgrading Lightning to LND v0.21 may break BOLT12 Offer payments.
 
-  Includes all features from v0.2.108:
-   - Privacy Mode
-   - Private BIP353 Lightning Addresses
-   - Offer History BIP353 Publishing
-   - Automatic DNS Cleanup
+Bugfix release for the v0.2.108 Privacy Mode update.
+
+* Improved reliability of BOLT12 offer creation
+* Automatically retries transient LNDK TLS connection failures
+* Prevents occasional first-attempt offer creation errors observed on some Umbrel systems
+
+Includes all features from v0.2.108:
+
+* Privacy Mode
+* Private BIP353 Lightning Addresses
+* Offer History BIP353 Publishing
+* Automatic DNS Cleanup
 
 dependencies:
   - lightning

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -6,73 +6,73 @@ category: bitcoin
 version: 0.2.109
 port: 8367
 description: >-
-BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
-It supports BOLT12 Offers, Lightning Address (BIP353), LNURL, and BOLT11 fallback,
-with optional Nostr identity features such as NIP-05 and Zaps.
+  BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
+  It supports BOLT12 Offers, Lightning Address (BIP353), LNURL, and BOLT11 fallback,
+  with optional Nostr identity features such as NIP-05 and Zaps.
 
-IMPORTANT: Current releases of BOLT12 Pay depend on LNDK, which is currently
-compatible with LND v0.20.x only.
+  IMPORTANT: Current releases of BOLT12 Pay depend on LNDK, which is currently
+  compatible with LND v0.20.x only.
 
-LND v0.21 introduced native onion messaging and is currently incompatible with
-the version of LNDK used by this app. If your Lightning node is upgraded to
-LND v0.21, BOLT12 Offer payments may stop working until LNDK is updated for
-the new API.
+  LND v0.21 introduced native onion messaging and is currently incompatible with
+  the version of LNDK used by this app. If your Lightning node is upgraded to
+  LND v0.21, BOLT12 Offer payments may stop working until LNDK is updated for
+  the new API.
 
-If you want to continue using BOLT12 Pay, remain on LND v0.20.x for now.
+  If you want to continue using BOLT12 Pay, remain on LND v0.20.x for now.
 
-In your LND configuration file (Go to Files: Apps → lightning → data → lnd → lnd.conf), add:
+  In your LND configuration file (Go to Files: Apps → lightning → data → lnd → lnd.conf), add:
 
-```
-[protocol]
-protocol.custom-message=513
-protocol.custom-nodeann=39
-protocol.custom-init=39
-```
+  ```
+  [protocol]
+  protocol.custom-message=513
+  protocol.custom-nodeann=39
+  protocol.custom-init=39
+  ```
 
-Save and restart Lightning afterwards. Without this, BOLT12 functionality will not work.
+  Save and restart Lightning afterwards. Without this, BOLT12 functionality will not work.
 
-Note: These protocol settings are only required for LND v0.20.x and should
-not be used with future native BOLT12/onion messaging implementations.
+  Note: These protocol settings are only required for LND v0.20.x and should
+  not be used with future native BOLT12/onion messaging implementations.
 
-Domain setup guide:
+  Domain setup guide:
 
-https://github.com/Alex71btc/lndk-pay/blob/main/README.md#-domain-configuration-bip353-vs-lnurl
+  https://github.com/Alex71btc/lndk-pay/blob/main/README.md#-domain-configuration-bip353-vs-lnurl
 
-BOLT12 support on LND is still evolving, wallet compatibility may vary,
-and this app uses cutting-edge Lightning features.
+  BOLT12 support on LND is still evolving, wallet compatibility may vary,
+  and this app uses cutting-edge Lightning features.
 
-Support ongoing development by donating to this project:
+  Support ongoing development by donating to this project:
 
-https://geyser.fund/project/bolt12pay
+  https://geyser.fund/project/bolt12pay
 
-Made for sovereign Bitcoin users.
+  Made for sovereign Bitcoin users.
 
-developer: Alex71btc
-website: https://github.com/Alex71btc
-submitter: Alex71btc
-submission: https://github.com/getumbrel/umbrel-apps/pull/5429
-repo: https://github.com/Alex71btc/lndk-pay
+  developer: Alex71btc
+  website: https://github.com/Alex71btc
+  submitter: Alex71btc
+  submission: https://github.com/getumbrel/umbrel-apps/pull/5429
+  repo: https://github.com/Alex71btc/lndk-payments
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
 
-Compatibility notice:
+  Compatibility notice:
 
-* LND v0.21 is currently incompatible with the LNDK version used by BOLT12 Pay.
-* Users who rely on BOLT12 Offers should remain on LND v0.20.x until LNDK support for LND v0.21 is available.
-* Upgrading Lightning to LND v0.21 may break BOLT12 Offer payments.
+  * LND v0.21 is currently incompatible with the LNDK version used by BOLT12 Pay.
+  * Users who rely on BOLT12 Offers should remain on LND v0.20.x until LNDK support for LND v0.21 is available.
+  * Upgrading Lightning to LND v0.21 may break BOLT12 Offer payments.
 
-Bugfix release for the v0.2.108 Privacy Mode update.
+  Bugfix release for the v0.2.108 Privacy Mode update.
 
-* Improved reliability of BOLT12 offer creation
-* Automatically retries transient LNDK TLS connection failures
-* Prevents occasional first-attempt offer creation errors observed on some Umbrel systems
+  * Improved reliability of BOLT12 offer creation
+  * Automatically retries transient LNDK TLS connection failures
+  * Prevents occasional first-attempt offer creation errors observed on some Umbrel systems
 
-Includes all features from v0.2.108:
+  Includes all features from v0.2.108:
 
-* Privacy Mode
-* Private BIP353 Lightning Addresses
-* Offer History BIP353 Publishing
-* Automatic DNS Cleanup
+  * Privacy Mode
+  * Private BIP353 Lightning Addresses
+  * Offer History BIP353 Publishing
+  * Automatic DNS Cleanup
 
 dependencies:
   - lightning

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -47,11 +47,11 @@ description: >-
 
   Made for sovereign Bitcoin users.
 
-  developer: Alex71btc
-  website: https://github.com/Alex71btc
-  submitter: Alex71btc
-  submission: https://github.com/getumbrel/umbrel-apps/pull/5429
-  repo: https://github.com/Alex71btc/lndk-payments
+developer: Alex71btc
+website: https://github.com/Alex71btc
+submitter: Alex71btc
+submission: https://github.com/getumbrel/umbrel-apps/pull/5429
+repo: https://github.com/Alex71btc/lndk-payments
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
 

--- a/lightning/docker-compose.yml
+++ b/lightning/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3006
 
   app:
-    image: getumbrel/umbrel-lightning:v1.2.2@sha256:61694e8abe448f407af0596387ef964c2687376e5083b602616a123e2d88e32d
+    image: getumbrel/umbrel-lightning:v1.3.1@sha256:94090ec616210f427cd8ab3ea95dad02b52fa0a82a62d72cb4a7987b4b7b1367
     restart: on-failure
     volumes:
       - "${APP_LIGHTNING_NODE_DATA_DIR}:/data/.lnd"
@@ -42,7 +42,7 @@ services:
 
   lnd:
     hostname: "${DEVICE_DOMAIN_NAME}" # Needed so LND can generate a valid cert
-    image: lightninglabs/lnd:v0.20.1-beta@sha256:f0a2bdc4b8bc89cb3b31b6e12d6b16ac5145defd916d8152cf0c1c07d8697cff
+    image: lightninglabs/lnd:v0.21.0-beta@sha256:60fca3f409cf3d500db1d15c9965678a4b5a60758ff30863d52b02529c18be8b
     command: "${APP_LIGHTNING_COMMAND}"
     user: 1000:1000
     restart: unless-stopped

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -114,4 +114,6 @@ widgets:
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/commit/576ecd2bef8d625abceed0f67ec9c487da9b2b1b
 backupIgnore:
-  - data/graph/mainnet/channel.db
+  - data/lnd/data/graph/*/channel.db
+  - data/lnd/data/graph/*/wtclient.db
+  - data/lnd/data/watchtower/*/*/watchtower.db

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: lightning
 category: bitcoin
 name: Lightning Node
-version: "0.20.1-beta"
+version: "0.21.0-beta"
 tagline: Run your personal Lightning Network node
 description: >-
   Run your personal Lightning Network node, and join the future of Bitcoin today.
@@ -22,10 +22,22 @@ description: >-
 
   An official app from Umbrel.
 releaseNotes: >-
-  This update includes the latest version of LND (v0.20.1-beta) and improves the Connect Wallet QR codes so they scan more reliably in Zeus and other mobile wallets.
+  ⚠️ Important for users who manually changed LND protocol settings: if you previously added `protocol.custom-nodeann=39` or `protocol.custom-init=39` for BOLT 12/LNDK integrations, remove those lines before updating. LND v0.21.0-beta now advertises onion messaging itself, and leaving those custom feature-bit settings in place can prevent LND from starting.
 
 
-  Full LND release notes can be found at https://github.com/lightningnetwork/lnd/releases/tag/v0.20.1-beta
+  This update includes LND v0.21.0-beta along with the latest improvements to the Lightning Node app experience on Umbrel.
+
+
+  LND v0.21.0-beta adds onion messaging support, production taproot channel support, safer channel-close confirmation handling, and performance improvements.
+
+
+  Lightning Node on Umbrel now includes dark mode, a fiat currency selector for balances, improved QR code scanning in dark mode, improved automatic backup and channel recovery handling, plus bug fixes and improvements.
+
+
+  Power users: LND v0.21.0-beta removes deprecated payment RPCs and rejects manually configured Tor v2 onion addresses. Lightning Node on Umbrel already uses Tor v3 by default. Review the upstream release notes if you use custom scripts, external integrations, or custom LND advanced settings.
+
+
+  Full LND release notes can be found at https://github.com/lightningnetwork/lnd/releases/tag/v0.21.0-beta
 developer: Umbrel
 website: https://umbrel.com
 dependencies:


### PR DESCRIPTION
This PR adds an important compatibility notice for BOLT12 Pay users.

Current BOLT12 functionality relies on LNDK's custom onion messaging integration using custom message type 513. LND v0.21 introduced native onion messaging support and is currently not compatible with the LNDK version used by BOLT12 Pay.

Without this notice, users may upgrade Lightning to LND v0.21 and unexpectedly lose BOLT12 Offer payment functionality.

Changes:

* Added LND v0.21 compatibility warning to the app description.
* Clarified that the protocol.custom-* configuration is only applicable to LND v0.20.x.
* Added release notes warning for users considering a Lightning upgrade.

No functional code changes.
Documentation update only.
