### PR TITLE
portainer: pin bundled DinD back to 27.2.0

### DIFF
--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   docker:
-    image: docker:29.6.0-dind@sha256:7bb861a04bb42bda1d237fc2cb539f9823c9b666ecfbfdbd3e534ab74c8cb976
+    image: docker:27.2.0-dind@sha256:f9f72ad901a78f27be922b2d320bbc263174f12919c1b37e6a01f828fa904565
     privileged: true
     network_mode: host
     stop_grace_period: 1m

--- a/portainer/umbrel-app.yml
+++ b/portainer/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: portainer
 category: developer
 name: Portainer
-version: "2.39.4"
+version: "2.39.4-1"
 tagline: Run custom Docker containers on your Umbrel
 description: >-
   ⚠️ Make sure to only use named Docker volumes for your stacks and containers. Data in bind-mounted volumes
@@ -51,7 +51,10 @@ path: ""
 defaultUsername: "admin"
 defaultPassword: "changeme"
 releaseNotes: >-
-  Portainer 2.39.4 LTS includes security fixes, stack management fixes, and reliability improvements. This update also refreshes the bundled Docker runtime used by Portainer.
+  This release keeps Portainer at version 2.39.4 but reverts the bundled Docker runtime to a known-good version after the previous update caused containers to fail to start on some setups.
+
+
+  Release notes for version 2.39.4 remain the same. Portainer 2.39.4 LTS includes security fixes, stack management fixes, and reliability improvements.
 
 
   Highlights include:


### PR DESCRIPTION
The v2.39.4 update bumped the bundled DinD sidecar from `docker:27.2.0-dind` to `docker:29.6.0-dind` alongside the Portainer CE bump. The DinD bump is what's causing trouble.

Docker 28+ rewrites the host `DOCKER-FORWARD` iptables chain when its daemon starts. Because this sidecar runs `privileged: true` with `network_mode: host`, the DinD daemon only inserts ACCEPT rules for its own bridges and leaves `umbrel_main_network` (`br-…`) under the default DROP policy. The result is that every other app loses outbound connectivity a minute or so after Portainer starts — cloudflared tunnels drop, Immich can't reach the internet, etc. The host itself is unaffected, which makes it easy to misdiagnose.

This reverts only the DinD image to the `27.2.0-dind` digest that shipped through 2.39.1–2.39.3 without this problem. Portainer CE stays on 2.39.4, and 27.x is fully compatible with the Portainer CE daemon API. Pre-28 DinD doesn't touch the new firewall manager, so it no longer clobbers the host chain.

Closes #5802.

One thing for maintainers to decide: the manifest version stays `2.39.4`, so let me know if you'd rather re-release to push this to users who already updated.