### PR TITLE
Update BOLT12 Pay for LND 0.21.x native onion messages

### DIFF
--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.2.108@sha256:33df5203b894ef102b4e9823ee7005548e7304747b6466347cfc31a2c89a5910
+    image: alex71btc/bolt12-pay:0.2.109@sha256:681c1a2af8fb0f3b4f439f915f0ec04f8bf60ccfbc7f0ec761bb3eb5f59effb4
     restart: on-failure
     depends_on:
       - lndk

--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - ${APP_LIGHTNING_NODE_DATA_DIR}:/lnd:ro
 
   lndk:
-    image: alex71btc/lndk:amountless-fix-v2@sha256:dcace5e9c90c4dfe26c85979f373ecebfafdf0a56b494e22fd5abe7fb731987e
+    image: alex71btc/lndk:native-onion-messages@sha256:7a8a75c604b1c907e170e77a896ab9747828806daa92d44b65184cd2062a47b3
     restart: on-failure
     entrypoint:
       - /bin/sh

--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -6,14 +6,11 @@ services:
       APP_HOST: bolt12-pay_web_1
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
-
   web:
     image: alex71btc/bolt12-pay:0.2.109@sha256:681c1a2af8fb0f3b4f439f915f0ec04f8bf60ccfbc7f0ec761bb3eb5f59effb4
     restart: on-failure
-
     depends_on:
       - lndk
-
     environment:
       APP_DATA_DIR: /data
       APP_CONFIG_PATH: /data/config.json
@@ -27,13 +24,13 @@ services:
       LNDK_GRPC_HOST: https://lndk
       LNDK_GRPC_PORT: "7000"
       LNDK_CERT_PATH: /data/lndk/tls-cert.pem
-      LNDK_MACAROON_PATH: /lnd/data/chain/bitcoin/mainnet/admin.macaroon
+      LNDK_MACAROON_PATH: /lnd/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/admin.macaroon
       LNDK_TIMEOUT_SECONDS: "30"
       ALLOW_PAY_OFFER: "true"
 
-      LND_REST_URL: https://192.168.188.39:32851
+      LND_REST_URL: https://lightning_lnd_1:8080
       LND_TLS_CERT_PATH: /lnd/tls.cert
-      LND_MACAROON_PATH: /lnd/data/chain/bitcoin/mainnet/admin.macaroon
+      LND_MACAROON_PATH: /lnd/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/admin.macaroon
       LND_REST_INSECURE: "true"
 
       LNURL_MIN_SENDABLE_MSAT: "1000"
@@ -43,43 +40,30 @@ services:
       LNURL_SHARED_DESCRIPTION: "LNURL payment"
       LNURL_DEFAULT_DESCRIPTION: "Lightning payment"
       LNURL_ALIAS_MAP: ""
-
     volumes:
       - ${APP_DATA_DIR}/data:/data
-      - /home/umbrel/umbrel/app-data/alex-lnd21/data:/lnd:ro
+      - ${APP_LIGHTNING_NODE_DATA_DIR}:/lnd:ro
 
   lndk:
     image: alex71btc/lndk:native-onion-messages@sha256:7a8a75c604b1c907e170e77a896ab9747828806daa92d44b65184cd2062a47b3
-
     restart: on-failure
-
     entrypoint:
       - /bin/sh
       - -c
-
     command:
       - |
         echo "Waiting for LND TLS + macaroon..."
-        while [ ! -f /lnd/tls.cert ] || [ ! -f /lnd/data/chain/bitcoin/mainnet/admin.macaroon ]; do
+        while [ ! -f /lnd/tls.cert ] || [ ! -f /lnd/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/admin.macaroon ]; do
           echo "Waiting for cert/macaroon..."
           sleep 5
         done
 
-        echo "Starting LNDK with native onion messages..."
-
+        echo "Starting LNDK with retry loop..."
         while true; do
-          lndk \
-            --address=https://192.168.188.39:32853 \
-            --cert-path=/lnd/tls.cert \
-            --macaroon-path=/lnd/data/chain/bitcoin/mainnet/admin.macaroon \
-            --data-dir=/data/lndk \
-            --grpc-host=0.0.0.0 \
-            --grpc-port=7000
-
+          lndk --address=https://lightning_lnd_1:10009 --cert-path=/lnd/tls.cert --macaroon-path=/lnd/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/admin.macaroon --data-dir=/data/lndk --grpc-host=0.0.0.0 --grpc-port=7000
           echo "LNDK exited or failed. Retrying in 10s..."
           sleep 10
         done
-
     volumes:
       - ${APP_DATA_DIR}/data:/data
-      - /home/umbrel/umbrel/app-data/alex-lnd21/data:/lnd:ro
+      - ${APP_LIGHTNING_NODE_DATA_DIR}:/lnd:ro

--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -6,11 +6,14 @@ services:
       APP_HOST: bolt12-pay_web_1
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
+
   web:
     image: alex71btc/bolt12-pay:0.2.109@sha256:681c1a2af8fb0f3b4f439f915f0ec04f8bf60ccfbc7f0ec761bb3eb5f59effb4
     restart: on-failure
+
     depends_on:
       - lndk
+
     environment:
       APP_DATA_DIR: /data
       APP_CONFIG_PATH: /data/config.json
@@ -24,13 +27,13 @@ services:
       LNDK_GRPC_HOST: https://lndk
       LNDK_GRPC_PORT: "7000"
       LNDK_CERT_PATH: /data/lndk/tls-cert.pem
-      LNDK_MACAROON_PATH: /lnd/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/admin.macaroon
+      LNDK_MACAROON_PATH: /lnd/data/chain/bitcoin/mainnet/admin.macaroon
       LNDK_TIMEOUT_SECONDS: "30"
       ALLOW_PAY_OFFER: "true"
 
-      LND_REST_URL: https://lightning_lnd_1:8080
+      LND_REST_URL: https://192.168.188.39:32851
       LND_TLS_CERT_PATH: /lnd/tls.cert
-      LND_MACAROON_PATH: /lnd/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/admin.macaroon
+      LND_MACAROON_PATH: /lnd/data/chain/bitcoin/mainnet/admin.macaroon
       LND_REST_INSECURE: "true"
 
       LNURL_MIN_SENDABLE_MSAT: "1000"
@@ -40,30 +43,43 @@ services:
       LNURL_SHARED_DESCRIPTION: "LNURL payment"
       LNURL_DEFAULT_DESCRIPTION: "Lightning payment"
       LNURL_ALIAS_MAP: ""
+
     volumes:
       - ${APP_DATA_DIR}/data:/data
-      - ${APP_LIGHTNING_NODE_DATA_DIR}:/lnd:ro
+      - /home/umbrel/umbrel/app-data/alex-lnd21/data:/lnd:ro
 
   lndk:
     image: alex71btc/lndk:native-onion-messages@sha256:7a8a75c604b1c907e170e77a896ab9747828806daa92d44b65184cd2062a47b3
+
     restart: on-failure
+
     entrypoint:
       - /bin/sh
       - -c
+
     command:
       - |
         echo "Waiting for LND TLS + macaroon..."
-        while [ ! -f /lnd/tls.cert ] || [ ! -f /lnd/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/admin.macaroon ]; do
+        while [ ! -f /lnd/tls.cert ] || [ ! -f /lnd/data/chain/bitcoin/mainnet/admin.macaroon ]; do
           echo "Waiting for cert/macaroon..."
           sleep 5
         done
 
-        echo "Starting LNDK with retry loop..."
+        echo "Starting LNDK with native onion messages..."
+
         while true; do
-          lndk --address=https://lightning_lnd_1:10009 --cert-path=/lnd/tls.cert --macaroon-path=/lnd/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/admin.macaroon --data-dir=/data/lndk --grpc-host=0.0.0.0 --grpc-port=7000
+          lndk \
+            --address=https://192.168.188.39:32853 \
+            --cert-path=/lnd/tls.cert \
+            --macaroon-path=/lnd/data/chain/bitcoin/mainnet/admin.macaroon \
+            --data-dir=/data/lndk \
+            --grpc-host=0.0.0.0 \
+            --grpc-port=7000
+
           echo "LNDK exited or failed. Retrying in 10s..."
           sleep 10
         done
+
     volumes:
       - ${APP_DATA_DIR}/data:/data
-      - ${APP_LIGHTNING_NODE_DATA_DIR}:/lnd:ro
+      - /home/umbrel/umbrel/app-data/alex-lnd21/data:/lnd:ro

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.108.1
+version: 0.2.109
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
@@ -11,8 +11,22 @@ description: >-
   with optional Nostr identity features such as NIP-05 and Zaps.
 
 
-  This app currently depends on a custom LND build with BOLT12-related custom
+   ## ⚠️  IMPORTANT USER WARNING: 
+    - Current releases of BOLT12 Pay depend on LNDK, which is currently compatible with LND v0.20.x only.
+
+    - LND v0.21 introduced native onion messaging and is currently incompatible with the version of LNDK used by this app.
+
+    - If your Lightning node is upgraded to LND v0.21, BOLT12 Offer payments may stop working until LNDK is updated for the new API.
+
+
+    **⚠️  If you want to continue using BOLT12 Pay, remain on LND v0.20.1-beta for now!**
+
+
+  This app currently depends on custom LND protocol changes in LND versions <=0.20.1 beta with BOLT12-related custom
   message support enabled.
+
+
+  🛠️  SET-UP INSTRUCTIONS:
 
 
   In your LND configuration file (Go to Files: Apps → lightning → data → lnd → lnd.conf), add:
@@ -43,6 +57,8 @@ description: >-
 
 
   Made for sovereign Bitcoin users.
+
+
 developer: Alex71btc
 website: https://github.com/Alex71btc
 submitter: Alex71btc
@@ -51,17 +67,24 @@ repo: https://github.com/Alex71btc/lndk-pay
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
 
+  Compatibility notice:
+
+  - LND v0.21 is currently incompatible with the LNDK version used by BOLT12 Pay.
+  - Users who rely on BOLT12 Offers should remain on LND v0.20.x until LNDK support for LND v0.21 is available.
+  - Upgrading Lightning to LND v0.21 may break BOLT12 Offer payments.
+
   Bugfix release for the v0.2.108 Privacy Mode update.
 
-   - Improved reliability of BOLT12 offer creation
-   - Automatically retries transient LNDK TLS connection failures
-   - Prevents occasional first-attempt offer creation errors observed on some Umbrel systems
+  - Improved reliability of BOLT12 offer creation
+  - Automatically retries transient LNDK TLS connection failures
+  - Prevents occasional first-attempt offer creation errors observed on some Umbrel systems
 
   Includes all features from v0.2.108:
-   - Privacy Mode
-   - Private BIP353 Lightning Addresses
-   - Offer History BIP353 Publishing
-   - Automatic DNS Cleanup
+
+  - Privacy Mode
+  - Private BIP353 Lightning Addresses
+  - Offer History BIP353 Publishing
+  - Automatic DNS Cleanup
 
 dependencies:
   - lightning

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.109
+version: 0.2.110
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -11,15 +11,63 @@ description: >-
   with optional Nostr identity features such as NIP-05 and Zaps.
 
 
-   ## ⚠️  IMPORTANT USER WARNING: 
-    - Current releases of BOLT12 Pay depend on LNDK, which is currently compatible with LND v0.20.x only.
-
-    - LND v0.21 introduced native onion messaging and is currently incompatible with the version of LNDK used by this app.
-
-    - If your Lightning node is upgraded to LND v0.21, BOLT12 Offer payments may stop working until LNDK is updated for the new API.
+  ## ⚠️ LND Compatibility Notice
 
 
-    **⚠️  If you want to continue using BOLT12 Pay, remain on LND v0.20.1-beta for now!**
+   BOLT12 Pay now supports both:
+
+
+   * LND v0.20.1 beta with the legacy custom-message transport
+   * LND v0.21.0 with native onion messaging support
+
+
+   ### ⚠️  Upgrading from LND v0.20.x to LND v0.21.x
+
+
+   If you previously used BOLT12 Pay with LND v0.20.1 beta, you likely added custom protocol settings to your `lnd.conf`:
+
+
+   [protocol]
+   protocol.custom-message=513
+   protocol.custom-nodeann=39
+   protocol.custom-init=39
+
+
+   ### ⚠️   IMPORTANT
+
+
+   Before upgrading your Lightning node to LND v0.21.x, remove the entire custom protocol section from your `lnd.conf`. 
+   In your LND configuration file (Go to Files: Apps → lightning → data → lnd → lnd.conf), remove 
+
+   [protocol]
+   protocol.custom-message=513
+   protocol.custom-nodeann=39
+   protocol.custom-init=39
+
+
+   Save and restart LND, then you may savely update the Lightning Node app on umbrel.
+
+
+   Native onion messaging support is now built directly into LND v0.21 and these legacy settings are no longer required.
+
+   ⚠️  Leaving old custom protocol settings in place may cause unexpected behaviour after upgrading and may result in Lightning Node crash.
+
+   Once the custom protocol entries are removed, LND will work again.
+
+
+   ### LND v0.20.1 beta Users
+
+
+   If you remain on LND v0.20.x, the custom protocol settings above are still required for BOLT12 functionality.
+
+
+   ### LND v0.21.x Users
+
+
+   No custom protocol configuration is required.
+
+   BOLT12 Pay will automatically use LND's native onion messaging support.
+
 
 
   This app currently depends on custom LND protocol changes in LND versions <=0.20.1 beta with BOLT12-related custom
@@ -28,6 +76,16 @@ description: >-
 
   🛠️  SET-UP INSTRUCTIONS:
 
+
+  ## LND v0.21.0 beta and newer
+
+
+  No custom protocol configuration is required.
+
+  BOLT12 Pay automatically uses LND's native onion messaging support.
+
+
+  ## LND v0.20.1 beta and older LND implementations
 
   In your LND configuration file (Go to Files: Apps → lightning → data → lnd → lnd.conf), add:
 
@@ -67,11 +125,22 @@ repo: https://github.com/Alex71btc/lndk-pay
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
 
-  Compatibility notice:
+  Native Onion Messaging Release
 
-  - LND v0.21 is currently incompatible with the LNDK version used by BOLT12 Pay.
-  - Users who rely on BOLT12 Offers should remain on LND v0.20.x until LNDK support for LND v0.21 is available.
-  - Upgrading Lightning to LND v0.21 may break BOLT12 Offer payments.
+   - Added support for LND v0.21 native onion messaging
+   - Removed dependency on custom-message transport when using LND v0.21
+   - BOLT12 Offer creation verified on LND v0.21
+   - BOLT12 Offer payments verified on LND v0.21
+   - BIP353 payment flow verified on LND v0.21
+   - Improved future compatibility with upcoming Lightning releases
+
+  Upgrade notes:
+
+  - LND v0.20.x users should keep their existing custom protocol configuration.
+  - LND v0.21.x users should remove all legacy custom protocol settings from lnd.conf before upgrading Lightning.
+
+  This release maintains compatibility with existing BOLT12 Pay installations while preparing for the transition to native onion messaging in LND.
+
 
   Bugfix release for the v0.2.108 Privacy Mode update.
 

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.108
+version: 0.2.108.1
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
@@ -15,7 +15,7 @@ description: >-
   message support enabled.
 
 
-  In your LND configuration, add:
+  In your LND configuration file (Go to Files: Apps → lightning → data → lnd → lnd.conf), add:
 
     [protocol]
     protocol.custom-message=513
@@ -23,7 +23,7 @@ description: >-
     protocol.custom-init=39
 
 
-  Restart Lightning afterwards. Without this, BOLT12 functionality will not work.
+  Save and restart Lightning afterwards. Without this, BOLT12 functionality will not work.
 
 
   Domain setup guide:
@@ -36,7 +36,9 @@ description: >-
   and this app uses cutting-edge Lightning features.
 
 
-  Support ongoing development:
+  Support ongoing development by donating to this project:
+
+
   https://geyser.fund/project/bolt12pay
 
 
@@ -49,12 +51,17 @@ repo: https://github.com/Alex71btc/lndk-pay
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
 
- - Publish BIP353 Lightning Addresses directly from Offer History
- - Create private Lightning Addresses for customers, events, or temporary use
- - Automatic DNS cleanup when deleting history entries or clearing history
- - Improved Offer History management with server-side persistence
- - Extends the Privacy Mode features introduced in v0.2.106
+  Bugfix release for the v0.2.108 Privacy Mode update.
 
+   - Improved reliability of BOLT12 offer creation
+   - Automatically retries transient LNDK TLS connection failures
+   - Prevents occasional first-attempt offer creation errors observed on some Umbrel systems
+
+  Includes all features from v0.2.108:
+   - Privacy Mode
+   - Private BIP353 Lightning Addresses
+   - Offer History BIP353 Publishing
+   - Automatic DNS Cleanup
 
 dependencies:
   - lightning


### PR DESCRIPTION
## Summary

This PR updates BOLT12 Pay for LND v0.21 compatibility.

### Changes

* Added native onion messaging support through updated LNDK backend
* Verified BOLT12 Offer creation on LND v0.21
* Verified BOLT12 Offer payment on LND v0.21
* Verified BIP353 payment flow on LND v0.21
* Updated user-facing upgrade instructions

### Important

Users upgrading from LND v0.20.x must remove the legacy custom protocol entries from `lnd.conf` before updating Lightning.

LND v0.21 includes native onion messaging support and no longer requires:

```ini
[protocol]
protocol.custom-message=513
protocol.custom-nodeann=39
protocol.custom-init=39
```

Keeping these entries may prevent Lightning from starting after upgrade.

### Validation

Tested successfully on Umbrel with:

* LND v0.21.0-beta
* Native onion messaging transport
* Offer creation
* Offer payment
* BIP353 payment flow
