### PR TITLE
booklore: whitelist OPDS + KOReader sync paths in app_proxy

### DIFF
--- a/booklore/docker-compose.yml
+++ b/booklore/docker-compose.yml
@@ -5,7 +5,14 @@ services:
     environment:
       APP_HOST: booklore_web_1
       APP_PORT: 6060
-      
+      # Whitelist BookLore's OPDS catalog and KOReader sync API. E-reader
+      # companion clients (KOReader, CrossPoint) can't send Umbrel auth
+      # cookies, so without this they follow app_proxy's login redirect and
+      # receive the portal HTML instead of JSON (KOReader/CrossPoint report a
+      # "sync failed / JSON parse error"). The web UI stays behind Umbrel auth;
+      # OPDS + KOReader endpoints keep their own BookLore auth.
+      PROXY_AUTH_WHITELIST: "/api/v1/opds*,/api/koreader*"
+
   web:
     image: ghcr.io/booklore-app/booklore:v2.3.1@sha256:d3d3af34bc2cc44349178535ce19e86049968fba2e7d2acf965f770bf37bad01
     # does not work rootless

--- a/booklore/docker-compose.yml
+++ b/booklore/docker-compose.yml
@@ -5,13 +5,8 @@ services:
     environment:
       APP_HOST: booklore_web_1
       APP_PORT: 6060
-      # Whitelist BookLore's OPDS catalog and KOReader sync API. E-reader
-      # companion clients (KOReader, CrossPoint) can't send Umbrel auth
-      # cookies, so without this they follow app_proxy's login redirect and
-      # receive the portal HTML instead of JSON (KOReader/CrossPoint report a
-      # "sync failed / JSON parse error"). The web UI stays behind Umbrel auth;
-      # OPDS + KOReader endpoints keep their own BookLore auth.
-      PROXY_AUTH_WHITELIST: "/api/v1/opds*,/api/koreader*"
+      # OPDS catalog access and KOReader progress sync.
+      PROXY_AUTH_WHITELIST: "/api/v1/opds,/api/v1/opds/*,/api/koreader/*"
 
   web:
     image: ghcr.io/booklore-app/booklore:v2.3.1@sha256:d3d3af34bc2cc44349178535ce19e86049968fba2e7d2acf965f770bf37bad01

--- a/booklore/umbrel-app.yml
+++ b/booklore/umbrel-app.yml
@@ -3,7 +3,7 @@ id: booklore
 name: BookLore
 tagline: An app for managing and reading books
 category: files
-version: "2.3.1"
+version: "2.3.1-1"
 port: 6060
 description: >-
   📖 BookLore is a modern web application created to transform the way digital libraries are managed and experienced. It is designed for readers who want to bring order and beauty to their collection of books and comics while also making them instantly accessible. Instead of leaving files scattered across folders, BookLore gathers them into a central library that can be explored and enjoyed directly through the browser. It provides a seamless reading environment where organization, discovery, and enjoyment flow together.
@@ -48,13 +48,16 @@ gallery:
   - 5.jpg
   - 6.jpg
 releaseNotes: >-
-  This update adds OpenLibrary as a metadata provider and improves Goodreads metadata fetching when detail pages are blocked.
+  This packaging update fixes connecting BookLore to compatible e-reader apps, including KOReader. E-readers can access your library and sync reading progress again, while the BookLore web app remains protected by your Umbrel login.
+
+
+  BookLore 2.3.1 also adds OpenLibrary as a metadata provider and improves Goodreads metadata fetching when detail pages are blocked.
 
 
   It also updates backend and frontend dependencies, including Flyway, Jackson, Angular CLI, Transloco, and Vitest.
 
 
-  Full release notes can be found at: https://github.com/booklore-app/booklore/releases/tag/v2.3.1
+  Full upstream release notes can be found at: https://github.com/booklore-app/booklore/releases/tag/v2.3.1
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
### What this changes

Adds a scoped `PROXY_AUTH_WHITELIST` to BookLore's `app_proxy` so e-reader
companion clients can reach the OPDS catalog and the KOReader progress-sync
API. No image, data, or version change — packaging fix only.

```yaml
PROXY_AUTH_WHITELIST: "/api/v1/opds*,/api/koreader*"
```

### Why

BookLore is used both in a browser and from e-readers (KOReader on Kindle,
CrossPoint on Xteink) that pull books over **OPDS** and sync reading position
over BookLore's **KOReader sync** endpoint. These clients can't carry an Umbrel
portal session cookie, so `app_proxy` 302-redirects their requests to the login
portal and they receive **HTML instead of JSON** — which the readers surface as
`sync failed / JSON parse error` (and OPDS simply fails to authenticate).

Today the only workaround is to set `PROXY_AUTH_ADD: "false"`, which drops
Umbrel auth for the **entire** app — including the web UI. This PR follows the
`app_proxy` guidance to instead whitelist only the companion-client paths and
keep the rest of the app behind Umbrel auth.

### Scope of the whitelist

Route prefixes come from BookLore's controllers:

- `/api/v1/opds*` — OPDS catalog root, `/{bookId}/download`, covers (`OpdsController`, `@RequestMapping("/api/v1/opds")`)
- `/api/koreader*` — `/users/auth`, `/users/create`, `/syncs/progress` (`KoreaderController`, `@RequestMapping("/api/koreader")`)

Uses the prefix form (`/path*`, per the app_proxy matcher: bare = exact,
`/path/*` = children only, `/path*` = prefix) so the OPDS **root** path is
matched as well as its sub-paths.

Admin/UI controllers do **not** match either prefix and stay behind Umbrel auth:
`/api/v1/koreader-users` and `/api/v2/opds-users`. Both whitelisted namespaces
enforce BookLore's own authentication (OPDS Basic auth realm `"Booklore OPDS"`;
KOReader `x-auth-user`/`x-auth-key`), so nothing is left unauthenticated.

### Testing performed

Applied to a live install (umbrelOS on Beelink SER8, `linux/amd64`, BookLore
v2.3.1) and verified against the running `app_proxy`:

| Request | Before | After |
| --- | --- | --- |
| `GET /api/koreader/users/auth` | 302 → `:2000` portal (HTML) | 403 JSON from BookLore (passthrough) ✅ |
| `GET /api/v1/opds` | 302 → portal | 401 `WWW-Authenticate: Basic realm="Booklore OPDS"` ✅ |
| `GET /api/v1/opds/1/download` | 302 → portal | 401 (passthrough) ✅ |
| `GET /` (web UI) | 302 → portal | 302 → portal (unchanged, still protected) ✅ |
| `GET /api/v1/koreader-users/me` | 302 → portal | 302 → portal (still protected) ✅ |

End-to-end: KOReader (Kindle) and CrossPoint (Xteink) sync succeeds again after
the change.

### Notes for maintainers

- **No manifest `version` bump.** This is a packaging-only fix and upstream is
  still v2.3.1, so I left `version` mirroring upstream. New installs pick up the
  fix immediately; existing installs will receive it with the next upstream
  version bump. Happy to bump `version` + add `releaseNotes` if you'd prefer to
  push it to existing installs now — just say the word.

### I have tested my app on
- [ ] umbrelOS on a Raspberry Pi
- [x] umbrelOS on an Umbrel Home / Beelink (amd64)
- [ ] umbrelOS on Linux VM
