### PR TITLE
pearcircle-seeder: update to 1.0.18

### DIFF
--- a/pearcircle-seeder/docker-compose.yml
+++ b/pearcircle-seeder/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8730
 
   app:
-    image: ghcr.io/peerloomllc/pearcircle-seeder:1.0.17@sha256:305485b61dea25507b245066b9d8fd8405b0841132ed8a3b9d3b6e6991198f20
+    image: ghcr.io/peerloomllc/pearcircle-seeder:1.0.18@sha256:b1cb7ce24acbc6117980bd27d9d63f663e68d95a8fd68bbd071ba507e00ce7b2
     restart: on-failure
     stop_grace_period: 1m
     security_opt:

--- a/pearcircle-seeder/umbrel-app.yml
+++ b/pearcircle-seeder/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: pearcircle-seeder
 category: networking
 name: PearCircle Seeder
-version: "1.0.17"
+version: "1.0.18"
 tagline: Keep your PearCircle circles online 24/7
 description: >-
   Run a blind seeder for your PearCircle circles on your Umbrel so their


### PR DESCRIPTION
Bump **PearCircle Seeder** to `1.0.18`, pinned to the multi-arch (amd64 + arm64) manifest-list digest `sha256:b1cb7ce24acbc6117980bd27d9d63f663e68d95a8fd68bbd071ba507e00ce7b2`.

Image: `ghcr.io/peerloomllc/pearcircle-seeder:1.0.18` (public).

Changes since 1.0.17: adds a Support/donation panel to the seeder dashboard; no config or behavior changes for the app itself (same port, env, and volume).

`npm run lint:apps` passes (with the previously-justified `no-new-privileges` warning).