### PR TITLE
Remove Oak Node from app store

### DIFF
--- a/oak-node/umbrel-app.yml
+++ b/oak-node/umbrel-app.yml
@@ -1,4 +1,4 @@
-manifestVersion: 1
+manifestVersion: 1.2
 id: oak-node
 category: bitcoin
 name: Oak Node

--- a/oak-node/umbrel-app.yml
+++ b/oak-node/umbrel-app.yml
@@ -5,6 +5,8 @@ name: Oak Node
 version: "0.3.8"
 tagline: Do more with your LND node
 description: >-
+  ⚠️ Removal Notice: The Oak Node project is no longer maintained and is non-functional. For more information, visit the project's repository.
+  
   Oak Node lets you schedule recurring tips to your favorite projects or content creators. All they need is a Lightning Address.
 
 
@@ -33,3 +35,4 @@ defaultUsername: ""
 defaultPassword: ""
 submitter: ok300
 submission: https://github.com/getumbrel/umbrel-apps/pull/60
+disabled: true


### PR DESCRIPTION
The Oak Node project is unmaintained and is now non-functional: https://oak-node.net

This PR:

- adds `disabled: true` to the app manifest which results in Oak Node not being shown in the app store on umbrelOS >= 1.0
- adds a removal notice to the app description so that umbrelOS 0.5 users are aware that it is no longer functional

For the exact PR diff, I took inspiration from similar "app removal" PRs like #1741. Let me know if this is ok or if I missed anything.