### PR TITLE
lightning-terminal: update to `v0.17.0-alpha`

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.16.1-alpha@sha256:7f8e16d940ee350ff38b2d8e71bda0c512a89822fa62a60097ac7ecc71d660ae
+    image: lightninglabs/lightning-terminal:v0.17.0-alpha@sha256:fd6d6040f78e0a342437312f3a3c154f4b63d79172c6b466e2dfd242b06b4a1c
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     environment:
       HOME: "/data"
       APP_PASSWORD: "$APP_PASSWORD"
+      # Auto-approve LiT's one-time bbolt-to-SQL migration for non-interactive Umbrel updates.
+      LIT_AUTO_MIGRATE_TO_SQL: "true"
     command:
         - --uipassword_env=APP_PASSWORD
         - --insecure-httplisten=0.0.0.0:3004

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -59,6 +59,9 @@ releaseNotes: >-
   ⚠️ Please update your Lightning Node app to the latest version available in the app store to ensure compatibility with Lightning Terminal.
 
 
+  This update automatically migrates Lightning Terminal's internal database from bbolt to SQLite on first startup. No action is required, but the first startup after updating may take longer than usual while the migration runs.
+
+
   This version of Lightning Terminal (LiT) ships lnd v0.21.1-beta, loop v0.33.3-beta, faraday v0.2.16-alpha,
   pool v0.7.1-beta and tapd v0.8.0.
 

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.16.1-alpha"
+version: "0.17.0-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -59,8 +59,8 @@ releaseNotes: >-
   ⚠️ Please update your Lightning Node app to the latest version available in the app store to ensure compatibility with Lightning Terminal.
 
 
-  This version of Lightning Terminal (LiT) ships lnd v0.20.1-beta, loop v0.31.8-beta, faraday v0.2.16-alpha,
-  pool v0.6.6-beta and tapd v0.7.1.
+  This version of Lightning Terminal (LiT) ships lnd v0.21.1-beta, loop v0.33.3-beta, faraday v0.2.16-alpha,
+  pool v0.7.1-beta and tapd v0.8.0.
 
 
   IMPORTANT NOTE: To avoid loss of funds, it's imperative that you read the
@@ -98,7 +98,7 @@ releaseNotes: >-
   feedback from the community.
 
 
-  This release packages LND v0.20.1-beta, Taproot Assets Daemon v0.7.1,
-  Loop v0.31.8-beta, Pool v0.6.6-beta and Faraday v0.2.16-alpha.
+  This release packages LND v0.21.1-beta, Taproot Assets Daemon v0.8.0,
+  Loop v0.33.3-beta, Pool v0.7.1-beta and Faraday v0.2.16-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
In this PR we bump Litd to `v0.17.0-alpha`.

--------

NOTE!! There's an important change with this release which potentially effects how you want host `lightning-terminal` in Umbrel:

With this release, we added support for SQL-based database backends, and by default, user which have run `litd` prior to this release and has an existing database will therefore be prompted to migrate their old `bbolt` databases to SQL.

For users which runs the `litd` as a standalone daemon, this prompt is shown to the user when the daemon in started, and the user thereafter needs to manually confirm the migration by passing `yes` via `stdin`. I would assume that this user flow is not supported in Umbrel though?

For environments where that user flow does not work, we have provided an alternative approach:
Instead of the approach where the migration prompt needs to manually be confirmed with `yes` through `stdin`, you can instead either set a config flag `auto-migrate-to-sql=true` for `litd`, or set an env variable `LIT_AUTO_MIGRATE_TO_SQL=true`. Once those are set, the prompt will not show on startup and the SQL migration will be started automatically. I'd assume that the env variable approach is likely the most appropriate for Umbrel users, but you'd know this best.

Alternatively, the migration can also be deferred by setting the following config option: `databasebackend=bbolt`. Note though that deferring the migration will only work temporarily, as we will make the migration mandatory in future `litd` releases.

-------

See these release notes for more information:
https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha

Additionally, you can check these release notes:
https://github.com/lightninglabs/lightning-terminal/blob/master/docs/release-notes/release-notes-0.17.0.md
