### PR TITLE
lightningmate: update to 0.6.23

### DIFF
--- a/lightningmate/docker-compose.yml
+++ b/lightningmate/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3001
 
   web:
-    image: ghcr.io/opensourceminers/lightningmate:v0.6.10@sha256:199a9df7855714d3b2fe2bc011ebdda88bd58fee2653f283111b35094ca61c1a
+    image: ghcr.io/opensourceminers/lightningmate:v0.6.23@sha256:72eb2b86a42088298db520deb383fb1a4f7ef557907a134f99fff33048d12a97
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -39,3 +39,5 @@ services:
       # comment these two lines out.
       LM_ENABLE_WRITE: "true"
       LND_WRITE_MACAROON_PATH: "/lnd/data/chain/bitcoin/$APP_BITCOIN_NETWORK/admin.macaroon"
+      LM_SELL_FEE_BPS: "100"
+      LM_SELL_FEE_ADDRESS: "lightningmate@btcpay.opensourceminers.de"

--- a/lightningmate/umbrel-app.yml
+++ b/lightningmate/umbrel-app.yml
@@ -5,7 +5,7 @@ manifestVersion: 1
 id: lightningmate
 category: finance
 name: Lightning Mate
-version: "0.6.10"
+version: "0.6.23"
 tagline: Profit-aware management & autopilot for your Lightning node
 description: >-
   Lightning Mate manages your Lightning node so you don't have to babysit it.
@@ -18,7 +18,7 @@ description: >-
   the network graph and open channels in a click, plus a node health score.
 
 
-  Flip on the Autopilot and the node tunes its own fees, runs only profitable
+  Flip on the Autopilot and the node tunes its own pricing, runs only profitable
   rebalances, and opens channels to top peers — all on recommended settings with
   safe caps and cooldowns.
 
@@ -32,7 +32,35 @@ description: >-
   Lightning Mate signs in with the per-app password Umbrel generates for it
   (shown when you open the app), so no other app on your server can read your
   node or move your funds.
-releaseNotes: ""
+releaseNotes: |-
+  A huge upgrade since 0.6.10 — the Autopilot is now fully profit-first, with
+  one-click strategies (Maximize routing / Magma leasing / Balanced).
+
+  Pricing & routing
+  - Reworked pricing engine: role-aware dynamic channel pricing (source / sink /
+    router) with profit floors, so a channel never routes below its own refill cost.
+  - It learns: tracks how each peer's flow reacts to price changes and adapts.
+
+  Rebalancing
+  - Profit-gated — only runs moves that pay for themselves, with full cost
+    accounting and per-channel cooldowns.
+  - Cheapest-route decisioning + a shared on-chain capital budget across the
+    autopilots so they never fight over the same coins.
+
+  Amboss Magma (buy & sell liquidity)
+  - Sell with adaptive auto-pricing (undercut / market / premium / auto) and a live
+    on-chain cost floor; auto-list freed capital.
+  - Optional Autopilot fulfilment — opens channels to buyers within your capital,
+    channel-size and on-chain reserve caps; fast (~3 min) order poll.
+  - Buy inbound liquidity in one click.
+
+  Analytics & tools
+  - Profit & Loss overview, a full Forwards report, and a "Did the Autopilot pay
+    off?" outcomes view.
+  - Channel peer + close suggestions, node health score, on-chain + Lightning
+    wallet, and one-click channel backup (SCB) export.
+
+  Polished dark UI throughout.
 developer: opensourceminers.de
 website: https://opensourceminers.de
 dependencies:


### PR DESCRIPTION
Updates **Lightning Mate** from `0.6.10` to `0.6.23` — a large upgrade.

### Highlights
The Autopilot is now fully profit-first, with one-click strategies (Maximize routing / Magma leasing / Balanced):

- **Reworked pricing engine** — role-aware dynamic channel pricing (source / sink / router) with profit floors, so a channel never routes below its own refill cost, and it learns how each peer's flow reacts to price changes.
- **Profit-gated rebalancing** — only runs moves that pay for themselves, with full cost accounting, cheapest-route decisioning and a shared on-chain capital budget.
- **Amboss Magma, built in** — buy inbound liquidity, sell your own with adaptive auto-pricing and a live on-chain cost floor, and optional Autopilot order fulfilment within capital / channel-size / reserve caps.
- **Analytics** — Profit & Loss overview, a full Forwards report, and a "Did the Autopilot pay off?" outcomes view.
- **More** — channel peer + close suggestions, node health score, an on-chain + Lightning wallet, and one-click channel backup (SCB) export. Polished dark UI throughout.

### Packaging
- Multi-arch image (`linux/amd64` + `linux/arm64`), public on GHCR, pinned by digest:
  `ghcr.io/opensourceminers/lightningmate:v0.6.23@sha256:72eb2b86a42088298db520deb383fb1a4f7ef557907a134f99fff33048d12a97`
- Open source: https://github.com/opensourceminers/lightningmate
- No changes to `id`, `port`, gallery or app structure. Writes stay gated behind the admin macaroon; the Autopilot is off by default and every fund-moving action asks for confirmation.
