### PR TITLE
Update hashrate-autopilot to v1.16.0

### DIFF
--- a/hashrate-autopilot/docker-compose.yml
+++ b/hashrate-autopilot/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3010
 
   web:
-    image: ghcr.io/rdouma/hashrate-autopilot:1.15.1@sha256:b2c9f7ea947a387dc89b3d01869b7d238628976eee8a6e5d760aca2d4bb1d68b
+    image: ghcr.io/rdouma/hashrate-autopilot:1.16.0@sha256:d44526468eca52d24ac592869ea552c07f3dbdb7acdc3e44df2ad31518a69a46
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/hashrate-autopilot/umbrel-app.yml
+++ b/hashrate-autopilot/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: hashrate-autopilot
 category: bitcoin
 name: Hashrate Autopilot
-version: "1.15.1"
+version: "1.16.0"
 tagline: Autopilot for renting hashrate to mine on Ocean Mining
 
 description: >-
@@ -71,16 +71,16 @@ defaultPassword: ""
 submitter: Remco Douma
 submission: https://github.com/getumbrel/umbrel-apps/pull/5685
 releaseNotes: >-
-  v1.15.1 - patch release: fixes and polish, no new headline features.
+  v1.16.0 - the Timeline release: one unified event log, alert recoveries, Excel export, and two controller-safety fixes.
 
 
-  Price-chart fixes: the safety-ceiling line is relabeled from "max bid" to "effective cap", and the "max premium over hashprice" knob is now recorded per tick (and backfilled for older history), so changing it moves the line from that point forward instead of rewriting your whole past.
+  New: the former "History" page is rebuilt as **Timeline**, a single chronological feed of everything that happened - bid actions, alert conditions with their durations, on-chain payouts, Braiins deposits, every pool block (yours crowned), difficulty retargets, public-IP changes, config edits, and daemon restarts. Every row opens a detail panel; rows and chart markers jump to each other with a sonar ping. Alert **recoveries** now log as emerald "resolved" rows the moment the condition heals. **Excel export** streams the current filtered Timeline to a formatted .xlsx (frozen header, autofilter, your display units, your language) with no row cap. **Follow (live tail)** pins newest events to the top and polls all sources faster - a live console during an incident. Daemon restarts show on the price chart as an emerald power marker. Timeline columns, detail panels, chart tooltips, decision reasons, and the Excel export are all denomination-aware (sats/BTC/USD, TH/PH/EH).
 
 
-  Other fixes: invalid Bitcoin payout addresses are now rejected at Config and in the first-run wizard, so a typo can't silently credit earnings to nobody. The "Per Day" P&L card no longer sticks on "refreshing...". DATUM stats-API errors now tell you whether the API is behind an auth proxy or its port moved, instead of a cryptic parse error. Electrum host/port help points you to your server's own connection page. The IP-change marker tooltip shows how long ago the address changed. On mobile, the "add tile" control no longer overlaps the time-range buttons, and block-explorer presets set both the block and transaction URL in one click. Ocean payout wording corrected throughout - payouts arrive as batched sweep transactions, not coinbase-direct.
+  Fixes: a transient failure fetching Braiins's bid list could make the autopilot post a duplicate bid - creating now requires a confirmed-successful fetch and an empty local ledger. Stop-spend protection during a DATUM outage now keys on the mandatory stratum probe instead of the optional stats API, so the protection works without the stats API configured and a stats-API blip can no longer cancel healthy bids. Pool-block alerts now report the exact TIDES credit Ocean recorded instead of a ~1%-high estimate. Wallet-runway alert threshold accepts fractional days via env var; BIP 110 block amounts render with fixed 8 decimals; unpaid-line block dots explain the balance step they sit on.
 
 
   Migrating from the community-store version (rdouma-hashrate-autopilot)? One-time five-minute guide: https://github.com/rdouma/hashrate-autopilot/blob/main/docs/migrating-from-community-store.md
 
 
-  Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.15.1
+  Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.16.0


### PR DESCRIPTION
The Timeline release: one unified event log, alert recoveries, Excel export, and two controller-safety fixes.

## Highlights

- The former **History** page is rebuilt as **Timeline**: a single chronological feed of bid actions, alerts, on-chain payouts, Braiins deposits, pool blocks, difficulty retargets, IP changes, config edits, and daemon restarts - every row jumps to the chart and back with a sonar ping.
- **Excel export** streams the current filtered Timeline to a formatted `.xlsx` with no row cap.
- **Follow (live tail)** turns the Timeline into a live incident console.
- Controller-safety fixes: no duplicate bid after a Braiins bid-list fetch hiccup, and stop-spend protection now keys on the mandatory stratum probe instead of the optional stats API.

## Gallery screenshots need refreshing

The dashboard nav item labeled "History" is now "Timeline" (and completely rebuilt). Two of the four currently-live gallery screenshots show the old "History" label - please swap them for the fresh set. The updated, six-screenshot set for this release lives here:

- https://raw.githubusercontent.com/rdouma/hashrate-autopilot/main/rdouma-hashrate-autopilot/1.png
- https://raw.githubusercontent.com/rdouma/hashrate-autopilot/main/rdouma-hashrate-autopilot/2.png
- https://raw.githubusercontent.com/rdouma/hashrate-autopilot/main/rdouma-hashrate-autopilot/3.png
- https://raw.githubusercontent.com/rdouma/hashrate-autopilot/main/rdouma-hashrate-autopilot/4.png
- https://raw.githubusercontent.com/rdouma/hashrate-autopilot/main/rdouma-hashrate-autopilot/5.png
- https://raw.githubusercontent.com/rdouma/hashrate-autopilot/main/rdouma-hashrate-autopilot/6.png

Happy to attach these directly if you would prefer - just let me know the preferred format / count.

Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.16.0
