### PR TITLE
pearcircle-seeder: update to 1.0.19

### DIFF
--- a/pearcircle-seeder/docker-compose.yml
+++ b/pearcircle-seeder/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8730
 
   app:
-    image: ghcr.io/peerloomllc/pearcircle-seeder:1.0.17@sha256:305485b61dea25507b245066b9d8fd8405b0841132ed8a3b9d3b6e6991198f20
+    image: ghcr.io/peerloomllc/pearcircle-seeder:1.0.19@sha256:31e77c6f14dc0df1f072faad206b87d159aba0c33442d3e4d17454311cd884c3
     restart: on-failure
     stop_grace_period: 1m
     security_opt:

--- a/pearcircle-seeder/umbrel-app.yml
+++ b/pearcircle-seeder/umbrel-app.yml
@@ -26,7 +26,20 @@ description: >-
 
   To enroll a circle: open the seeder dashboard, then in the PearCircle phone
   app mint a seed invite for the circle and paste it in.
-releaseNotes: ""
+releaseNotes: >-
+  This update improves PearCircle Seeder reliability and day-to-day maintenance.
+  The seeder dashboard now supports QR pairing for adding circles without
+  copying and pasting invites, plus controls to run a retention sweep or restart
+  the seeder when needed.
+
+
+  It also improves storage retention and compaction for encrypted circle data,
+  fixes multi-circle seed invites that were broken by encoded line breaks, and
+  adds safeguards to prevent or recover from sync conflicts. No manual action is
+  required after updating.
+
+
+  Full upstream release notes: https://github.com/peerloomllc/pearcircle/releases/tag/v1.0.18 and https://github.com/peerloomllc/pearcircle/releases/tag/v1.0.19
 developer: PeerLoom
 website: https://peerloomllc.com
 dependencies: []

--- a/pearcircle-seeder/umbrel-app.yml
+++ b/pearcircle-seeder/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: pearcircle-seeder
 category: networking
 name: PearCircle Seeder
-version: "1.0.17"
+version: "1.0.19"
 tagline: Keep your PearCircle circles online 24/7
 description: >-
   Run a blind seeder for your PearCircle circles on your Umbrel so their


### PR DESCRIPTION
Bump PearCircle Seeder to 1.0.19 (image pinned to the multi-arch manifest-list digest sha256:31e77c6f14dc0df1f072faad206b87d159aba0c33442d3e4d17454311cd884c3).