### PR TITLE
Add SkyBro

### DIFF
--- a/skybro/docker-compose.yml
+++ b/skybro/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+
+  app_proxy:
+    environment:
+      APP_HOST: skybro_web_1
+      APP_PORT: 5000
+
+  tracker:
+    image: xdeekay/skybro-tracker:1.5.5@sha256:dfc1fd319822ab2b3b5d9388747586e87c8d07f8f7c1969f8d9763c265d06d86
+    restart: unless-stopped
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+      - /etc/localtime:/etc/localtime:ro
+
+  web:
+    image: xdeekay/skybro-dashboard:1.5.5@sha256:914cabde096c214afc1e23e032e65f1ec68f2e8faf6942595896adae7e9de750
+    restart: unless-stopped
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+      - /etc/localtime:/etc/localtime:ro
+    depends_on:
+      - tracker

--- a/skybro/docker-compose.yml
+++ b/skybro/docker-compose.yml
@@ -6,15 +6,15 @@ services:
       APP_PORT: 5000
 
   tracker:
-    image: xdeekay/skybro-tracker:1.5.6@sha256:b0aed5500c65fe6d147a18fc3f98657c9f7c2afe6718c9602a7fd555c067f6db
-    restart: unless-stopped
+    image: xdeekay/skybro-tracker:1.5.7@sha256:bdf57d79bd57edab657fc8c87f6699636e381d796228c6e0f545864155b6ecc6
+    restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/data
       - /etc/localtime:/etc/localtime:ro
 
   web:
-    image: xdeekay/skybro-dashboard:1.5.6@sha256:12d32de5519e637f75f6f0e9a35a65d3c7ce3b5a7c7a6cc61ac3a405d3369aeb
-    restart: unless-stopped
+    image: xdeekay/skybro-dashboard:1.5.7@sha256:4582ab1ca4bd682e4b36631ab9f1ba37ef6d0b7acf17560395835da525c33158
+    restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/data
       - /etc/localtime:/etc/localtime:ro

--- a/skybro/docker-compose.yml
+++ b/skybro/docker-compose.yml
@@ -6,14 +6,14 @@ services:
       APP_PORT: 5000
 
   tracker:
-    image: xdeekay/skybro-tracker:1.5.5@sha256:dfc1fd319822ab2b3b5d9388747586e87c8d07f8f7c1969f8d9763c265d06d86
+    image: xdeekay/skybro-tracker:1.5.6@sha256:b0aed5500c65fe6d147a18fc3f98657c9f7c2afe6718c9602a7fd555c067f6db
     restart: unless-stopped
     volumes:
       - ${APP_DATA_DIR}/data:/data
       - /etc/localtime:/etc/localtime:ro
 
   web:
-    image: xdeekay/skybro-dashboard:1.5.5@sha256:914cabde096c214afc1e23e032e65f1ec68f2e8faf6942595896adae7e9de750
+    image: xdeekay/skybro-dashboard:1.5.6@sha256:12d32de5519e637f75f6f0e9a35a65d3c7ce3b5a7c7a6cc61ac3a405d3369aeb
     restart: unless-stopped
     volumes:
       - ${APP_DATA_DIR}/data:/data

--- a/skybro/umbrel-app.yml
+++ b/skybro/umbrel-app.yml
@@ -1,6 +1,6 @@
 manifestVersion: 1
 id: skybro
-category: utilities
+category: networking
 name: SkyBro
 version: "1.5.5"
 tagline: Live aircraft, ISS, weather & moon tracker

--- a/skybro/umbrel-app.yml
+++ b/skybro/umbrel-app.yml
@@ -46,7 +46,10 @@ repo: https://github.com/xDeeKay/SkyBro
 support: https://github.com/xDeeKay/SkyBro/issues
 
 port: 7437
-gallery: []
+gallery:
+  - 1.webp
+  - 2.webp
+  - 3.webp
 path: ""
 
 defaultUsername: ""

--- a/skybro/umbrel-app.yml
+++ b/skybro/umbrel-app.yml
@@ -2,8 +2,8 @@ manifestVersion: 1
 id: skybro
 category: networking
 name: SkyBro
-version: "1.5.5"
-tagline: Live aircraft, ISS, weather & moon tracker
+version: "1.5.6"
+tagline: Live aircraft, satellite, weather & astronomy tracker
 description: >-
   SkyBro is a real-time sky tracker for your home. It runs silently in the
   background 24/7 and alerts you the moment something interesting is overhead.

--- a/skybro/umbrel-app.yml
+++ b/skybro/umbrel-app.yml
@@ -56,4 +56,4 @@ backupIgnore:
   - data/aircraft_db.json
 
 submitter: xDeeKay
-submission: ""
+submission: https://github.com/getumbrel/umbrel-apps/pull/5835

--- a/skybro/umbrel-app.yml
+++ b/skybro/umbrel-app.yml
@@ -1,0 +1,59 @@
+manifestVersion: 1
+id: skybro
+category: utilities
+name: SkyBro
+version: "1.5.5"
+tagline: Live aircraft, ISS, weather & moon tracker
+description: >-
+  SkyBro is a real-time sky tracker for your home. It runs silently in the
+  background 24/7 and alerts you the moment something interesting is overhead.
+
+
+  ✈️ Aircraft — Tracks live planes in your vicinity using OpenSky Network's
+  ADS-B data. Get Pushover or Discord alerts (with photo) when a plane enters
+  your configured radius and altitude window. The live map shows per-airframe
+  silhouettes for jets, widebodies, helicopters, light props, and military
+  aircraft. Every alerted plane is saved to history with its full flight path.
+
+
+  🛰️ Satellites — Monitors upcoming passes for the ISS, Hubble Space
+  Telescope, and Tiangong CSS. Fires a push alert before each ISS pass so you
+  never miss one.
+
+
+  🔭 Astronomy — Full night-sky planner powered by ephem. Shows tonight's dark
+  window, Bortle sky quality, and observation highlights. Browse all 110
+  Messier objects with equipment and horizon filters, track all 7 planets with
+  rise/set times, and follow 11 annual meteor showers.
+
+
+  ☁️ Weather — Pulls hyperlocal forecasts from Open-Meteo (no API key needed)
+  including current conditions, 24-hour hourly breakdown, and 7-day forecast.
+  Includes a sky visibility score for tonight.
+
+
+  All settings — home coordinates, alert radius, altitude threshold, satellite
+  lead time, and notification credentials are configurable through the built-in
+  settings page. No config file editing required. Changes apply within 15
+  seconds without restarting.
+
+releaseNotes: ""
+
+developer: xDeeKay
+website: https://github.com/xDeeKay/SkyBro
+dependencies: []
+repo: https://github.com/xDeeKay/SkyBro
+support: https://github.com/xDeeKay/SkyBro/issues
+
+port: 7437
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+backupIgnore:
+  - data/aircraft_db.json
+
+submitter: xDeeKay
+submission: ""

--- a/skybro/umbrel-app.yml
+++ b/skybro/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: skybro
 category: networking
 name: SkyBro
-version: "1.5.6"
+version: "1.5.7"
 tagline: Live aircraft, satellite, weather & astronomy tracker
 description: >-
   SkyBro is a real-time sky tracker for your home. It runs silently in the


### PR DESCRIPTION
## Type

New app

## App

App ID: skybro
Upstream project: https://github.com/xDeeKay/SkyBro
Version: 1.5.6

## Summary

Adds SkyBro, a real-time sky tracker: live aircraft (OpenSky Network ADS-B data), ISS/Hubble/Tiangong satellite pass alerts (n2yo.com), hyperlocal weather (Open-Meteo), and a full astronomy planner (planets, 110 Messier objects, meteor showers, moon phase, Bortle sky quality) via the local `ephem` library.
Sends push alerts via Pushover and/or Discord when a plane enters a configured radius/altitude window or a satellite pass is approaching.

Two-service app (tracker + web dashboard), no database beyond local SQLite, no required environment variables.
First-run browser onboarding detects an approximate home location from the browser's timezone, no SSH or manual config needed.
Every setting is configured through the in-app Settings page and hot-reloaded by the tracker, no container restart needed.
Containers run as a non-root user (UID/GID 1000).

## Verification

Umbrel testing performed: fresh install and an in-place version update both tested through the actual Umbrel app lifecycle (install/uninstall via the Umbrel Apps UI, and a version bump deployed in place).
Verified main functionality end-to-end: live aircraft tracking, alert firing (Pushover + Discord, including photo attachment), satellite pass computation, weather/astronomy data, history logging with recorded flight paths, and settings persistence across restarts.
Also cross-browser/OS tested on Windows 11, iPadOS 17.7 (Safari), Android 12 (Chrome), and SteamOS 3.8 Desktop Mode (Firefox).

Environment tested:
- [x] Umbrel device (Raspberry Pi 5, Umbrel 1.7.3)
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [x] arm64

Known lint warnings or caveats: `restart: unless-stopped` is used instead of `on-failure` for both services, intentionally: the tracker is meant to run continuously 24/7, and `unless-stopped` ensures it comes back after a host reboot or an unexpected exit, not just an application-level failure.

`npm run lint:apps -- skybro --check-images` was run locally; the `image.pullable` check reported a fetch failure for both images from this test network, independently confirmed via `docker pull`, `docker buildx imagetools inspect`, and a raw curl replicating the linter's own registry API calls that both images are genuinely public and correctly multi-arch (linux/amd64 + linux/arm64).
The failure reproduces as a Node `fetch()` connection timeout specific to this network's route to Docker Hub's registry backend, not the images themselves.

## Notes

No permissions, dependencies, or migrations. No default credentials (defaultUsername/defaultPassword are empty; no login of its own, protected only by Umbrel's own app_proxy auth at its default setting).

Screenshots and icon attached below.

<img width="512" height="512" alt="icon" src="https://github.com/user-attachments/assets/65a36e1c-6680-48e3-9f2a-7297d2711724" />
<img width="2160" height="1350" alt="1" src="https://github.com/user-attachments/assets/5ce3b162-d744-4955-9138-d6bc02ee26d8" />
<img width="2160" height="1350" alt="2" src="https://github.com/user-attachments/assets/9ec9fb95-06e2-4083-8d13-86f33d697764" />
<img width="2160" height="1350" alt="3" src="https://github.com/user-attachments/assets/b70d5b27-2034-47bf-979b-04b34462373c" />
