### PR TITLE
Update Obsidian to 1.12.7

### DIFF
--- a/obsidian/docker-compose.yml
+++ b/obsidian/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   server:
-    image: linuxserver/obsidian:1.8.10@sha256:b85e75e572e75f5e00062fb564102eaad8e19970938ee8ec7bae0a96566c1400
+    image: linuxserver/obsidian:1.12.7@sha256:bbc7d7fc7ad76e7fee9f90055f09b81d6bb44631fbf4fb239cbc807a5a7f26b0
     restart: on-failure
     environment:
       - PUID=1000

--- a/obsidian/umbrel-app.yml
+++ b/obsidian/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: obsidian
 category: files
 name: Obsidian
-version: "1.8.10"
+version: "1.12.7"
 tagline: The private and flexible writing app that adapts to the way you think
 description: >-
   **Your thoughts are yours.**
@@ -19,8 +19,14 @@ description: >-
 
   Obsidian uses open, non-proprietary files, so you're never locked in, and can preserve your data for the long term.
 releaseNotes: >-
-  This release of Obsidian brings a bug fix:
-    - Fixed numbering issues in lists with leading spaces or within block quotes
+  This update brings Obsidian up to 1.12.7, covering everything since the 1.9
+  series along with many performance improvements and bug fixes:
+    - Bases: a new core plugin that turns any set of notes into a powerful database, with table, list, and map views
+    - Footnotes view: a sidebar tab for managing a note's footnotes without losing your place
+    - Smoother mobile editing and navigation, plus theming support for window corner shapes
+
+  Heads up: the singular "tag", "alias", and "cssclass" properties have been
+  removed — use the plural "tags", "aliases", and "cssclasses" (as lists) instead.
 
   Full release notes are available at https://obsidian.md/changelog/
 developer: Obsidian


### PR DESCRIPTION
Obsidian has been pinned at `linuxserver/obsidian:1.8.10` since #2679, and upstream has shipped the whole 1.9–1.12 series since then. This bumps it to 1.12.7, the current stable.

The headline change across those releases is Bases, the new core plugin that turns a set of notes into a database with table, list, and map views. There's also the new Footnotes view sidebar, smoother mobile editing, and a long tail of performance and bug fixes. One bigger under-the-hood change: 1.12.x swaps the remote-desktop backend in the LinuxServer image from KasmVNC to Selkies.

One thing worth flagging in the release notes (and I did): 1.9 dropped the singular `tag`/`alias`/`cssclass` frontmatter properties in favor of the plural `tags`/`aliases`/`cssclasses` as lists. Anyone still using the old singular form will need to update their notes.

Nothing changed on the packaging side. It's still the single `server` service persisting to `/config`, and I pinned the new tag to its multi-arch manifest-list digest (`sha256:bbc7d7fc…`) with amd64 + arm64 both present.

Tested on a real Umbrel (umbrelOS 1.7.3, amd64):
- Fresh install of 1.12.7 comes up clean — Selkies starts, the Wayland desktop and websocket server come up, app_proxy reports ready, no s6-overlay errors.
- Update path: started 1.12.7 on top of an existing 1.8.10 `/config` directory (with a marker file dropped in beforehand). It booted cleanly, `[migrations] no migrations found`, and the marker survived — so existing vaults/config carry over despite the KasmVNC→Selkies switch.
- `npm run lint:apps -- obsidian --check-images` clean.

(I tested by mirroring this exact package into a throwaway community-store app rather than overwriting the managed official source on the device; same images and compose, just a different app id and port.)

Changelog: https://obsidian.md/changelog/