### PR TITLE
Update Tailscale to v1.98.3-2

### DIFF
--- a/tailscale/hooks/pre-start
+++ b/tailscale/hooks/pre-start
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Kernel TUN subnet routing forwards packets from tailscale0 to the LAN in the
+# host network namespace. These runtime sysctls are required for Linux subnet
+# routing and are safe to apply repeatedly.
+set_proc_sys() {
+  local path="$1"
+  local value="$2"
+
+  if [[ ! -e "$path" ]]; then
+    echo "tailscale pre-start: warning: $path does not exist; skipping" >&2
+    return 0
+  fi
+
+  printf '%s\n' "$value" > "$path"
+  echo "tailscale pre-start: set $path=$value"
+}
+
+set_proc_sys /proc/sys/net/ipv4/ip_forward 1
+set_proc_sys /proc/sys/net/ipv6/conf/all/forwarding 1
+set_proc_sys /proc/sys/net/ipv4/conf/all/src_valid_mark 1

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -1,8 +1,8 @@
-manifestVersion: 1
+manifestVersion: 1.1
 id: tailscale
 category: networking
 name: Tailscale
-version: "v1.98.3-1"
+version: "v1.98.3-2"
 tagline: Zero config VPN to access your Umbrel from anywhere
 description: >-
   Tailscale is zero config VPN that creates a secure network between
@@ -30,10 +30,10 @@ torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/1248
 releaseNotes: >-
-  This update lets umbrelOS use the tailnet routes created by the Tailscale app.
+  Fixes Tailscale subnet routing after the recent host networking update.
 
 
-  Good news for umbrelOS Backups: you can now back up one Umbrel to another over Tailscale. When adding the destination, use its Tailscale IP address shown in the Tailscale app; Tailscale device names are not supported.
+  The previous update moved Tailscale to kernel TUN mode so umbrelOS itself can use tailnet routes, including for Umbrel-to-Umbrel backups. This update enables the Linux forwarding settings needed for approved subnet routes to pass traffic from remote Tailscale clients to devices on your LAN.
 
 
   The bundled Tailscale version remains v1.98.3.


### PR DESCRIPTION
## App name
Tailscale

## Tested on
- tmp clone of `getumbrel/umbrel-apps` on amd64
- `bash -n tailscale/hooks/pre-start`
- parsed `tailscale/umbrel-app.yml` and `tailscale/docker-compose.yml` with PyYAML
- `APP_DATA_DIR=/tmp/tailscale-app-data docker compose -f tailscale/docker-compose.yml config --quiet`
- `git diff --check`
- ran the new `pre-start` hook twice inside an isolated privileged Docker container and verified it sets `net.ipv4.ip_forward`, `net.ipv6.conf.all.forwarding`, and `net.ipv4.conf.all.src_valid_mark` to `1`
- verified Docker rejects `net.ipv4.ip_forward` as a container `sysctl` with `network_mode: host`, so this needs to run from a host hook instead of Compose

## Future / update notes
- bumps Tailscale from `v1.98.3-1` to `v1.98.3-2`
- adds an executable `pre-start` hook that enables the Linux forwarding settings required for kernel TUN subnet routing
- keeps the bundled Tailscale image at `v1.98.3@sha256:854b77123b9536adae2e97f5a5fdb1790ed03438b911ab7f07780155e0af6ce2`
- keeps the host tailnet routing behavior added in #5793 for Umbrel-to-Umbrel backups
- no data migration
