### PR TITLE
App Submission: EE Gateway

### DIFF
--- a/ee-gateway/docker-compose.yml
+++ b/ee-gateway/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   # extra download, and it is the only place root is used. This is NOT privileged
   # mode; the app containers themselves stay non-root.
   init_perms:
-    image: encryptedenergy/ee-gateway-worker:0.7.5@sha256:e1ce654087e6db114ea8bbb6ae195e96b85330bd3108d6e1616c3a9bee4880d3
+    image: encryptedenergy/ee-gateway-worker:0.7.5@sha256:0b58f6e9e1b0ca5c15150b23ac66958a27fac84db5487581495bf9a0a2c99999
     user: "0:0"
     entrypoint: ["sh", "-c", "chown -R 1000:1000 /data"]
     restart: on-failure
@@ -66,7 +66,7 @@ services:
   # Python process runs as uid 1000; gpsd starts as root only to open the
   # serial device, then drops to user nobody.
   worker:
-    image: encryptedenergy/ee-gateway-worker:0.7.5@sha256:e1ce654087e6db114ea8bbb6ae195e96b85330bd3108d6e1616c3a9bee4880d3
+    image: encryptedenergy/ee-gateway-worker:0.7.5@sha256:0b58f6e9e1b0ca5c15150b23ac66958a27fac84db5487581495bf9a0a2c99999
     init: true
     restart: on-failure
     depends_on:

--- a/ee-gateway/docker-compose.yml
+++ b/ee-gateway/docker-compose.yml
@@ -35,10 +35,10 @@ services:
   # extra download, and it is the only place root is used. This is NOT privileged
   # mode; the app containers themselves stay non-root.
   init_perms:
-    image: encryptedenergy/ee-gateway-worker:0.7.4
+    image: encryptedenergy/ee-gateway-worker:0.7.4@sha256:c9487c7d138e871fd49298ba4f2a4ba2e57173a4e24cfd30e57774026dbcc898
     user: "0:0"
     entrypoint: ["sh", "-c", "chown -R 1000:1000 /data"]
-    restart: "no"
+    restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/data
 
@@ -46,8 +46,9 @@ services:
   # no added capabilities, no Bluetooth access. Runs as uid 1000 (set in the
   # image). init: true so SIGTERM reaches Flask for a clean shutdown.
   ui:
-    image: encryptedenergy/ee-gateway-ui:0.6.2
+    image: encryptedenergy/ee-gateway-ui:0.6.2@sha256:c565138959c1498706d4954521ff7630cb41f8fec4b2ec1ef91e6a2d36f15a4e
     init: true
+    restart: on-failure
     depends_on:
       init_perms:
         condition: service_completed_successfully
@@ -65,7 +66,7 @@ services:
   # Python process runs as uid 1000; gpsd starts as root only to open the
   # serial device, then drops to user nobody.
   worker:
-    image: encryptedenergy/ee-gateway-worker:0.7.4
+    image: encryptedenergy/ee-gateway-worker:0.7.4@sha256:c9487c7d138e871fd49298ba4f2a4ba2e57173a4e24cfd30e57774026dbcc898
     init: true
     restart: on-failure
     depends_on:

--- a/ee-gateway/docker-compose.yml
+++ b/ee-gateway/docker-compose.yml
@@ -1,0 +1,111 @@
+# EE Gateway: Umbrel app composition
+# Copyright (C) 2026 encryptedenergy.com
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# Two services share ${APP_DATA_DIR}/data (mounted at /data) for file-based
+# IPC: the UI writes config.json, the worker writes state.json and packets.db.
+# They never communicate over the network, so the worker can run on the host
+# network (which it needs to reach the Bluetooth radio) while the UI stays on
+# Umbrel's app network behind app_proxy.
+#
+# Credentials are NOT passed as environment variables here. The user enters the
+# upstream network's org id and API token once in the UI setup wizard, which
+# writes them to config.json in the shared volume; the worker reads that file
+# every scan cycle.
+#
+# umbreld creates ${APP_DATA_DIR}/data owned by root, but both app containers
+# run as uid 1000 and so cannot write it. The init_perms service fixes ownership
+# once before the app containers start. The worker also carries a restart policy
+# so a transient Bluetooth or D-Bus error on real hardware self-heals.
+
+version: "3.7"
+
+services:
+
+  # Umbrel's reverse proxy. It terminates Umbrel auth and forwards to the UI.
+  # APP_HOST format is <app-id>_<compose-service-name>_1.
+  app_proxy:
+    environment:
+      APP_HOST: ee-gateway_ui_1
+      APP_PORT: 8080
+
+  # One-time root init. umbreld creates the shared /data dir owned by root; both
+  # app containers run as uid 1000 and cannot write it. This chowns /data to
+  # 1000:1000 and exits. It reuses the already-pulled worker image so there is no
+  # extra download, and it is the only place root is used. This is NOT privileged
+  # mode; the app containers themselves stay non-root.
+  init_perms:
+    image: encryptedenergy/ee-gateway-worker:0.7.4
+    user: "0:0"
+    entrypoint: ["sh", "-c", "chown -R 1000:1000 /data"]
+    restart: "no"
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+
+  # Flask setup wizard + status dashboard. Fully unprivileged: no host network,
+  # no added capabilities, no Bluetooth access. Runs as uid 1000 (set in the
+  # image). init: true so SIGTERM reaches Flask for a clean shutdown.
+  ui:
+    image: encryptedenergy/ee-gateway-ui:0.6.2
+    init: true
+    depends_on:
+      init_perms:
+        condition: service_completed_successfully
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+    environment:
+      EE_DATA_DIR: /data
+      EE_UI_PORT: 8080
+      EE_GATEWAY_VERSION: "0.10.3"
+
+  # BLE scan + GPS-stamped cloud ingest worker. It reaches the host's
+  # Bluetooth radio through bluetoothd over the D-Bus system bus, talks to
+  # a bundled gpsd against an optional USB GPS dongle for per-packet
+  # coordinates, and makes outbound HTTPS calls to encryptedenergy.com. The
+  # Python process runs as uid 1000; gpsd starts as root only to open the
+  # serial device, then drops to user nobody.
+  worker:
+    image: encryptedenergy/ee-gateway-worker:0.7.4
+    init: true
+    restart: on-failure
+    depends_on:
+      init_perms:
+        condition: service_completed_successfully
+    # Host networking gives the container direct use of the host Bluetooth
+    # stack. Docker does not bridge BlueZ, so this is the only path that
+    # exposes the host's Bluetooth radio to the container. The worker uses
+    # the host network only for outbound HTTPS; it does not bind any
+    # listening port.
+    network_mode: host
+    # The only privilege grant for BLE: NET_ADMIN + NET_RAW let the
+    # Bluetooth stack manage and read from the radio. Deliberately NO
+    # `privileged: true`, NO Docker socket, NO host filesystem write.
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    # USB device access for an optional GPS dongle. Two layers:
+    #
+    # 1) `device_cgroup_rules` grants the container permission to access
+    #    character devices with major 188 (USB serial, e.g. PL2303 ->
+    #    ttyUSB*) and 166 (CDC ACM, e.g. u-blox NEO -> ttyACM*). The
+    #    rule is permission only; without step 2 the device nodes are
+    #    not present inside the container's tmpfs /dev.
+    #
+    # 2) Bind-mounting the host's /dev INTO the container's /dev makes
+    #    the actual device nodes visible. The cgroup_rules above keep
+    #    the container from actually opening any device outside the
+    #    two allowed majors.
+    device_cgroup_rules:
+      - 'c 188:* rwm'
+      - 'c 166:* rwm'
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+      # D-Bus system bus, read-only: the worker speaks to the host
+      # bluetoothd over the bus but never needs to write the bus directory.
+      - /var/run/dbus:/var/run/dbus:ro
+      # Full /dev passthrough so the GPS dongle's tty node is visible to
+      # the container. Constrained to majors 188 and 166 by the
+      # device_cgroup_rules above.
+      - /dev:/dev
+    environment:
+      EE_DATA_DIR: /data

--- a/ee-gateway/docker-compose.yml
+++ b/ee-gateway/docker-compose.yml
@@ -43,8 +43,10 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   # Flask setup wizard + status dashboard. Fully unprivileged: no host network,
-  # no added capabilities, no Bluetooth access. Runs as uid 1000 (set in the
-  # image). init: true so SIGTERM reaches Flask for a clean shutdown.
+  # no added capabilities, no Bluetooth access. During setup it may make
+  # outbound HTTPS requests to encryptedenergy.com to verify credentials.
+  # Runs as uid 1000 (set in the image). init: true so SIGTERM reaches Flask
+  # for a clean shutdown.
   ui:
     image: encryptedenergy/ee-gateway-ui:0.6.2@sha256:c565138959c1498706d4954521ff7630cb41f8fec4b2ec1ef91e6a2d36f15a4e
     init: true

--- a/ee-gateway/docker-compose.yml
+++ b/ee-gateway/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   # extra download, and it is the only place root is used. This is NOT privileged
   # mode; the app containers themselves stay non-root.
   init_perms:
-    image: encryptedenergy/ee-gateway-worker:0.7.4@sha256:c9487c7d138e871fd49298ba4f2a4ba2e57173a4e24cfd30e57774026dbcc898
+    image: encryptedenergy/ee-gateway-worker:0.7.5@sha256:e1ce654087e6db114ea8bbb6ae195e96b85330bd3108d6e1616c3a9bee4880d3
     user: "0:0"
     entrypoint: ["sh", "-c", "chown -R 1000:1000 /data"]
     restart: on-failure
@@ -57,7 +57,7 @@ services:
     environment:
       EE_DATA_DIR: /data
       EE_UI_PORT: 8080
-      EE_GATEWAY_VERSION: "0.10.3"
+      EE_GATEWAY_VERSION: "0.10.4"
 
   # BLE scan + GPS-stamped cloud ingest worker. It reaches the host's
   # Bluetooth radio through bluetoothd over the D-Bus system bus, talks to
@@ -66,7 +66,7 @@ services:
   # Python process runs as uid 1000; gpsd starts as root only to open the
   # serial device, then drops to user nobody.
   worker:
-    image: encryptedenergy/ee-gateway-worker:0.7.4@sha256:c9487c7d138e871fd49298ba4f2a4ba2e57173a4e24cfd30e57774026dbcc898
+    image: encryptedenergy/ee-gateway-worker:0.7.5@sha256:e1ce654087e6db114ea8bbb6ae195e96b85330bd3108d6e1616c3a9bee4880d3
     init: true
     restart: on-failure
     depends_on:
@@ -74,9 +74,12 @@ services:
         condition: service_completed_successfully
     # Host networking gives the container direct use of the host Bluetooth
     # stack. Docker does not bridge BlueZ, so this is the only path that
-    # exposes the host's Bluetooth radio to the container. The worker uses
-    # the host network only for outbound HTTPS; it does not bind any
-    # listening port.
+    # exposes the host's Bluetooth radio to the container. The worker
+    # makes outbound HTTPS calls only; it does not bind any LAN-facing
+    # listening port. The container does run a bundled gpsd internally
+    # for the optional GPS dongle, but as of worker 0.7.5 it is started
+    # without -G, so it binds 127.0.0.1:2947 (loopback) only — the worker
+    # reads from that same loopback, no other consumer.
     network_mode: host
     # The only privilege grant for BLE: NET_ADMIN + NET_RAW let the
     # Bluetooth stack manage and read from the radio. Deliberately NO

--- a/ee-gateway/umbrel-app.yml
+++ b/ee-gateway/umbrel-app.yml
@@ -1,6 +1,6 @@
 manifestVersion: 1
 id: ee-gateway
-category: Networking
+category: networking
 name: EE Gateway
 version: "0.10.3"
 tagline: Self-hosted Bluetooth gateway for open BLE networks

--- a/ee-gateway/umbrel-app.yml
+++ b/ee-gateway/umbrel-app.yml
@@ -33,7 +33,10 @@ dependencies: []
 repo: https://github.com/Encrypted-Energy/gateway
 support: https://github.com/Encrypted-Energy/gateway/issues
 port: 8083
-gallery: []
+gallery:
+  - 1.webp
+  - 2.webp
+  - 3.webp
 path: ""
 defaultUsername: ""
 defaultPassword: ""

--- a/ee-gateway/umbrel-app.yml
+++ b/ee-gateway/umbrel-app.yml
@@ -1,0 +1,40 @@
+manifestVersion: 1
+id: ee-gateway
+category: Networking
+name: EE Gateway
+version: "0.10.3"
+tagline: Self-hosted Bluetooth gateway for open BLE networks
+description: >-
+  EE Gateway turns your Umbrel into a self-hosted Bluetooth gateway for
+  open BLE networks.
+
+
+  It scans with your device's Bluetooth radio for nearby BLE devices from
+  supported networks and forwards their packets to the right upstream cloud,
+  extending ground coverage from hardware you already own. Hubble Network
+  is supported today; more partner networks will be added as they come
+  online.
+
+
+  Two containers do the work: a worker that scans over Bluetooth and ingests
+  packets upstream, and a small web dashboard for first-time setup and live
+  status. Enter your network organization ID and API token once in the setup
+  wizard, and the gateway runs on its own.
+
+
+  EE Gateway is free and open-source software (GPL-3.0-only), built by
+  encryptedenergy.com. It is an independent community project and is not
+  affiliated with any specific BLE network.
+releaseNotes: ""
+developer: encryptedenergy.com
+website: https://encryptedenergy.com
+dependencies: []
+repo: https://github.com/Encrypted-Energy/gateway
+support: https://github.com/Encrypted-Energy/gateway/issues
+port: 8083
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: John Marbach
+submission: ""

--- a/ee-gateway/umbrel-app.yml
+++ b/ee-gateway/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ee-gateway
 category: networking
 name: EE Gateway
-version: "0.10.3"
+version: "0.10.4"
 tagline: Self-hosted Bluetooth gateway for open BLE networks
 description: >-
   EE Gateway turns your Umbrel into a self-hosted Bluetooth gateway for

--- a/ee-gateway/umbrel-app.yml
+++ b/ee-gateway/umbrel-app.yml
@@ -37,4 +37,4 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: John Marbach
-submission: ""
+submission: https://github.com/getumbrel/umbrel-apps/pull/5771

--- a/ee-gateway/umbrel-app.yml
+++ b/ee-gateway/umbrel-app.yml
@@ -18,8 +18,9 @@ description: >-
 
   Two containers do the work: a worker that scans over Bluetooth and ingests
   packets upstream, and a small web dashboard for first-time setup and live
-  status. Enter your network organization ID and API token once in the setup
-  wizard, and the gateway runs on its own.
+  status. You'll need a free encryptedenergy.com account to create the
+  organization ID and API token used during setup. Enter those once in the
+  setup wizard, and the gateway runs on its own.
 
 
   EE Gateway is free and open-source software (GPL-3.0-only), built by


### PR DESCRIPTION
## Type

New app

## App

App ID: `ee-gateway`
Upstream project: https://github.com/Encrypted-Energy/gateway
Version: 0.10.3

## Summary

Self-hosted Bluetooth gateway for open BLE networks. An always-on Umbrel
is the perfect ground node for Bluetooth-LE devices that need to reach
the cloud. EE Gateway turns it into one.

It scans with the host's Bluetooth radio for BLE devices from supported
open networks (Hubble Network today; more partners coming) and forwards
their packets to the right upstream cloud. Free, open source, runs in
the background, no maintenance.

**Architecture:** Two containers, both running as uid 1000:

- `worker` — scans BLE, queues packets to SQLite, drains to
  `encryptedenergy.com` over outbound HTTPS.
- `ui` — Flask dashboard behind `app_proxy` on port 8083. Read-only on
  the worker's status file, no Bluetooth, no outbound calls.

State lives in `${APP_DATA_DIR}/data` as bind mounts. Already shipping at
`v0.10.3` via the
[encryptedenergy community app store](https://github.com/Encrypted-Energy/umbrel-community-app-store/tree/main/encryptedenergy-ee-gateway).

## Verification

Environment tested:
- [x] Umbrel device (Raspberry Pi 5, arm64)
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [ ] amd64
- [x] arm64

Both images (`encryptedenergy/ee-gateway-worker:0.7.4`,
`encryptedenergy/ee-gateway-ui:0.6.2`) are published multi-arch
(`linux/amd64` + `linux/arm64`); amd64 verified by image manifest,
runtime amd64 testing pending. Install, restart, stop/start, and
reinstall all preserve data across `${APP_DATA_DIR}/data`.

## Notes

**Why the worker needs host network + NET_ADMIN/NET_RAW + /dev:**
Bluetooth scanning is the product. The worker talks to the host's `bluetoothd`
over the D-Bus system bus (mounted read-only), and the BLE stack
requires `NET_ADMIN` + `NET_RAW` to manage the radio and read raw
frames. Host networking is the only path that exposes the host's
Bluetooth radio to the container — Docker doesn't bridge BlueZ.

`/dev:/dev` is mounted so an optional USB GPS dongle (vehicle-mounted
gateways) becomes visible without rebuilding the container. The
`device_cgroup_rules` lock access to char-major 188 (USB serial) and
166 (CDC ACM) only. No other devices are reachable.

Explicitly NOT used: `privileged: true`, Docker socket, named volumes,
public listening ports. The `ui` container is fully unprivileged.

**Dependencies:** None. 
**Default credentials:** None. Entered by the user in the in-app setup.

**Links:** 
- [website](https://encryptedenergy.com) ·
- [source (GPL-3.0)](https://github.com/Encrypted-Energy/gateway) ·
- [support](https://github.com/Encrypted-Energy/gateway/issues)

**Assets** 
Icon + three gallery screenshots attached inline below for
the Umbrel team to seed the official assets.

<img width="256" height="256" alt="icon" src="https://github.com/user-attachments/assets/d9d340f5-d321-4d67-8011-32fc2bf38394" />

<img width="1280" height="800" alt="1-setup" src="https://github.com/user-attachments/assets/151b18e8-9a36-449a-b068-d86a1f74e880" />
<img width="1280" height="800" alt="2-dashboard" src="https://github.com/user-attachments/assets/d849960a-c00e-41bc-83ba-74696c849fb1" />
<img width="1280" height="800" alt="3-status" src="https://github.com/user-attachments/assets/ddd8ff51-0742-41eb-ad4b-3479b32c0d45" />

