### PR TITLE
elements: add backupIgnore for re-syncable chain data

### DIFF
--- a/elements/umbrel-app.yml
+++ b/elements/umbrel-app.yml
@@ -34,5 +34,9 @@ gallery:
 path: ''
 deterministicPassword: false
 torOnly: false
+backupIgnore:
+  - data/liquidv1/blocks
+  - data/liquidv1/chainstate
+  - data/liquidv1/indexes
 submitter: Marco Argentieri
 submission: https://github.com/getumbrel/umbrel/pull/1319


### PR DESCRIPTION
The elements manifest has no `backupIgnore`, so umbrelOS backups end up including the entire Liquid blockchain. On a synced node that's roughly 76 GB of data that's fully re-syncable from the local Bitcoin node and peers, so there's no reason to copy it into every backup.

This adds:

```yaml
backupIgnore:
  - data/liquidv1/blocks
  - data/liquidv1/chainstate
  - data/liquidv1/indexes
```

The compose mounts `${APP_DATA_DIR}/data:/home/elements/.elements` and Liquid mainnet lives under `liquidv1`, so these paths line up with what's actually on disk. It's the same approach the `bitcoin` app already uses for `data/bitcoin/{blocks,chainstate,indexes}`.

`data/liquidv1/wallets` is intentionally left in the backup since that holds the user's funds (e.g. peerswap). After a restore Elements just re-syncs the chain, same as Bitcoin does.

Closes #5729 (the lightning half of that issue already looks fixed in the current manifest, so this only covers elements).