### PR TITLE
Add SINGULARITY Pool — zero-fee solo Bitcoin mining pool

### DIFF
--- a/singularity-pool/docker-compose.yml
+++ b/singularity-pool/docker-compose.yml
@@ -1,0 +1,47 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: singularity-pool_pool_1
+      APP_PORT: 3337
+      PROXY_AUTH_WHITELIST: "/api/state,/events,/api/logs,/api/diag,/widget-api/*"
+
+  pool:
+    # Pre-built, multi-arch (amd64+arm64), pinned by manifest-list digest — required
+    # by the official App Store (no build from source). Image is public on GHCR.
+    image: ghcr.io/blackhole-axe/singularity-pool:1.7.0@sha256:df628f69a02721765f611a9aba0317f255cc3b4dc07e63cf0f245487c6ab95e1
+    restart: on-failure
+    stop_grace_period: 30s
+    ports:
+      - "2038:2038" # Stratum — point your ASIC miners here
+    volumes:
+      - "${APP_DATA_DIR}/data:/data"
+    environment:
+      # Bitcoin node — injected automatically by Umbrel (dependencies: [bitcoin])
+      RPC_URL: http://${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_RPC_PORT}/
+      RPC_USER: ${APP_BITCOIN_RPC_USER}
+      RPC_PASS: ${APP_BITCOIN_RPC_PASS}
+      ZMQ_BLOCKS: tcp://${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_ZMQ_HASHBLOCK_PORT}
+      BITCOIN_NETWORK: mainnet
+      # Per-miner mode: no default wallet. Every miner is paid to the address it
+      # uses as its Stratum username; address-less miners are rejected.
+      PAYOUT_ADDRESS: ""
+      COINBASE_TAG: "SINGULARITY on Umbrel"
+      STRATUM_PORT: "2038"
+      STRATUM_BIND: "0.0.0.0"
+      DASHBOARD_PORT: "3337"
+      DASHBOARD_BIND: "0.0.0.0"
+      START_DIFFICULTY: "1024"
+      MIN_DIFFICULTY: "1024"
+      MAX_DIFFICULTY: "0"
+      TARGET_SHARE_SECS: "8"
+      RETARGET_SECS: "30"
+      VERSION_MASK: "1fffe000"
+      TEMPLATE_REFRESH_MS: "30000"
+      POLL_FALLBACK_MS: "250"
+      INSTANT_EMPTY_JOB: "true"
+      STALE_GRACE_MS: "3000"
+      WORKER_IDLE_SECS: "300"
+      DATA_DIR: "/data"
+      NODE_ENV: "production"

--- a/singularity-pool/umbrel-app.yml
+++ b/singularity-pool/umbrel-app.yml
@@ -34,7 +34,7 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: BlackHole-Axe
-submission: "https://github.com/getumbrel/umbrel-apps/pull/5790"
+submission: "https://github.com/getumbrel/umbrel-apps/pull/5791"
 widgets:
   - id: "stats"
     type: "four-stats"

--- a/singularity-pool/umbrel-app.yml
+++ b/singularity-pool/umbrel-app.yml
@@ -34,7 +34,7 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: BlackHole-Axe
-submission: ""
+submission: "https://github.com/getumbrel/umbrel-apps/pull/5790"
 widgets:
   - id: "stats"
     type: "four-stats"

--- a/singularity-pool/umbrel-app.yml
+++ b/singularity-pool/umbrel-app.yml
@@ -1,0 +1,55 @@
+manifestVersion: 1
+id: singularity-pool
+category: bitcoin
+name: SINGULARITY Pool
+version: "1.7.0"
+tagline: Zero-fee solo Bitcoin mining pool
+description: >-
+  Self-hosted solo Bitcoin mining pool. Connects automatically to your Bitcoin
+  Core node — no manual RPC or ZMQ configuration required.
+
+
+  Zero fees: if you find a block, 100% of the reward goes to your wallet. Each
+  miner uses its own Bitcoin address as the Stratum username, so whoever finds
+  the block is paid directly — the pool never holds a default wallet.
+
+
+  Connect your ASICs:
+
+  - URL: stratum+tcp://umbrel.local:2038
+
+  - Worker / Username: your Bitcoin address (e.g. bc1q...), optionally ADDRESS.workername
+
+  - Password: anything (e.g. x)
+releaseNotes: ""
+developer: BlackHole-Axe
+website: https://github.com/BlackHole-Axe/singularity-umbrel
+dependencies:
+  - bitcoin
+repo: https://github.com/BlackHole-Axe/singularity-umbrel
+support: https://github.com/BlackHole-Axe/singularity-umbrel/issues
+port: 3337
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: BlackHole-Axe
+submission: ""
+widgets:
+  - id: "stats"
+    type: "four-stats"
+    refresh: "5s"
+    endpoint: "pool:3337/widget-api/stats"
+    link: ""
+    example:
+      type: "four-stats"
+      link: ""
+      items:
+        - title: "Hash Rate"
+          text: "719 TH/s"
+        - title: "Miners"
+          text: "17"
+        - title: "Blocks Found"
+          text: "0"
+        - title: "Best Share"
+          text: "2.07G"


### PR DESCRIPTION
## SINGULARITY Pool

Zero-fee **solo** Bitcoin mining pool. Each miner uses its own Bitcoin address
as the Stratum username, so 100% of any block reward is paid straight to the
finder's wallet — the pool holds no default wallet (per-miner mode).

- **App ID:** `singularity-pool`
- **Version:** 1.7.0
- **Upstream / source:** https://github.com/BlackHole-Axe/singularity-umbrel
- **Depends on:** Bitcoin (RPC + ZMQ auto-wired)

### Image (pre-built, public, multi-arch)
`ghcr.io/blackhole-axe/singularity-pool:1.7.0@sha256:df628f69a02721765f611a9aba0317f255cc3b4dc07e63cf0f245487c6ab95e1`
- Platforms: **linux/amd64 + linux/arm64** ✅
- Public on GHCR ✅

### Testing performed
- Installs cleanly and opens to the dashboard
- Home-screen **four-stats widget** works (Hash Rate / Miners / Blocks / Best Share)
- Connects automatically to the Bitcoin node (RPC + ZMQ), consensus self-audit passes
- Survives app restart (data persists under `${APP_DATA_DIR}/data`)
- Per-miner payouts verified: each miner is paid to the address in its Stratum
  username; address-less miners are rejected (no funds ever go to a default wallet)

### Notes
- Stratum on `2038` (raw TCP, non-HTTP); dashboard via app_proxy on `3337`
- `gallery: []` and no `icon` field — icon + screenshots attached below for the team