### PR TITLE
Bump HermitStash to 1.13.0

### DIFF
--- a/hermitstash/docker-compose.yml
+++ b/hermitstash/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/dotcoocoo/hermitstash:1.12.11@sha256:1c0c7b52e6a09eb600f9fc0dca683d273ebe3ac3c523d756daad7b270eefb843
+    image: ghcr.io/dotcoocoo/hermitstash:1.13.0@sha256:e36518ec236d7576f835ec804723626bf3b009125e8e14d4683911a4d414fe98
     user: "1000:1000"
     init: true
     restart: on-failure

--- a/hermitstash/umbrel-app.yml
+++ b/hermitstash/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: hermitstash
 category: files
 name: HermitStash
-version: "1.12.11"
+version: "1.13.0"
 tagline: Post-quantum encrypted self-hosted file sharing
 description: >-
   HermitStash is a self-hosted file upload server with post-quantum encryption. Every file and database field is sealed with an ML-KEM-1024 + ECDH P-384 hybrid envelope and XChaCha20-Poly1305 before touching disk; passwords use Argon2id. Nothing is stored in plaintext, including database fields the operator never thinks of as sensitive.
@@ -14,7 +14,7 @@ description: >-
   The admin panel covers users, uploads, webhooks, API keys, branding, and storage backends — local disk by default, or any S3-compatible bucket (MinIO, Cloudflare R2, Backblaze B2) for off-device archives. Retry-safe writes via the standard Idempotency-Key header. RFC 9457 problem-details on every API error response.
 
 
-  On supported browsers the TLS handshake negotiates X25519MLKEM768 or SecP384r1MLKEM1024 for quantum-resistant key exchange — the wire is end-to-end post-quantum, not just the data at rest.
+  Files and database fields are sealed with post-quantum encryption at rest no matter how you reach the app. When it is served over HTTPS — a custom domain, or remote access over Tor or Tailscale — the TLS handshake also negotiates a post-quantum key exchange (X25519MLKEM768 or SecP384r1MLKEM1024), so the connection itself is quantum-resistant; over a plain local-network address the at-rest protection still applies.
 developer: dotCooCoo
 website: https://hermitstash.com
 repo: https://github.com/dotCooCoo/hermitstash
@@ -31,11 +31,28 @@ defaultPassword: ""
 submitter: dotCooCoo
 submission: https://github.com/getumbrel/umbrel-apps/pull/5378
 releaseNotes: >-
-  Adds security hardening across file sharing and account flows, including verified email changes before anonymous uploads can be claimed, rate-limited and memory-bounded public ZIP downloads, and admin APIs that no longer expose file keys or bundle secrets.
+  This release rolls up the security and reliability improvements from versions 1.12.12 through 1.13.0.
 
 
-  Improves backup, restore, and vault safety with checksum-verified restores, rollback of certificate material on restore failure, rotation-safe database encryption, and fixes for permanent backup/restore locks.
+  Sign-in and accounts:
+    - Two-factor authentication is now required on Google and passkey sign-in, not only password login, and a code-entry page completes the flow.
+    - Email changes are verified before they take effect: your current address stays your login identity until you confirm the new one, so a mistyped address can no longer lock you out.
+    - A captured passkey assertion and your two-factor backup codes are now strictly single-use, even when requests arrive at the same time.
 
 
-  Strengthens sessions, lockouts, quotas, token checks, webhook handling, and sync enrollment while fixing admin reset/search, stash counters, and webhook delivery/history behavior.
+  Encryption and key safety:
+    - Vault key rotation can no longer leave a file stranded under a discarded key, and a lost or mismatched vault key no longer overwrites the database key — the server refuses to start instead, so your data stays recoverable.
+    - The file paths of skipped uploads are now encrypted at rest like every other field, and values inserted into HTML email templates are escaped.
+    - The first-response session-key exchange now requires a verified client certificate.
+
+
+  Sync, uploads, and access control:
+    - Revoking a sync API key immediately disconnects its live connection, and the sync channel now enforces the IP blocklist and per-IP rate limits.
+    - API-key scopes are enforced on read and mutating routes, so a key issued for a narrow purpose can no longer act with full administrator authority.
+    - Uploads that fail content validation are rejected rather than accepted, and the global and per-account storage quotas now hold under concurrent uploads.
+
+
+  Reliability:
+    - Scheduled backups run at the configured time of day and survive restarts, and automatic client-certificate renewal no longer locks out an offline sync client.
+    - Large sync catch-up requests are paged, and corrupted stored data now fails with a clear error instead of crashing.
 dependencies: []


### PR DESCRIPTION
Updates HermitStash from 1.12.11 to 1.13.0.

**Image:** pinned to the multi-arch (linux/amd64 + linux/arm64) OCI index digest `ghcr.io/dotcoocoo/hermitstash:1.13.0@sha256:e36518ec236d7576f835ec804723626bf3b009125e8e14d4683911a4d414fe98`.

### What changed (1.12.12 → 1.13.0)

**Sign-in and accounts**
- Two-factor authentication is now required on Google and passkey sign-in, not only password login, and a code-entry page completes the flow.
- Email changes are verified before they take effect: the current address stays the login identity until the new one is confirmed, so a mistyped address can't lock the user out.
- Passkey assertions and two-factor backup codes are strictly single-use, even when requests arrive at the same time.

**Encryption and key safety**
- Vault key rotation can no longer strand a file under a discarded key, and a lost or mismatched vault key no longer overwrites the database key — the server refuses to start instead, keeping data recoverable.
- The file paths of skipped uploads are now encrypted at rest like every other field, and values inserted into HTML email templates are escaped.
- The first-response session-key exchange requires a verified client certificate.

**Sync, uploads, and access control**
- Revoking a sync API key immediately disconnects its live connection, and the sync channel enforces the IP blocklist and per-IP rate limits.
- API-key scopes are enforced on read and mutating routes, so a narrowly-scoped key can't act with full administrator authority.
- Uploads that fail content validation are rejected, and the global and per-account storage quotas hold under concurrent uploads.

**Reliability**
- Scheduled backups run at the configured time of day and survive restarts; automatic client-certificate renewal no longer locks out an offline sync client.
- Large sync catch-up requests are paged, and corrupted stored data fails with a clear error instead of crashing.

### Description correction

The app `description` previously stated the wire is "end-to-end post-quantum," which isn't accurate on Umbrel's plain-HTTP local-network origin (there's no TLS on that hop). The text now scopes the post-quantum TLS key exchange to HTTPS access (custom domain / Tor / Tailscale) while noting that the at-rest encryption applies in all cases.

`releaseNotes` in `umbrel-app.yml` carries the same summary for the App Store update card.