### PR TITLE
Disable accepted Tailscale subnet routes by default

### DIFF
--- a/tailscale/docker-compose.yml
+++ b/tailscale/docker-compose.yml
@@ -18,6 +18,28 @@ services:
     devices:
       - /dev/net/tun:/dev/net/tun
     # Keep tailscaled in kernel TUN mode so host routes are available.
-    command: "sh -c 'tailscale web --listen 0.0.0.0:8240 & exec tailscaled'"
+    #
+    # Disable accept-routes on startup to migrate older Tailscale prefs that
+    # defaulted to accepting subnet routes. In host networking mode, accepting
+    # an overlapping subnet route can route local LAN replies through tailscale0
+    # and make the Umbrel unreachable on its LAN IP.
+    command:
+      - sh
+      - -c
+      - |
+        tailscale web --listen 0.0.0.0:8240 &
+
+        (
+          for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
+            if tailscale set --accept-routes=false >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Warning: failed to disable Tailscale accept-routes; continuing"
+        ) &
+
+        exec tailscaled
     volumes:
       - ${APP_DATA_DIR}/data:/var/lib

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -30,7 +30,7 @@ torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/1248
 releaseNotes: >-
-  This update lets umbrelOS use the tailnet routes created by the Tailscale app. It also fixes a regression that prevented subnet routing from working properly in the last version, and prevents an issue where your Umbrel could become inaccessible over the local network when using third-party subnet routers.
+  This update lets umbrelOS use the tailnet routes created by the Tailscale app. It also fixes a regression that prevented subnet routing from working properly in the last version, and prevents an issue where your Umbrel could be unable to be accessed over the local network when using 3rd party subnet routers.
 
 
   Good news for umbrelOS Backups: you can now back up one Umbrel to another over Tailscale. When adding the destination, use its Tailscale IP address shown in the Tailscale app; Tailscale device names are not supported.

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: tailscale
 category: networking
 name: Tailscale
-version: "v1.98.3-2"
+version: "v1.98.3-3"
 tagline: Zero config VPN to access your Umbrel from anywhere
 description: >-
   Tailscale is zero config VPN that creates a secure network between
@@ -30,7 +30,7 @@ torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/1248
 releaseNotes: >-
-  This update lets umbrelOS use the tailnet routes created by the Tailscale app. It also fixes a regression that prevented subnet routing from working properly in the last version.
+  This update lets umbrelOS use the tailnet routes created by the Tailscale app. It also fixes a regression that prevented subnet routing from working properly in the last version, and prevents old route-acceptance settings from routing local LAN access through another subnet router.
 
 
   Good news for umbrelOS Backups: you can now back up one Umbrel to another over Tailscale. When adding the destination, use its Tailscale IP address shown in the Tailscale app; Tailscale device names are not supported.

--- a/tailscale/umbrel-app.yml
+++ b/tailscale/umbrel-app.yml
@@ -30,7 +30,7 @@ torOnly: false
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/1248
 releaseNotes: >-
-  This update lets umbrelOS use the tailnet routes created by the Tailscale app. It also fixes a regression that prevented subnet routing from working properly in the last version, and prevents old route-acceptance settings from routing local LAN access through another subnet router.
+  This update lets umbrelOS use the tailnet routes created by the Tailscale app. It also fixes a regression that prevented subnet routing from working properly in the last version, and prevents an issue where your Umbrel could become inaccessible over the local network when using third-party subnet routers.
 
 
   Good news for umbrelOS Backups: you can now back up one Umbrel to another over Tailscale. When adding the destination, use its Tailscale IP address shown in the Tailscale app; Tailscale device names are not supported.


### PR DESCRIPTION
Older Tailscale releases defaulted `RouteAll` to `true`. Those prefs can persist across app updates. After moving the Umbrel app to host networking/kernel TUN mode, an accepted subnet route that overlaps the local LAN can route LAN replies through `tailscale0`, making the Umbrel unreachable on its LAN IP.

Disabling accepted routes on startup is a no-op for new installs with current defaults, and migrates older installs away from the risky persisted state. Umbrels can still advertise their own subnet routes; they just will not consume routes advertised by other subnet routers by default.