### PR TITLE
Update EE Gateway to 0.10.5

### DIFF
--- a/ee-gateway/docker-compose.yml
+++ b/ee-gateway/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   # extra download, and it is the only place root is used. This is NOT privileged
   # mode; the app containers themselves stay non-root.
   init_perms:
-    image: encryptedenergy/ee-gateway-worker:0.7.5@sha256:0b58f6e9e1b0ca5c15150b23ac66958a27fac84db5487581495bf9a0a2c99999
+    image: encryptedenergy/ee-gateway-worker:0.7.6@sha256:b3098383cbdf7be72d4e43e5f4581ae7b5f0ae4d3cb71e6e0136711c54a89df2
     user: "0:0"
     entrypoint: ["sh", "-c", "chown -R 1000:1000 /data"]
     restart: on-failure
@@ -48,7 +48,7 @@ services:
   # Runs as uid 1000 (set in the image). init: true so SIGTERM reaches Flask
   # for a clean shutdown.
   ui:
-    image: encryptedenergy/ee-gateway-ui:0.6.2@sha256:c565138959c1498706d4954521ff7630cb41f8fec4b2ec1ef91e6a2d36f15a4e
+    image: encryptedenergy/ee-gateway-ui:0.6.3@sha256:2a5c2bb43daf5d22ad5f284d4cb6236c89365d83b31848acb8223c724e9bca75
     init: true
     restart: on-failure
     depends_on:
@@ -59,7 +59,7 @@ services:
     environment:
       EE_DATA_DIR: /data
       EE_UI_PORT: 8080
-      EE_GATEWAY_VERSION: "0.10.4"
+      EE_GATEWAY_VERSION: "0.10.5"
 
   # BLE scan + GPS-stamped cloud ingest worker. It reaches the host's
   # Bluetooth radio through bluetoothd over the D-Bus system bus, talks to
@@ -68,7 +68,7 @@ services:
   # Python process runs as uid 1000; gpsd starts as root only to open the
   # serial device, then drops to user nobody.
   worker:
-    image: encryptedenergy/ee-gateway-worker:0.7.5@sha256:0b58f6e9e1b0ca5c15150b23ac66958a27fac84db5487581495bf9a0a2c99999
+    image: encryptedenergy/ee-gateway-worker:0.7.6@sha256:b3098383cbdf7be72d4e43e5f4581ae7b5f0ae4d3cb71e6e0136711c54a89df2
     init: true
     restart: on-failure
     depends_on:

--- a/ee-gateway/umbrel-app.yml
+++ b/ee-gateway/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ee-gateway
 category: networking
 name: EE Gateway
-version: "0.10.4"
+version: "0.10.5"
 tagline: Self-hosted Bluetooth gateway for open BLE networks
 description: >-
   EE Gateway turns your Umbrel into a self-hosted Bluetooth gateway for
@@ -26,7 +26,19 @@ description: >-
   EE Gateway is free and open-source software (GPL-3.0-only), built by
   encryptedenergy.com. It is an independent community project and is not
   affiliated with any specific BLE network.
-releaseNotes: ""
+releaseNotes: >-
+  Fixes the (0.0, 0.0) fixed-location bug. Two coordinated changes:
+  the UI's location form no longer accepts (0, 0) as a valid coordinate
+  pair (they're the classic "unset" tell), and the worker's GpsClient
+  ignores any (0, 0) it finds in config.json and falls back to gpsd.
+  Prevents the failure mode where every packet gets rejected upstream
+  with an opaque HTTP 422.
+
+
+  Also adds EE_GPS_BAUD env var for u-blox M10-based receivers
+  (EVK-M102, NEO-M9N modules) that need a 38400 baud hint to gpsd.
+  Unset by default; standard consumer dongles (BU-353N, VK-172)
+  continue to work with gpsd's auto-probe.
 developer: encryptedenergy.com
 website: https://encryptedenergy.com
 dependencies: []


### PR DESCRIPTION
Fixes the (0.0, 0.0) fixed-location bug and adds EE_GPS_BAUD env var for u-blox M10 receivers.

Full changelog: https://github.com/Encrypted-Energy/gateway/releases/tag/v0.10.5