### PR TITLE
Update yuvomi to v0.75.2

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:0.74.4@sha256:e109b2f00fd898ac6428bf0d38f5a0a7087f0c7371ff68f28ff9609644e51b58
+    image: ghcr.io/ulsklyc/yuvomi:0.77.2@sha256:2ef8abcfab128835765d5001e2e2a13eb979781932701099d1c88fcfc34f4fe7
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "0.74.4"
+version: "0.77.2"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -51,17 +51,15 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  This update includes a large set of Yuvomi improvements since 0.66.0:
+  This update includes Yuvomi improvements since 0.74.4:
 
-  - Added public and school holiday overlays, a subscriptions tracker under Budget, budget category management, and optional SMTP password reset.
+  - Added per-user weather locations and self-hosted Gotify and ntfy notification channels for reminder delivery.
 
-  - Added in-browser document previews, Paperless-ngx/DMS integrations, and optional WebDAV document storage.
+  - Added an admin password reset field for family members, improved calendar click-to-create behavior, and polished settings, navigation, status summaries, breadcrumbs, and mobile module rows.
 
-  - Reorganized Settings and navigation, refreshed mobile layouts, added a visible help entry, and improved create/edit dialogs across the app.
+  - Fixed reminder notifications failing with a missing reminders.pushed_at database column after fresh installs or updates.
 
-  - Improved reminders with optional Web Push notifications where HTTPS is available.
-
-  - Fixed and hardened several areas, including document preview handling, WebDAV target validation, subscription logo discovery, email dependency vulnerabilities, calendar/task edge cases, backups, localization, and dashboard/weather layout issues.
+  - Fixed calendar export handling for events with explicit UTC offsets and fixed shopping item checkboxes after switching lists.
 developer: Ulas Kalayci
 website: https://github.com/ulsklyc/yuvomi
 dependencies: []


### PR DESCRIPTION
Hi @ulsklyc, while testing Yuvomi 0.75.2 for Umbrel I saw a recurring error on both fresh installs and updates:

`PushScheduler: no such column: r.pushed_at`

It looks like migration 54 adds `reminders.pushed_at`, but migration 57 rebuilds the `reminders` table without preserving that column. The scheduler then queries `r.pushed_at`, so reminder notifications appear broken.

Could you patch the migration/schema and cut a new release? I can retest once it’s available.
