### PR TITLE
Update BOLT12 Pay to v0.2.116.1

### DIFF
--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.2.114@sha256:e971d1457faacfd92f5e9e8c71cf4f3f4fc7e76070a2f2801f3e8ebb3e7a07ab
+    image: alex71btc/bolt12-pay:0.2.116@sha256:5b454695653a150424eb2b2ea5e77111680d2335c0be9c4cf45303a90e580c7d
     restart: on-failure
     depends_on:
       - lndk

--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.2.113@sha256:3b4359cc688e6bc768526070d6d039f3f43c44081c924b9adb5e7ebf2d680197
+    image: alex71btc/bolt12-pay:0.2.114@sha256:e971d1457faacfd92f5e9e8c71cf4f3f4fc7e76070a2f2801f3e8ebb3e7a07ab
     restart: on-failure
     depends_on:
       - lndk

--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.2.111@sha256:7d856fa4a70bf4988e4d32640731261c816b67d8796f5bc551d7bf7668429130
+    image: alex71btc/bolt12-pay:0.2.113@sha256:3b4359cc688e6bc768526070d6d039f3f43c44081c924b9adb5e7ebf2d680197
     restart: on-failure
     depends_on:
       - lndk

--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.2.116@sha256:5b454695653a150424eb2b2ea5e77111680d2335c0be9c4cf45303a90e580c7d
+    image: alex71btc/bolt12-pay:0.2.116.1@sha256:5e68460c007133e633ff5e7c060124acfefee9ab0e6ac8f826b6fa252fdecbcd
     restart: on-failure
     depends_on:
       - lndk

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,12 +3,37 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.114
+version: 0.2.116
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
   It supports BOLT12 Offers, Lightning Address (BIP353), LNURL, and BOLT11 fallback,
   with optional Nostr identity features such as NIP-05 and Zaps.
+
+  ## 🚀 Before you install
+
+  To get the most out of BOLT12 Pay you should ideally own a domain name.
+
+  Recommended setup:
+
+  - Your own domain (for example: example.com)
+  - DNS managed through Cloudflare, you can also import domains from other providers for DNS management to cloudflare.
+  - A public HTTPS endpoint (Cloudflare Tunnel works well on Umbrel)
+
+  This enables:
+
+  - Human-readable Lightning Addresses
+  - BIP353 Lightning Addresses
+  - Automatic DNS management
+  - Public payment pages
+  - Nostr NIP-05 identities
+
+  BOLT12 Offers can still be tested without a real domain by using placeholder values during setup,
+  but Lightning Addresses, BIP353 and public payment identities require a real domain.
+
+  Domain setup guide:
+
+  https://github.com/Alex71btc/lndk-pay/blob/main/README.md#-domain-configuration-bip353-vs-lnurl
 
 
   ## ⚠️ LND Compatibility Notice
@@ -125,23 +150,13 @@ repo: https://github.com/Alex71btc/lndk-pay
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
 
-  Bugfix Release for the initial Native Onion Messaging Release
+  Native Onion Messaging:
 
-   - Added support for LND v0.21 native onion messaging
-   - Removed dependency on custom-message transport when using LND v0.21
-   - BOLT12 Offer creation verified on LND v0.21
-   - BOLT12 Offer payments verified on LND v0.21
-   - BIP353 payment flow verified on LND v0.21
-   - Improved future compatibility with upcoming Lightning releases
-
-
-  REST API compatibility:
-
-   - Added automatic fallback for LND v0.21 payment APIs
-   - Maintains compatibility with both LND v0.20.x and LND v0.21.x
-   - Uses legacy REST payment endpoint on LND v0.20.x
-   - Automatically switches to RouterRPC payment endpoint on LND v0.21 when required
-   - Fixes LNURL, Lightning Address, BOLT11 and NWC payment flows on LND v0.21
+   - Added automatic detection of native onion messaging support in LND v0.21+
+   - Setup page automatically detects compatible LND versions
+   - Native Onion Messaging status is displayed during setup
+   - Legacy configuration instructions are hidden when native support is available
+   - Maintains compatibility with LND v0.20.x custom-message transport
 
   Upgrade notes:
 
@@ -150,21 +165,6 @@ releaseNotes: |
 
   This release maintains compatibility with existing BOLT12 Pay installations while preparing for the transition to native onion messaging in LND.
 
-
-  Bugfix release for the v0.2.108 Privacy Mode update.
-
-  - Improved reliability of BOLT12 offer creation
-  - Automatically retries transient LNDK TLS connection failures
-  - Prevents occasional first-attempt offer creation errors observed on some Umbrel systems
-  - Adds a default routing fee limit for improved compatibility with GetAlby, Wallet of Satoshi and other Lightning Address providers
-  - Fixed LNURL string and QR-code payments failing with "CSRF Validation failed" after login 
-
-  Includes all features from v0.2.108:
-
-  - Privacy Mode
-  - Private BIP353 Lightning Addresses
-  - Offer History BIP353 Publishing
-  - Automatic DNS Cleanup
 
 dependencies:
   - lightning

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.116
+version: 0.2.116.1
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
@@ -17,7 +17,9 @@ description: >-
   Recommended setup:
 
   - Your own domain (for example: example.com)
-  - DNS managed through Cloudflare, you can also import domains from other providers for DNS management to cloudflare.
+
+  - DNS managed through Cloudflare, you can also import domains from other providers for DNS management to cloudflare
+
   - A public HTTPS endpoint (Cloudflare Tunnel works well on Umbrel)
 
   This enables:
@@ -158,13 +160,18 @@ releaseNotes: |
    - Legacy configuration instructions are hidden when native support is available
    - Maintains compatibility with LND v0.20.x custom-message transport
 
+  User Experience:
+
+   - Added copy-to-clipboard support for Last Payment Result output
+   - Fixed LNURL payment success messages not respecting the selected UI language
+   - Improved setup and documentation guidance
+
   Upgrade notes:
 
-  - LND v0.20.x users should keep their existing custom protocol configuration.
-  - LND v0.21.x users should remove all legacy custom protocol settings from lnd.conf before upgrading Lightning.
+   - LND v0.20.x users should keep their existing custom protocol configuration.
+   - LND v0.21.x users should remove all legacy custom protocol settings from lnd.conf before upgrading Lightning.
 
   This release maintains compatibility with existing BOLT12 Pay installations while preparing for the transition to native onion messaging in LND.
-
 
 dependencies:
   - lightning

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.113
+version: 0.2.114
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
@@ -157,6 +157,7 @@ releaseNotes: |
   - Automatically retries transient LNDK TLS connection failures
   - Prevents occasional first-attempt offer creation errors observed on some Umbrel systems
   - Adds a default routing fee limit for improved compatibility with GetAlby, Wallet of Satoshi and other Lightning Address providers
+  - Fixed LNURL string and QR-code payments failing with "CSRF Validation failed" after login 
 
   Includes all features from v0.2.108:
 

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -30,7 +30,7 @@ description: >-
   - Public payment pages
   - Nostr NIP-05 identities
 
-  BOLT12 Offers can still be tested without a real domain by using placeholder values during setup,
+  🔥 BOLT12 Offers can still be paid, created and stored without a real domain by using the suggested placeholder values during setup,
   but Lightning Addresses, BIP353 and public payment identities require a real domain.
 
   Domain setup guide:

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.2.111
+version: 0.2.113
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
@@ -125,7 +125,7 @@ repo: https://github.com/Alex71btc/lndk-pay
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
 
-  Native Onion Messaging Release
+  Bugfix Release for the initial Native Onion Messaging Release
 
    - Added support for LND v0.21 native onion messaging
    - Removed dependency on custom-message transport when using LND v0.21
@@ -156,6 +156,7 @@ releaseNotes: |
   - Improved reliability of BOLT12 offer creation
   - Automatically retries transient LNDK TLS connection failures
   - Prevents occasional first-attempt offer creation errors observed on some Umbrel systems
+  - Adds a default routing fee limit for improved compatibility with GetAlby, Wallet of Satoshi and other Lightning Address providers
 
   Includes all features from v0.2.108:
 


### PR DESCRIPTION
@nmfretz Just a small follow-up release 🙂

BOLT12 Pay now automatically detects native Onion Messaging support in LND v0.21+ and displays a native status message during setup instead of the legacy custom-message instructions. This prevents users to accidentally add custom protocol entries because of the UI hints of Bolt12 pay when running LND 0.21.1.

LND v0.20.x continues to use the existing custom-message transport flow and remains fully supported.

Also updated the app description with clearer domain setup guidance and release notes for the native Onion Messaging transition.

Tested with both LND v0.20.1-beta and LND v0.21.1-beta.