### PR TITLE
Update Tailscale to enable host tailnet routing

### DIFF
--- a/tailscale/docker-compose.yml
+++ b/tailscale/docker-compose.yml
@@ -2,10 +2,20 @@ version: "3.7"
 
 services:
   web:
-    network_mode: "host" # TODO: We can remove this later with some iptables magic
+    # Host networking plus kernel TUN mode lets tailscaled create the host
+    # tailscale0 interface and routes. umbrelOS host services, such as CIFS
+    # mounts used by network backups, need those routes to reach tailnet peers.
+    network_mode: "host"
     image: tailscale/tailscale:v1.98.3@sha256:854b77123b9536adae2e97f5a5fdb1790ed03438b911ab7f07780155e0af6ce2
     restart: on-failure
     stop_grace_period: 1m
-    command: "sh -c 'tailscale web --listen 0.0.0.0:8240 & exec tailscaled --tun=userspace-networking'"
+    # Required for tailscaled to manage the host TUN interface and route table.
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    # Keep tailscaled in kernel TUN mode so host routes are available.
+    command: "sh -c 'tailscale web --listen 0.0.0.0:8240 & exec tailscaled'"
     volumes:
       - ${APP_DATA_DIR}/data:/var/lib

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: tailscale
 category: networking
 name: Tailscale
-version: "v1.98.3"
+version: "v1.98.3-1"
 tagline: Zero config VPN to access your Umbrel from anywhere
 description: >-
   Tailscale is zero config VPN that creates a secure network between
@@ -30,14 +30,10 @@ torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/1248
 releaseNotes: >-
-  Tailscale v1.98.3 updates the Tailscale container with Linux networking reliability fixes, MagicDNS improvements, and dependency updates.
+  This update lets umbrelOS use the tailnet routes created by the Tailscale app.
 
 
-  Highlights include:
-    - Fixed inconsistent netfilter rule application after netfilter mode changes on Linux
-    - Fixed a regression that could prevent MagicDNS from resolving tailnet hostnames after a network change
-    - Updated Go/runtime dependencies and container libraries
-    - Improved Linux health checks for subnet-router and exit-node forwarding configuration
+  Good news for umbrelOS Backups: you can now back up one Umbrel to another over Tailscale. When adding the destination, use its Tailscale IP address shown in the Tailscale app; Tailscale device names are not supported.
 
 
-  Full release notes can be found at https://tailscale.com/changelog#2026-05-21.
+  The bundled Tailscale version remains v1.98.3.


### PR DESCRIPTION
This gets Tailscale out of userspace networking so it can create real host-level tailscale0 routes. The big win is that umbrelOS itself can now reach tailnet IPs, which makes Backups to another Umbrel over Tailscale work when using the destination’s Tailscale IP.

Security-wise, this does mean giving the Tailscale container NET_ADMIN, NET_RAW, and /dev/net/tun, but that’s expected for a VPN app that needs to manage a host TUN interface/routes. Other VPN apps in the store already use this same kind of access.

cc @al-lac who originally ran across this issue when trying remote backups