### PR TITLE
fix(core-lightning): wait for Tor before starting lightningd

### DIFF
--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -51,6 +51,9 @@ services:
   lightningd:
     image: elementsproject/lightningd:v26.06.1@sha256:abc26f1ece2ea2986f4cb5dc0117c81aed2c1662f6fb266838c4208c2f99468d
     restart: on-failure
+    depends_on:
+      tor:
+        condition: service_healthy
     ports:
       - ${APP_CORE_LIGHTNING_DAEMON_PORT}:9735
       - ${APP_CORE_LIGHTNING_WEBSOCKET_PORT}:${APP_CORE_LIGHTNING_WEBSOCKET_PORT}
@@ -89,3 +92,16 @@ services:
       - ${TOR_DATA_DIR}:/data
     environment:
       HOME: "/tmp"
+    # Gate lightningd on the Tor control port being reachable. lightningd's connectd
+    # calls a fatal, non-retrying status_failed() if it can't reach Tor at startup, so
+    # on a fresh start or OS update it crashes when it races ahead of Tor. The control
+    # port lives on umbrelOS's system Tor at ${TOR_PROXY_IP}:29051 (same endpoint
+    # lightningd connects to via --addr=statictor). The getumbrel/tor image has no nc
+    # and its /bin/sh lacks the /dev/tcp builtin, so probe with bash via CMD (not
+    # CMD-SHELL).
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/${TOR_PROXY_IP}/29051"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: core-lightning
 category: bitcoin
 name: Core Lightning
-version: "26.06.1"
+version: "26.06.1-hotfix.1"
 tagline: Run your personal Core Lightning node
 description: >-
   Get started with the Lightning network today with Core Lightning - a
@@ -32,11 +32,12 @@ defaultPassword: ""
 submitter: Blockstream
 submission: https://github.com/getumbrel/umbrel-apps/pull/475
 releaseNotes: >-
-  This updates Core Lightning to v26.06.1. CLN Application remains on v26.04.
+  This is a packaging fix and does not change the Core Lightning version (still v26.06.1).
 
 
-  **Core Lightning v26.06.1:**
-    - Fixes the `bwatch` plugin failing to register on startup after `make install`.
+  It stops lightningd from crashing on startup when it races ahead of Tor — a problem
+  that showed up most often after an umbrelOS update recreated all the containers at once.
+  The node now waits for the Tor control port to be reachable before lightningd starts.
 
 backupIgnore:
   - data/lightningd/bitcoin/lightningd.sqlite3


### PR DESCRIPTION
Fixes #5529. On a fresh start — and especially after an umbrelOS update recreates every container at once — lightningd can come up before Tor is ready. When connectd can't reach the Tor control port it calls `status_failed()`, which is fatal and doesn't retry, so the node just dies. The log makes it look like a bitcoind problem (`plugin-bcli: Could not connect to bitcoind`) but the real line is `connectd: STATUS_FAIL_INTERNAL_ERROR: Connecting stream socket to Tor service`.

There's currently no `depends_on` or healthcheck anywhere in the compose file, so nothing holds lightningd back.

The part that took a bit of digging: lightningd doesn't talk to the bundled `tor` service in this app — that one only publishes the CLNRest hidden service (its torrc is just a `HiddenServiceDir`). The control port lightningd actually uses is `${TOR_PROXY_IP}:29051`, which is umbrelOS's system Tor (`TOR_PROXY_IP` is a framework-global, same one the LND app uses). Since `depends_on` can only reference services inside this compose project, I use the bundled `tor` service as the gate: it gets a healthcheck that probes `${TOR_PROXY_IP}:29051`, and lightningd waits for it to go healthy.

The healthcheck has to use bash's `/dev/tcp` — `getumbrel/tor:0.4.7.8` has no `nc`/`ncat`/`curl`, and its `/bin/sh` doesn't support the `/dev/tcp` builtin (it does have `/bin/bash`), which is why it's `CMD` and not `CMD-SHELL`.

Bumped the manifest to `26.06.1-hotfix.1` so existing installs actually get this — the CLN version itself is unchanged. Lint is clean.

Tested on a real Umbrel (umbrelOS 1.7.3, amd64, with the Bitcoin app as the dependency):
- The `tor` service's healthcheck resolves `${TOR_PROXY_IP}` to the system Tor IP and goes `healthy` (`exec 3<>/dev/tcp/<system-tor-ip>/29051`, failing streak 0) — so the gate clears at the right endpoint instead of deadlocking.
- lightningd waits for that, then starts: connectd binds its static Tor onion successfully (the exact step that crashes in this bug), bitcoind connects fine, and "Server started" — with 0 restarts. No `STATUS_FAIL_INTERNAL_ERROR`.

What I could not do is force the actual race on a healthy device — system Tor is always already up, so I couldn't reproduce the original crash to watch the fix prevent it. So this verifies the gate works and doesn't deadlock or change normal startup; it doesn't demonstrate the failure-then-fixed sequence. If a maintainer can reproduce the OS-update race on real hardware, that'd be the last piece. If you'd rather gate the `app` service too, or check a different port, happy to adjust.

(Tested via a throwaway community-store clone of this package — same compose/exports/hooks, different app id — rather than overwriting the managed official app-store source on the device.)

Upstream context for the non-retrying connectd behavior: ElementsProject/lightning#5499 and #5617.