### PR TITLE
lightningmate: update to 0.6.23

### DIFF
--- a/lightningmate/docker-compose.yml
+++ b/lightningmate/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3001
 
   web:
-    image: ghcr.io/opensourceminers/lightningmate:v0.6.10@sha256:199a9df7855714d3b2fe2bc011ebdda88bd58fee2653f283111b35094ca61c1a
+    image: ghcr.io/opensourceminers/lightningmate:v0.6.23@sha256:72eb2b86a42088298db520deb383fb1a4f7ef557907a134f99fff33048d12a97
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -39,3 +39,8 @@ services:
       # comment these two lines out.
       LM_ENABLE_WRITE: "true"
       LND_WRITE_MACAROON_PATH: "/lnd/data/chain/bitcoin/$APP_BITCOIN_NETWORK/admin.macaroon"
+      # Service fee on completed Magma liquidity sales: 1% (100 bps) of the earned
+      # lease fee, paid to the address below. Shown in the Sell tab. Set to "0" to
+      # disable. Best-effort + skipped on the seller's own node.
+      LM_SELL_FEE_BPS: "100"
+      LM_SELL_FEE_ADDRESS: "lightningmate@btcpay.opensourceminers.de"

--- a/lightningmate/umbrel-app.yml
+++ b/lightningmate/umbrel-app.yml
@@ -5,7 +5,7 @@ manifestVersion: 1
 id: lightningmate
 category: finance
 name: Lightning Mate
-version: "0.6.10"
+version: "0.6.23"
 tagline: Profit-aware management & autopilot for your Lightning node
 description: >-
   Lightning Mate manages your Lightning node so you don't have to babysit it.
@@ -32,7 +32,22 @@ description: >-
   Lightning Mate signs in with the per-app password Umbrel generates for it
   (shown when you open the app), so no other app on your server can read your
   node or move your funds.
-releaseNotes: ""
+releaseNotes: |-
+  A major upgrade — the Autopilot is now profit-first, with one-click strategies
+  (Maximize routing / Magma leasing / Balanced):
+
+  - New fee engine: role-aware dynamic fees with profit floors, so a channel never
+    routes below its own refill cost — and it learns how each peer's flow responds
+    to fee changes.
+  - Profit-gated rebalancing: only runs rebalances that pay for themselves, with
+    full cost accounting.
+  - Amboss Magma, built in: buy inbound liquidity, sell your own liquidity with
+    adaptive auto-pricing, and let the Autopilot fulfil orders automatically within
+    your capital, channel-size and on-chain reserve caps.
+  - Smarter analytics: a Profit & Loss overview, a full Forwards report, and a
+    "Did the Autopilot pay off?" outcomes view.
+  - Channel peer + close suggestions from the network graph, an on-chain + Lightning
+    wallet, and one-click channel backup (SCB) export.
 developer: opensourceminers.de
 website: https://opensourceminers.de
 dependencies:


### PR DESCRIPTION
Updates **Lightning Mate** from `0.6.10` to `0.6.23`.

### What changed
The Autopilot is now profit-first, with one-click strategies (Maximize routing / Magma leasing / Balanced):

- **New fee engine** — role-aware dynamic fees with profit floors (a channel never routes below its own refill cost) and learned per-peer fee elasticity.
- **Profit-gated rebalancing** — only runs rebalances that pay for themselves, with full cost accounting.
- **Amboss Magma, built in** — buy inbound liquidity, sell your own liquidity with adaptive auto-pricing, and optional Autopilot order fulfilment within capital, channel-size and on-chain reserve caps.
- **Analytics** — Profit & Loss overview, a full Forwards report, and a "Did the Autopilot pay off?" outcomes view.
- **More** — channel peer + close suggestions from the network graph, an on-chain + Lightning wallet, and one-click channel backup (SCB) export.

### Packaging
- Multi-arch image (`linux/amd64` + `linux/arm64`), public on GHCR, pinned by digest:
  `ghcr.io/opensourceminers/lightningmate:v0.6.23@sha256:72eb2b86a42088298db520deb383fb1a4f7ef557907a134f99fff33048d12a97`
- Open source: https://github.com/opensourceminers/lightningmate
- No changes to `id`, `port`, gallery or app structure. Writes stay gated behind the admin macaroon; the Autopilot is off by default and every fund-moving action asks for confirmation.
