### PR TITLE
Update hashrate-autopilot to v1.15.1

### DIFF
--- a/hashrate-autopilot/docker-compose.yml
+++ b/hashrate-autopilot/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3010
 
   web:
-    image: ghcr.io/rdouma/hashrate-autopilot:1.15.0@sha256:bcc72c2b8f17207e3ece7e9ab0ba9f7da782dd9685194c372eae666c1dae6a50
+    image: ghcr.io/rdouma/hashrate-autopilot:1.15.1@sha256:b2c9f7ea947a387dc89b3d01869b7d238628976eee8a6e5d760aca2d4bb1d68b
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/hashrate-autopilot/umbrel-app.yml
+++ b/hashrate-autopilot/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: hashrate-autopilot
 category: bitcoin
 name: Hashrate Autopilot
-version: "1.15.0"
+version: "1.15.1"
 tagline: Autopilot for renting hashrate to mine on Ocean Mining
 
 description: >-
@@ -71,19 +71,16 @@ defaultPassword: ""
 submitter: Remco Douma
 submission: https://github.com/getumbrel/umbrel-apps/pull/5685
 releaseNotes: >-
-  v1.15.0 - aviator branding, bid-vs-hashprice tile, BIP-110 block explorers, not-hashing detection, stale-bid self-heal.
+  v1.15.1 - patch release: fixes and polish, no new headline features.
 
 
-  New: a stats-bar tile shows your bid as a percentage of Ocean's break-even hashprice with a state-aware caption that tracks cheap-mode entry. Mempool.guide - a mempool.space fork that surfaces BIP-110 miner signaling - is the new default block explorer for fresh installs, with mempool.kilombino.com added as a second BIP-110-aware preset. The app's identity is now a stylized 1940s aviator: favicon, top-bar badge, and Umbrel app icon.
+  Price-chart fixes: the safety-ceiling line is relabeled from "max bid" to "effective cap", and the "max premium over hashprice" knob is now recorded per tick (and backfilled for older history), so changing it moves the line from that point forward instead of rewriting your whole past.
 
 
-  Improvements & fixes: a Bitaxe / AxeOS miner that is reachable but has stopped hashing (overheat_mode, NerdQAxe shutdown, impossible hashrate-per-watt after a stall) is now excluded from the fleet tile and badged "reboot needed". Stale local bids deleted at Braiins out-of-band self-heal each tick - no more hand-editing the database. False giant "bid paused" idle bands, the History "jump to event" beacon in Firefox / Safari, and a year-long browser cache pinning index.html are all fixed. Daemon-offline gaps now count as downtime in the uptime tile and bid-coverage math.
-
-
-  Safe to upgrade from any 1.14.x release.
+  Other fixes: invalid Bitcoin payout addresses are now rejected at Config and in the first-run wizard, so a typo can't silently credit earnings to nobody. The "Per Day" P&L card no longer sticks on "refreshing...". DATUM stats-API errors now tell you whether the API is behind an auth proxy or its port moved, instead of a cryptic parse error. Electrum host/port help points you to your server's own connection page. The IP-change marker tooltip shows how long ago the address changed. On mobile, the "add tile" control no longer overlaps the time-range buttons, and block-explorer presets set both the block and transaction URL in one click. Ocean payout wording corrected throughout - payouts arrive as batched sweep transactions, not coinbase-direct.
 
 
   Migrating from the community-store version (rdouma-hashrate-autopilot)? One-time five-minute guide: https://github.com/rdouma/hashrate-autopilot/blob/main/docs/migrating-from-community-store.md
 
 
-  Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.15.0
+  Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.15.1


### PR DESCRIPTION
Patch release: fixes and polish, no new headline features.

Highlights: price-chart "effective cap" line is now historically accurate (per-tick recording of the premium knob, with backfill); invalid Bitcoin payout addresses are rejected in Config and the first-run wizard; clearer DATUM stats-API errors; Ocean payout wording corrected throughout.

Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.15.1