### PR TITLE
Update BOLT12 Pay to v0.2.114

### DIFF
--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.2.113@sha256:3b4359cc688e6bc768526070d6d039f3f43c44081c924b9adb5e7ebf2d680197
+    image: alex71btc/bolt12-pay:0.2.114@sha256:e971d1457faacfd92f5e9e8c71cf4f3f4fc7e76070a2f2801f3e8ebb3e7a07ab
     restart: on-failure
     depends_on:
       - lndk

--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.2.111@sha256:7d856fa4a70bf4988e4d32640731261c816b67d8796f5bc551d7bf7668429130
+    image: alex71btc/bolt12-pay:0.2.113@sha256:3b4359cc688e6bc768526070d6d039f3f43c44081c924b9adb5e7ebf2d680197
     restart: on-failure
     depends_on:
       - lndk

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.113
+version: 0.2.114
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
@@ -157,6 +157,7 @@ releaseNotes: |
   - Automatically retries transient LNDK TLS connection failures
   - Prevents occasional first-attempt offer creation errors observed on some Umbrel systems
   - Adds a default routing fee limit for improved compatibility with GetAlby, Wallet of Satoshi and other Lightning Address providers
+  - Fixed LNURL string and QR-code payments failing with "CSRF Validation failed" after login 
 
   Includes all features from v0.2.108:
 

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.111
+version: 0.2.113
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
@@ -125,7 +125,7 @@ repo: https://github.com/Alex71btc/lndk-pay
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
 
-  Native Onion Messaging Release
+  Bugfix Release for the initial Native Onion Messaging Release
 
    - Added support for LND v0.21 native onion messaging
    - Removed dependency on custom-message transport when using LND v0.21
@@ -156,6 +156,7 @@ releaseNotes: |
   - Improved reliability of BOLT12 offer creation
   - Automatically retries transient LNDK TLS connection failures
   - Prevents occasional first-attempt offer creation errors observed on some Umbrel systems
+  - Adds a default routing fee limit for improved compatibility with GetAlby, Wallet of Satoshi and other Lightning Address providers
 
   Includes all features from v0.2.108:
 


### PR DESCRIPTION
This follow-up updates BOLT12 Pay to v0.2.113.

It fixes Lightning Address, LNURL and BOLT11 payments on LND 0.21 when using the RouterRPC payment endpoint.

During testing on Umbrel with LND 0.21.1, some destinations failed with:

FAILURE_REASON_NO_ROUTE

The root cause was that RouterRPC may fail route finding when no fee limit is provided. This release applies a default fee limit only when using the LND 0.21 RouterRPC payment endpoint. The legacy LND 0.20 payment endpoint is left unchanged to preserve backwards compatibility.

Verified successfully against:

* Umbrel + LND 0.21.1
* StartOS + LND 0.20.1
* BOLT11 invoices
* LNURL payments
* Lightning Addresses
* Wallet of Satoshi
* GetAlby
* self-hosted LNURL endpoints
