### PR TITLE
Fix Tailscale subnet routing for kernel TUN mode

### DIFF
--- a/tailscale/docker-compose.yml
+++ b/tailscale/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     image: tailscale/tailscale:v1.98.3@sha256:854b77123b9536adae2e97f5a5fdb1790ed03438b911ab7f07780155e0af6ce2
     restart: on-failure
     stop_grace_period: 1m
+    environment:
+      - TS_DEBUG_FIREWALL_MODE=nftables
     # Required for tailscaled to manage the host TUN interface and route table.
     cap_add:
       - NET_ADMIN

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: tailscale
 category: networking
 name: Tailscale
-version: "v1.98.3-1"
+version: "v1.98.3-2"
 tagline: Zero config VPN to access your Umbrel from anywhere
 description: >-
   Tailscale is zero config VPN that creates a secure network between
@@ -30,10 +30,7 @@ torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/1248
 releaseNotes: >-
-  This update lets umbrelOS use the tailnet routes created by the Tailscale app.
+  This update lets umbrelOS use the tailnet routes created by the Tailscale app. It also fixes a regression that prevented subnet routing from working properly in the last version.
 
 
   Good news for umbrelOS Backups: you can now back up one Umbrel to another over Tailscale. When adding the destination, use its Tailscale IP address shown in the Tailscale app; Tailscale device names are not supported.
-
-
-  The bundled Tailscale version remains v1.98.3.

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -34,3 +34,6 @@ releaseNotes: >-
 
 
   Good news for umbrelOS Backups: you can now back up one Umbrel to another over Tailscale. When adding the destination, use its Tailscale IP address shown in the Tailscale app; Tailscale device names are not supported.
+
+
+  The bundled Tailscale version remains v1.98.3.


### PR DESCRIPTION
Tailscale was defaulting to iptables mode inside the container, which installed subnet-router forwarding and masquerade rules into iptables-legacy on umbrelOS. Docker and umbrelOS use the nftables-backed firewall path, so forwarded subnet traffic could still hit the nftables FORWARD policy and fail before NAT.

Forcing nftables makes Tailscale install its ts-forward and ts-postrouting rules into the same firewall backend used by Docker.

This was working fine previously since we used userspace networking mode.