### PR TITLE
App Submission: Homey Self-Hosted Server

### DIFF
--- a/homey/docker-compose.yml
+++ b/homey/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.7"
+
+services:
+  web:
+    image: ghcr.io/athombv/homey-shs:latest@sha256:cb219df1aa5ff450d14f11b64f33760de9a304aa7a5ed049cff16e496d373955
+    network_mode: host
+    privileged: true
+    volumes:
+      - ${APP_DATA_DIR}/data:/homey/user

--- a/homey/docker-compose.yml
+++ b/homey/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/athombv/homey-shs:latest@sha256:cb219df1aa5ff450d14f11b64f33760de9a304aa7a5ed049cff16e496d373955
+    image: ghcr.io/athombv/homey-shs:346723f@sha256:cb219df1aa5ff450d14f11b64f33760de9a304aa7a5ed049cff16e496d373955
     network_mode: host
     privileged: true
     volumes:

--- a/homey/docker-compose.yml
+++ b/homey/docker-compose.yml
@@ -2,7 +2,8 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/athombv/homey-shs:346723f@sha256:cb219df1aa5ff450d14f11b64f33760de9a304aa7a5ed049cff16e496d373955
+    image: ghcr.io/athombv/homey-shs:12.12.0@sha256:78071283dc7d990853d94b7d6da71099931cfbf88411d2aea1d6cb43360ac676
+    restart: on-failure
     network_mode: host
     privileged: true
     volumes:

--- a/homey/umbrel-app.yml
+++ b/homey/umbrel-app.yml
@@ -38,5 +38,5 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: baukeposthuma
-submission: ""
+submission: "https://github.com/getumbrel/umbrel-apps/pull/5009"
 releaseNotes: ""

--- a/homey/umbrel-app.yml
+++ b/homey/umbrel-app.yml
@@ -1,0 +1,42 @@
+manifestVersion: 1
+id: homey
+category: automation
+name: Homey
+version: "12.11.0"
+tagline: Run Homey Self-Hosted Server on your Umbrel
+description: >-
+  Homey Self-Hosted Server is a powerful, open-source smart home automation platform that runs entirely on your Umbrel device. Control and automate your smart home devices locally with full privacy and reliability.
+
+
+  Features:
+
+  - Local control of your smart home devices
+
+  - Advanced automation flows and logic
+
+  - Support for Matter, Wi-Fi, Ethernet, and Cloud-connected devices
+
+  - Connect Zigbee, Z-Wave, Bluetooth, 433MHz, and IR devices via Homey Bridge
+
+  - Voice assistant integration with Alexa, Google Home, and Siri
+
+  - No cloud dependency for core functionality
+
+  - Complete privacy - your data stays on your device
+
+
+  Get started by opening the Homey app on your iOS or Android device, adding a 
+  new Homey, and selecting "Self-Hosted Server".
+developer: Athom B.V.
+website: https://homey.app
+dependencies: []
+repo: https://github.com/athombv/homey
+support: https://community.homey.app
+port: 4859
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: baukeposthuma
+submission: ""
+releaseNotes: ""

--- a/homey/umbrel-app.yml
+++ b/homey/umbrel-app.yml
@@ -2,27 +2,28 @@ manifestVersion: 1
 id: homey
 category: automation
 name: Homey
-version: "12.11.0"
+version: "12.12.0"
 tagline: Run Homey Self-Hosted Server on your Umbrel
 description: >-
-  Homey Self-Hosted Server is a powerful, open-source smart home automation platform that runs entirely on your Umbrel device. Control and automate your smart home devices locally with full privacy and reliability.
+  Homey Self-Hosted Server runs the Homey smart home engine on your own Umbrel, so your automations and device connections are handled on hardware you control instead of Homey's cloud.
+
+
+  You manage your home through the familiar Homey app and web app, which pair with the server running on your Umbrel. Note that initial setup, your Homey account, and some integrations (such as cloud-connected devices or a Homey Bridge) may still rely on Homey's apps and online services.
 
 
   Features:
-    - Local control of your smart home devices
-    - Advanced automation flows and logic
-    - Support for Matter, Wi-Fi, Ethernet, and Cloud-connected devices
+    - Run the Homey automation engine locally on your Umbrel
+    - Build advanced automation flows and logic
+    - Support for Matter, Wi-Fi, Ethernet, and cloud-connected devices
     - Connect Zigbee, Z-Wave, Bluetooth, 433MHz, and IR devices via Homey Bridge
     - Voice assistant integration with Alexa, Google Home, and Siri
-    - No cloud dependency for core functionality
-    - Complete privacy - your data stays on your device
 
 
   Get started by opening the Homey app on your iOS or Android device, adding a new Homey, and selecting "Self-Hosted Server".
 developer: Athom B.V.
 website: https://homey.app
 dependencies: []
-repo: https://github.com/athombv/homey
+repo: ""
 support: https://community.homey.app
 port: 4859
 gallery: []

--- a/homey/umbrel-app.yml
+++ b/homey/umbrel-app.yml
@@ -26,7 +26,10 @@ dependencies: []
 repo: ""
 support: https://community.homey.app
 port: 4859
-gallery: []
+gallery:
+  - 1.webp
+  - 2.webp
+  - 3.webp
 path: ""
 defaultUsername: ""
 defaultPassword: ""

--- a/homey/umbrel-app.yml
+++ b/homey/umbrel-app.yml
@@ -30,5 +30,5 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: baukeposthuma
-submission: "https://github.com/getumbrel/umbrel-apps/pull/5009"
+submission: "https://github.com/getumbrel/umbrel-apps/pull/5784"
 releaseNotes: ""

--- a/homey/umbrel-app.yml
+++ b/homey/umbrel-app.yml
@@ -9,24 +9,16 @@ description: >-
 
 
   Features:
-
-  - Local control of your smart home devices
-
-  - Advanced automation flows and logic
-
-  - Support for Matter, Wi-Fi, Ethernet, and Cloud-connected devices
-
-  - Connect Zigbee, Z-Wave, Bluetooth, 433MHz, and IR devices via Homey Bridge
-
-  - Voice assistant integration with Alexa, Google Home, and Siri
-
-  - No cloud dependency for core functionality
-
-  - Complete privacy - your data stays on your device
+    - Local control of your smart home devices
+    - Advanced automation flows and logic
+    - Support for Matter, Wi-Fi, Ethernet, and Cloud-connected devices
+    - Connect Zigbee, Z-Wave, Bluetooth, 433MHz, and IR devices via Homey Bridge
+    - Voice assistant integration with Alexa, Google Home, and Siri
+    - No cloud dependency for core functionality
+    - Complete privacy - your data stays on your device
 
 
-  Get started by opening the Homey app on your iOS or Android device, adding a 
-  new Homey, and selecting "Self-Hosted Server".
+  Get started by opening the Homey app on your iOS or Android device, adding a new Homey, and selecting "Self-Hosted Server".
 developer: Athom B.V.
 website: https://homey.app
 dependencies: []


### PR DESCRIPTION
# App Submission

### App name
Homey

### 256x256 SVG icon
![homey](https://github.com/user-attachments/assets/e525f6a2-7725-4923-bacf-a61731549a44)

### Gallery images
_Initial screenshots of the app running on umbrelOS. The Homey Self-Hosted Server exposes a web UI for activation and login; the full dashboard and device/flow control happen through the Homey mobile & web app once the server is paired._

**Activation screen**
![Homey Self-Hosted Server activation screen](https://raw.githubusercontent.com/baukeposthuma/umbrel-apps/homey-screenshots/homey/screenshots/01-setup.png)

**Login screen**
![Homey web app login screen](https://raw.githubusercontent.com/baukeposthuma/umbrel-apps/homey-screenshots/homey/screenshots/02-login.png)

I'm happy to provide additional dashboard screenshots or work with you on the final 1440x900 gallery assets.

### I have tested my app on:
- [x] umbrelOS on a Raspberry Pi
- [x] umbrelOS on an Umbrel Home
- [x] umbrelOS on Linux VM

---

This is a fresh submission following up on #5009, which was closed for inactivity. Thanks for the patience! I've addressed the review feedback from @al-lac:
- Reformatted the `description` features list into indented list items
- Added the trailing newline to `umbrel-app.yml`

…and included screenshots as requested.
