### PR TITLE
Update Cloudflare Tunnel to 2026.6.1

### DIFF
--- a/cloudflared/docker-compose.yml
+++ b/cloudflared/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       CLOUDFLARED_TOKEN_FILE: "/app/data/token"
 
   connector:
-    image: ghcr.io/radiokot/umbrel-cloudflared-connector:1.0.1-cf.2026.5.2@sha256:8c55565d001fdc9b3c9ad904a11e6ab757a8a4b779331e5f692a4a5067232344
+    image: ghcr.io/radiokot/umbrel-cloudflared-connector:1.0.1-cf.2026.6.1@sha256:a72d52f15f8c9ad7a766140dc574775d2276381e1f4df9495fda038c4d2d2091
     restart: on-failure
     stop_grace_period: 3s
     volumes:

--- a/cloudflared/umbrel-app.yml
+++ b/cloudflared/umbrel-app.yml
@@ -3,7 +3,7 @@ id: cloudflared
 name: Cloudflare Tunnel
 tagline: Access your Umbrel apps from the Internet using Cloudflare network
 category: networking
-version: "2026.5.2"
+version: "2026.6.1"
 port: 4499
 description: >-
   Start a secure tunnel to access your Umbrel apps from the Internet using the Cloudflare network. 
@@ -34,7 +34,7 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  The tunneling daemon (cloudflared) has been updated to 2026.5.2
+  The tunneling daemon (cloudflared) has been updated to 2026.6.1
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
<!--
Title format:
- Add <app name>
- Update <app name> to <version>
- Fix <app name> <issue>
-->

## Type

App update

## App

App ID: cloudflared
Upstream project: https://github.com/cloudflare/cloudflared
Version: 2026.6.1

## Summary

The tunneling daemon (cloudflared) has been updated to 2026.6.1

## Verification

Umbrel testing performed:

Environment tested:
- [ ] Umbrel device
- [x] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64

Known lint warnings or caveats:

None

## Notes

None