### PR TITLE
Update BFFless to v0.1.90

### DIFF
--- a/bffless/docker-compose.yml
+++ b/bffless/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   # Nginx reverse proxy - serves frontend, routes API calls
   # Uses custom umbrel image with baked-in config template and setup page
   nginx:
-    image: ghcr.io/bffless/ce-nginx:umbrel@sha256:c49cbce6626ba73ccf296d7e39d4e192996fb613fb11d4ff7994ef8e7115afc4
+    image: ghcr.io/bffless/ce-nginx:umbrel@sha256:e7ac5f6db00b44335e872531bc85f2d3ff36b4a667565bbea5fe3d8667a8512a
     restart: on-failure
     stop_grace_period: 30s
     environment:
@@ -79,7 +79,7 @@ services:
   # NestJS backend API
   # Uses custom umbrel image with baked-in entrypoint that derives keys from APP_SEED
   backend:
-    image: ghcr.io/bffless/ce-backend:umbrel@sha256:c974e83fd5f1cfea84b2c35db4417f3250a2ef322af476704aef93b61176cc0c
+    image: ghcr.io/bffless/ce-backend:umbrel@sha256:2d675ec9c8aa7ecaaf293905e87e4f6a7138845908a75fcee5560564e7ed82a2
     restart: on-failure
     stop_grace_period: 30s
     depends_on:
@@ -136,7 +136,7 @@ services:
 
   # React frontend (serves static files)
   frontend:
-    image: ghcr.io/bffless/ce-frontend:umbrel@sha256:f31234703e2a5baa4d913b30a26ea39077ac2283f5f0f3f90cdaab0133e91a97
+    image: ghcr.io/bffless/ce-frontend:umbrel@sha256:de5d98fb69f28fe9a50dc4e1d9e61a625e83a998dd6894d9f6825a986931bb3d
     restart: on-failure
     stop_grace_period: 30s
     volumes:

--- a/bffless/umbrel-app.yml
+++ b/bffless/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bffless
 category: developer
 name: BFFless
-version: '0.1.53'
+version: '0.1.90'
 tagline: Self-hosted static site hosting platform
 description: >-
   BFFless is a self-hosted platform for hosting static websites and build artifacts from CI/CD pipelines.
@@ -33,22 +33,48 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  Updates BFFless CE from v0.1.42 to v0.1.53.
+  Updates BFFless CE from v0.1.53 to v0.1.90.
 
 
-  Highlights:
-    - Accept multiple proxy rule sets when creating a deployment
-    - Choose 301 or 302 status for redirect-type domains
-    - Custom-domain sign-ups now relay back to the target domain
-    - Pipeline string response bodies served verbatim instead of JSON-encoded
-    - Stronger authorization: global Admin treated as project Owner consistently, role lanes enforced when granting project permissions, and global admin honored on the repo feed and project settings
-    - Create Deployment button and proxy-rule actions hidden/disabled for viewers
-    - Fixed Azure Blob Storage upload and its setup wizard step
-    - Surface storage migration errors with a force-switch recovery path
-    - Include redirectType in the domain response DTO and SSL renewal regeneration
+  Pipelines & automation:
+    - New file_delete pipeline handler, with multi-object (keys[]) mode and runtime array expressions
+    - Project secrets for pipelines
+    - Presigned direct-to-bucket upload handlers
+    - file_serve_handler improvements: explicit key mode, byte-range streaming, and private caching by default
+    - Set arbitrary custom response headers via the UI editor and MCP tools
+    - Expose crypto utils to the function_handler sandbox; step-timeout field for the Replicate handler
 
 
-  Full release notes can be found at https://github.com/bffless/ce/releases/tag/v0.1.53
+  Proxy rules & domains:
+    - Export and import proxy rule sets from the admin UI, with bundled schema dependencies
+    - Proxy rules can match multiple HTTP methods
+    - Support absolute external URLs as path redirect targets
+
+
+  AI:
+    - Fetch Anthropic models live from /v1/models
+    - Pin which deployment alias AI skills load from
+
+
+  Auth & access:
+    - ENABLE_EMAIL_PASSWORD flag for OIDC-only sign-in
+    - Mint a content-domain session from a project API key
+    - Member-accessible user directory for people-pickers
+
+
+  Privacy:
+    - Opt-out install telemetry controls (setup wizard and settings)
+
+
+  Fixes:
+    - nginx: larger proxy header buffers for SuperTokens session refresh, http-level client_max_body_size, and upload-size fixes
+    - Raise the request body limit and return 413 for oversized bodies
+    - Markdown viewer renders GitHub-style with a source toggle
+    - Correct permission badges for global admins on repo cards
+    - Various proxy-rule and /auth routing fixes
+
+
+  Full release notes can be found at https://github.com/bffless/ce/releases/tag/v0.1.90
 path: ''
 defaultUsername: ''
 deterministicPassword: false


### PR DESCRIPTION
## Type

App update

## App

App ID: `bffless`
Upstream project: https://github.com/bffless/ce
Version: `0.1.53` → `0.1.90`

## Summary

Updates BFFless CE from v0.1.53 to v0.1.90. Bumps the manifest `version`, refreshes the `ce-nginx`, `ce-backend`, and `ce-frontend` image digests to the v0.1.90 build, and rewrites `releaseNotes` to cover the range.

Highlights across the range:
- **Pipelines & automation:** new `file_delete` handler (multi-object `keys[]` + runtime array expressions), project secrets, presigned direct-to-bucket uploads, `file_serve_handler` improvements (explicit key mode, byte-range streaming, private caching by default), custom response headers via UI/MCP, crypto utils in the `function_handler` sandbox.
- **Proxy rules & domains:** export/import proxy rule sets from the admin UI (with bundled schema deps), multi-method matching, absolute external URLs as path redirect targets.
- **AI:** live Anthropic model fetching from `/v1/models`, pin which deployment alias AI skills load from.
- **Auth & access:** `ENABLE_EMAIL_PASSWORD` flag for OIDC-only sign-in, mint a content-domain session from a project API key, member-accessible user directory.
- **Privacy:** opt-out install telemetry controls.
- **Fixes:** nginx proxy header buffer / body-size fixes, 413 for oversized bodies, GitHub-style markdown viewer, permission-badge and routing fixes.

Full upstream release notes: https://github.com/bffless/ce/releases/tag/v0.1.90

## Verification

Umbrel testing performed: Installed and ran the v0.1.90 package on a **physical Umbrel device** (fresh install) — the app pulls, starts, and opens successfully. Ran `npm run lint:apps -- bffless --check-images` (no issues; image pull + multi-arch manifest checks pass) and `git diff --check` (clean). Confirmed the pinned image digests were built from the exact v0.1.90 CE release commit (`b1c04bd`, "chore(main): release 0.1.90") via image SLSA provenance.

The in-place 0.1.53 → 0.1.90 update path was not separately exercised, but this change is metadata + image-digest only — no compose/env/port/`app_proxy`/persistence changes and no migrations — so the update path is low risk.

Environment tested:
- [x] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64 (physical device; interface naming `enp1s0` indicates x86 hardware)
- [ ] arm64 (image manifest verified & passes `--check-images`, not runtime-tested)

Known lint warnings or caveats: None.

## Notes

Metadata + image-digest update only. No changes to permissions, dependencies (`cloudflared`), ports, `app_proxy`, default credentials, persistence, or hooks. No migrations required. Diff is scoped to `bffless/umbrel-app.yml` and `bffless/docker-compose.yml`.
