### PR TITLE
App submission: Lightning Mate

### DIFF
--- a/lightningmate/data/.gitkeep
+++ b/lightningmate/data/.gitkeep
@@ -1,0 +1,3 @@
+# Bind-mount source for the app's writable data dir (autopilot config + rebalance
+# accounting). Committing it lets umbrelOS pre-create ${APP_DATA_DIR}/data with the
+# right owner (uid 1000), so settings persist across restarts and updates.

--- a/lightningmate/data/.gitkeep
+++ b/lightningmate/data/.gitkeep
@@ -1,3 +1,0 @@
-# Bind-mount source for the app's writable data dir (autopilot config + rebalance
-# accounting). Committing it lets umbrelOS pre-create ${APP_DATA_DIR}/data with the
-# right owner (uid 1000), so settings persist across restarts and updates.

--- a/lightningmate/docker-compose.yml
+++ b/lightningmate/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3001
 
   web:
-    image: ghcr.io/opensourceminers/lightningmate:v0.6.6@sha256:6b1ccb4f38816433cc0c0fddbb7f9d085e5f02e7f9c9b93cde62431f226d8dab
+    image: ghcr.io/opensourceminers/lightningmate:v0.6.10@sha256:199a9df7855714d3b2fe2bc011ebdda88bd58fee2653f283111b35094ca61c1a
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightningmate/docker-compose.yml
+++ b/lightningmate/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3001
 
   web:
-    image: ghcr.io/opensourceminers/lightningmate:v0.6.4@sha256:17c0e24aa4b01c34c0e76b37dfd4ac3b87f4a04db72b93cb09e3306dc687a46d
+    image: ghcr.io/opensourceminers/lightningmate:v0.6.6@sha256:6b1ccb4f38816433cc0c0fddbb7f9d085e5f02e7f9c9b93cde62431f226d8dab
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightningmate/docker-compose.yml
+++ b/lightningmate/docker-compose.yml
@@ -6,25 +6,11 @@ services:
       APP_HOST: lightningmate_web_1
       APP_PORT: 3001
 
-  # One-shot: make the bind-mounted data dir writable by the non-root app user.
-  # Docker creates the mount source as root, so without this the app (uid 1000)
-  # can't persist its config and settings silently reset on every restart/update.
-  init:
-    image: alpine:3.20
-    user: "0:0"
-    restart: "no"
-    command: sh -c "chown -R 1000:1000 /data"
-    volumes:
-      - ${APP_DATA_DIR}/data:/data
-
   web:
     image: ghcr.io/opensourceminers/lightningmate:v0.6.1@sha256:a1fc9f52c043f14b7b55ce29497ac6874085079abd527c3b9749c9d711100d62
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
-    depends_on:
-      init:
-        condition: service_completed_successfully
     volumes:
       # Read-only access to LND's tls.cert + macaroons.
       - ${APP_LIGHTNING_NODE_DATA_DIR}:/lnd:ro

--- a/lightningmate/docker-compose.yml
+++ b/lightningmate/docker-compose.yml
@@ -1,0 +1,49 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: lightningmate_web_1
+      APP_PORT: 3001
+
+  # One-shot: make the bind-mounted data dir writable by the non-root app user.
+  # Docker creates the mount source as root, so without this the app (uid 1000)
+  # can't persist its config and settings silently reset on every restart/update.
+  init:
+    image: alpine:3.20
+    user: "0:0"
+    restart: "no"
+    command: sh -c "chown -R 1000:1000 /data"
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+
+  web:
+    image: ghcr.io/opensourceminers/lightningmate:v0.6.1@sha256:a1fc9f52c043f14b7b55ce29497ac6874085079abd527c3b9749c9d711100d62
+    user: "1000:1000"
+    restart: on-failure
+    stop_grace_period: 1m
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    volumes:
+      # Read-only access to LND's tls.cert + macaroons.
+      - ${APP_LIGHTNING_NODE_DATA_DIR}:/lnd:ro
+      # App's own writable data dir (autopilot config + rebalance accounting).
+      - ${APP_DATA_DIR}/data:/data
+    environment:
+      APP_LIGHTNING_NODE_IP: "$APP_LIGHTNING_NODE_IP"
+      APP_LIGHTNING_NODE_GRPC_PORT: "$APP_LIGHTNING_NODE_GRPC_PORT"
+      LND_SOCKET: "$APP_LIGHTNING_NODE_IP:$APP_LIGHTNING_NODE_GRPC_PORT"
+      LND_DIR: "/lnd"
+      LND_CERT_PATH: "/lnd/tls.cert"
+      LND_MACAROON_PATH: "/lnd/data/chain/bitcoin/mainnet/readonly.macaroon"
+      DATA_DIR: "/data"
+      PORT: "3001"
+      # Bind all interfaces so app_proxy (which authenticates) can reach us.
+      LM_BIND: "0.0.0.0"
+      # Node management needs write access (like RTL / Thunderhub / Lightning
+      # Terminal). The autopilot itself stays OFF until the user turns it on, and
+      # every fund-moving action asks for confirmation. To run read-only instead,
+      # comment these two lines out.
+      LM_ENABLE_WRITE: "true"
+      LND_WRITE_MACAROON_PATH: "/lnd/data/chain/bitcoin/mainnet/admin.macaroon"

--- a/lightningmate/docker-compose.yml
+++ b/lightningmate/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3001
 
   web:
-    image: ghcr.io/opensourceminers/lightningmate:v0.6.1@sha256:a1fc9f52c043f14b7b55ce29497ac6874085079abd527c3b9749c9d711100d62
+    image: ghcr.io/opensourceminers/lightningmate:v0.6.4@sha256:17c0e24aa4b01c34c0e76b37dfd4ac3b87f4a04db72b93cb09e3306dc687a46d
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -22,14 +22,20 @@ services:
       LND_SOCKET: "$APP_LIGHTNING_NODE_IP:$APP_LIGHTNING_NODE_GRPC_PORT"
       LND_DIR: "/lnd"
       LND_CERT_PATH: "/lnd/tls.cert"
-      LND_MACAROON_PATH: "/lnd/data/chain/bitcoin/mainnet/readonly.macaroon"
+      LND_MACAROON_PATH: "/lnd/data/chain/bitcoin/$APP_BITCOIN_NETWORK/readonly.macaroon"
       DATA_DIR: "/data"
       PORT: "3001"
       # Bind all interfaces so app_proxy (which authenticates) can reach us.
       LM_BIND: "0.0.0.0"
+      # Per-install secrets for server-side auth. Other app containers share the
+      # Docker network, so the whole API requires a session token proving the
+      # per-app password Umbrel shows the user ($APP_PASSWORD, from
+      # deterministicPassword); $APP_SEED signs the tokens.
+      APP_PASSWORD: "$APP_PASSWORD"
+      APP_SEED: "$APP_SEED"
       # Node management needs write access (like RTL / Thunderhub / Lightning
       # Terminal). The autopilot itself stays OFF until the user turns it on, and
       # every fund-moving action asks for confirmation. To run read-only instead,
       # comment these two lines out.
       LM_ENABLE_WRITE: "true"
-      LND_WRITE_MACAROON_PATH: "/lnd/data/chain/bitcoin/mainnet/admin.macaroon"
+      LND_WRITE_MACAROON_PATH: "/lnd/data/chain/bitcoin/$APP_BITCOIN_NETWORK/admin.macaroon"

--- a/lightningmate/umbrel-app.yml
+++ b/lightningmate/umbrel-app.yml
@@ -38,4 +38,4 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: opensourceminers
-submission: ""
+submission: "https://github.com/getumbrel/umbrel-apps/pull/5783"

--- a/lightningmate/umbrel-app.yml
+++ b/lightningmate/umbrel-app.yml
@@ -5,7 +5,7 @@ manifestVersion: 1
 id: lightningmate
 category: finance
 name: Lightning Mate
-version: "0.6.6"
+version: "0.6.10"
 tagline: Profit-aware management & autopilot for your Lightning node
 description: >-
   Lightning Mate manages your Lightning node so you don't have to babysit it.

--- a/lightningmate/umbrel-app.yml
+++ b/lightningmate/umbrel-app.yml
@@ -5,7 +5,7 @@ manifestVersion: 1
 id: lightningmate
 category: finance
 name: Lightning Mate
-version: "0.6.4"
+version: "0.6.6"
 tagline: Profit-aware management & autopilot for your Lightning node
 description: >-
   Lightning Mate manages your Lightning node so you don't have to babysit it.
@@ -21,6 +21,12 @@ description: >-
   Flip on the Autopilot and the node tunes its own fees, runs only profitable
   rebalances, and opens channels to top peers — all on recommended settings with
   safe caps and cooldowns.
+
+
+  Buy and sell channel liquidity on the Amboss Magma marketplace right inside the
+  app: purchase inbound, list your own offer, and let the Autopilot fulfil orders
+  — opening channels to buyers within your capital, channel-size and on-chain
+  reserve caps.
 
 
   Lightning Mate signs in with the per-app password Umbrel generates for it

--- a/lightningmate/umbrel-app.yml
+++ b/lightningmate/umbrel-app.yml
@@ -21,11 +21,7 @@ description: >-
   Flip on the Autopilot and the node tunes its own fees, runs only profitable
   rebalances, and opens channels to top peers — all on recommended settings with
   safe caps and cooldowns. Read-only by default; writes are opt-in.
-releaseNotes: >-
-  Rebalancing reworked, Thunderhub-style: a manual rebalance (pick source /
-  target / amount / max fee), profitability shown as guidance so you decide and
-  can run any candidate, adaptive amounts, readable failure reasons in the log,
-  and a more generous pathfinding timeout.
+releaseNotes: ""
 developer: opensourceminers.de
 website: https://opensourceminers.de
 dependencies:

--- a/lightningmate/umbrel-app.yml
+++ b/lightningmate/umbrel-app.yml
@@ -1,0 +1,41 @@
+# Official Umbrel App Store manifest (getumbrel/umbrel-apps).
+# Per the packaging guide: bare `lightningmate` id, gallery [], NO icon field —
+# the Umbrel team hosts the final icon + screenshots (provide them in the PR body).
+manifestVersion: 1
+id: lightningmate
+category: finance
+name: Lightning Mate
+version: "0.6.1"
+tagline: Profit-aware management & autopilot for your Lightning node
+description: >-
+  Lightning Mate manages your Lightning node so you don't have to babysit it.
+  It connects automatically to your Umbrel Lightning (LND) node.
+
+
+  See channels with live balance bars and source / sink / router roles, a full
+  Forwards routing report, and a Profit & Loss overview (routing revenue vs
+  channel-open and rebalancing costs). Get scored channel-peer suggestions from
+  the network graph and open channels in a click, plus a node health score.
+
+
+  Flip on the Autopilot and the node tunes its own fees, runs only profitable
+  rebalances, and opens channels to top peers — all on recommended settings with
+  safe caps and cooldowns. Read-only by default; writes are opt-in.
+releaseNotes: >-
+  Rebalancing reworked, Thunderhub-style: a manual rebalance (pick source /
+  target / amount / max fee), profitability shown as guidance so you decide and
+  can run any candidate, adaptive amounts, readable failure reasons in the log,
+  and a more generous pathfinding timeout.
+developer: opensourceminers.de
+website: https://opensourceminers.de
+dependencies:
+  - lightning
+repo: https://github.com/opensourceminers/lightningmate
+support: https://github.com/opensourceminers/lightningmate/issues
+port: 3742
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: opensourceminers
+submission: ""

--- a/lightningmate/umbrel-app.yml
+++ b/lightningmate/umbrel-app.yml
@@ -40,7 +40,13 @@ dependencies:
 repo: https://github.com/opensourceminers/lightningmate
 support: https://github.com/opensourceminers/lightningmate/issues
 port: 3742
-gallery: []
+gallery:
+  - 1.webp
+  - 2.webp
+  - 3.webp
+  - 4.webp
+  - 5.webp
+  - 6.webp
 path: ""
 defaultUsername: ""
 defaultPassword: ""

--- a/lightningmate/umbrel-app.yml
+++ b/lightningmate/umbrel-app.yml
@@ -5,7 +5,7 @@ manifestVersion: 1
 id: lightningmate
 category: finance
 name: Lightning Mate
-version: "0.6.1"
+version: "0.6.4"
 tagline: Profit-aware management & autopilot for your Lightning node
 description: >-
   Lightning Mate manages your Lightning node so you don't have to babysit it.
@@ -20,7 +20,12 @@ description: >-
 
   Flip on the Autopilot and the node tunes its own fees, runs only profitable
   rebalances, and opens channels to top peers — all on recommended settings with
-  safe caps and cooldowns. Read-only by default; writes are opt-in.
+  safe caps and cooldowns.
+
+
+  Lightning Mate signs in with the per-app password Umbrel generates for it
+  (shown when you open the app), so no other app on your server can read your
+  node or move your funds.
 releaseNotes: ""
 developer: opensourceminers.de
 website: https://opensourceminers.de
@@ -33,5 +38,6 @@ gallery: []
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+deterministicPassword: true
 submitter: opensourceminers
 submission: "https://github.com/getumbrel/umbrel-apps/pull/5783"


### PR DESCRIPTION
**Lightning Mate** — profit-aware management & autopilot for an LND node.

- **Source:** https://github.com/opensourceminers/lightningmate (MIT)
- **Image:** `ghcr.io/opensourceminers/lightningmate` (multi-arch amd64 + arm64, digest-pinned)
- **Dependencies:** `lightning` (LND) — auto-discovered, zero-config
- **Default credentials:** none (UI sits behind the `app_proxy` auth)
- **Host access:** none beyond the mounted LND data dir
- Runs as **uid 1000 (non-root)**; a one-shot `init` container fixes the data-dir owner so user settings persist across updates
- Uses the LND **admin macaroon** for fee / rebalance / channel writes (same as Ride The Lightning, ThunderHub, Lightning Terminal). The **autopilot stays OFF** until the user enables it, and every fund-moving action asks for confirmation. Comment out two env lines in the compose to run fully read-only.

### What it does
Channels with live balance bars and source / sink / router roles, a Forwards routing report, a Profit & Loss overview, a node health score, graph-based channel-peer suggestions with one-click open, a **Lightning + on-chain wallet** (send / receive), **profit-aware rebalancing** (manual + adaptive), and an **autopilot** that tunes fees, runs profitable rebalances and opens channels on safe defaults.

### Testing
Tested on **umbrelOS 1.7.3**: installs zero-config against the Lightning (LND) app, all tabs load, the read-only view works, the fee / rebalance / autopilot write paths were verified, and settings persist across an app update.

### Screenshots
![Overview](https://cdn.jsdelivr.net/gh/opensourceminers/umbrel-app-store@master/opensourceminers-lightningmate/gallery/1.png)
![Wallet](https://cdn.jsdelivr.net/gh/opensourceminers/umbrel-app-store@master/opensourceminers-lightningmate/gallery/2.png)
![Channels](https://cdn.jsdelivr.net/gh/opensourceminers/umbrel-app-store@master/opensourceminers-lightningmate/gallery/3.png)
![Routing](https://cdn.jsdelivr.net/gh/opensourceminers/umbrel-app-store@master/opensourceminers-lightningmate/gallery/4.png)
![Autopilot](https://cdn.jsdelivr.net/gh/opensourceminers/umbrel-app-store@master/opensourceminers-lightningmate/gallery/5.png)

### Icon
256×256 SVG, square corners: https://cdn.jsdelivr.net/gh/opensourceminers/umbrel-app-store@master/opensourceminers-lightningmate/icon.svg
