### PR TITLE
Add Bisq 2 Node

### DIFF
--- a/bisq2-node/docker-compose.yml
+++ b/bisq2-node/docker-compose.yml
@@ -1,0 +1,31 @@
+# Bisq 2 Node — a headless Bisq 2 node (api-app) plus a small nginx web UI that shows node
+# status and a pairing QR code for the Bisq Connect mobile app.
+#
+# The node's API binds 127.0.0.1:8090 (loopback only) for security. The `web` sidecar runs with
+# `network_mode: "service:server"` so it shares the node's network namespace — that lets it read
+# the loopback API for the status check and serve its own :8091. Because `web` has no network
+# identity of its own, `app_proxy` targets the `server` container (which owns the namespace + :8091).
+# Umbrel's authenticated app_proxy is the only ingress; PROXY_AUTH_ADD is intentionally left unset
+# so auth stays ON (the pairing code grants node access, so it must never be exposed unauthenticated).
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: bisq2-node_server_1
+      APP_PORT: 8091
+
+  server:
+    image: ghcr.io/bisq-network/bisq2-api:2.1.11.1@sha256:af77443abc90114b0282d44a1fa5b5f3beeb608b6df76d8674f4366236856154
+    restart: on-failure
+    stop_grace_period: 1m
+    mem_limit: 2g
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+
+  web:
+    image: ghcr.io/bisq-network/bisq2-api-web-ui:2.1.11.1@sha256:0295d45b6dafb3d9bf0d2e6ba74caeb42222e00eb30d9fa847a136a0f358aa23
+    restart: on-failure
+    network_mode: "service:server"
+    volumes:
+      - ${APP_DATA_DIR}/data:/data:ro

--- a/bisq2-node/umbrel-app.yml
+++ b/bisq2-node/umbrel-app.yml
@@ -1,0 +1,32 @@
+manifestVersion: 1
+id: bisq2-node
+category: bitcoin
+name: Bisq 2 Node
+version: "2.1.11.1"
+tagline: Self-hosted Bisq 2 node for the Bisq Connect mobile app
+description: >-
+  Run your own Bisq 2 node so the Bisq Connect mobile app connects to a node you
+  control instead of a stranger's — more privacy, no third-party trust.
+
+
+  The node is headless and reaches the Bisq P2P network over its own bundled Tor.
+  This app gives it a simple browser face: open it to see node status and a pairing
+  QR code, scan it from Bisq Connect, and you're paired.
+
+
+  Heads up: the pairing code grants trade control of your node. Umbrel's
+  authenticated app proxy is what protects it — never expose this app to an
+  untrusted network.
+developer: Bisq
+website: https://bisq.network
+dependencies: []
+repo: https://github.com/bisq-network/bisq2
+support: https://github.com/bisq-network/bisq-mobile/issues
+port: 8390
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: rodvar
+submission: https://github.com/getumbrel/umbrel-apps/pull/0000
+releaseNotes: ""

--- a/bisq2-node/umbrel-app.yml
+++ b/bisq2-node/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bisq2-node
 category: bitcoin
 name: Bisq 2 Node
 version: "2.1.11.1"
-tagline: Self-hosted Bisq 2 node for the Bisq Connect mobile app
+tagline: Run your own Bisq 2 node for private Bitcoin trading
 description: >-
   Run your own Bisq 2 node so the Bisq Connect mobile app connects to a node you
   control instead of a stranger's — more privacy, no third-party trust.

--- a/bisq2-node/umbrel-app.yml
+++ b/bisq2-node/umbrel-app.yml
@@ -28,5 +28,5 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: rodvar
-submission: https://github.com/getumbrel/umbrel-apps/pull/0000
+submission: https://github.com/getumbrel/umbrel-apps/pull/5850
 releaseNotes: ""

--- a/bisq2-node/umbrel-app.yml
+++ b/bisq2-node/umbrel-app.yml
@@ -5,18 +5,20 @@ name: Bisq 2 Node
 version: "2.1.11.1"
 tagline: Run your own Bisq 2 node for private Bitcoin trading
 description: >-
-  Run your own Bisq 2 node so the Bisq Connect mobile app connects to a node you
-  control instead of a stranger's — more privacy, no third-party trust.
+  Bisq Connect lets you buy and sell Bitcoin peer-to-peer from your phone. This
+  app runs a Bisq 2 node for Bisq Connect, allowing your phone to connect through
+  a node you control instead of relying on someone else's.
 
 
-  The node is headless and reaches the Bisq P2P network over its own bundled Tor.
-  This app gives it a simple browser face: open it to see node status and a pairing
-  QR code, scan it from Bisq Connect, and you're paired.
+  The node joins the Bisq P2P network over its bundled Tor connection. Open this
+  app to check its status and scan the pairing QR code with Bisq Connect.
 
 
-  Heads up: the pairing code grants trade control of your node. Umbrel's
-  authenticated app proxy is what protects it — never expose this app to an
-  untrusted network.
+  This is not a Bitcoin full node and does not download the Bitcoin blockchain.
+
+
+  Treat the pairing code like a password. Anyone who has it can pair with your
+  node and control trades.
 developer: Bisq
 website: https://bisq.network
 dependencies: []

--- a/bisq2-node/umbrel-app.yml
+++ b/bisq2-node/umbrel-app.yml
@@ -25,7 +25,10 @@ dependencies: []
 repo: https://github.com/bisq-network/bisq2
 support: https://github.com/bisq-network/bisq-mobile/issues
 port: 8390
-gallery: []
+gallery:
+  - 1.webp
+  - 2.webp
+  - 3.webp
 path: ""
 defaultUsername: ""
 defaultPassword: ""


### PR DESCRIPTION
## Type

- [x] New app

## App

- **App ID:** `bisq2-node`
- **Upstream project:** Bisq 2 — https://github.com/bisq-network/bisq2
- **Version:** 2.1.11.1

## Summary

Bisq 2 Node lets a user self-host a Bisq 2 node so the **Bisq Connect** mobile app pairs with a
node they control instead of a stranger's — more privacy, no third-party trust. The node is
headless and reaches the Bisq P2P network over its own bundled Tor; the app opens to a small nginx
web UI showing node status and a **pairing QR code** to scan from Bisq Connect.

Images are public, multi-arch (amd64 + arm64), and built from https://github.com/bisq-network/bisq2
via the bisq-network/bisq-mobile release CI. Already live and validated in the bisq-network
community app store: https://github.com/bisq-network/bisq2-umbrel

## Verification

**Environment tested**
- [x] Real Umbrel device (Umbrel Home, amd64) — installed, opened the web UI, and **paired a real phone over Tor** end-to-end
- [ ] Local umbrelOS

**Architecture tested**
- [x] amd64 (tested on real hardware)
- [ ] arm64 — image is published multi-arch (verified) but not runtime-tested by me

## Notes

- **`network_mode: "service:server"` (unusual — flagging proactively):** the node's API binds
  `127.0.0.1:8090` (loopback only) for security. The `web` sidecar shares the node's network
  namespace so it can read that loopback API for the status check and serve its own `:8091`.
  Because `web` has no network identity of its own, `app_proxy` targets the `server` container.
- **Auth stays ON:** `PROXY_AUTH_ADD` is intentionally unset (defaults on). The pairing code grants
  trade control of the node, so it must never be reachable unauthenticated — Umbrel's app_proxy is
  the security boundary.
- **Tor is bundled inside the node image** (for the node's own P2P + the pairing onion), rather than
  a separate `getumbrel/tor` sidecar. Happy to switch to the sidecar pattern if you'd prefer.
- **Non-root:** the node image starts as root only to `chown` the mounted `/data`, then drops to
  uid 999 via `setpriv` before running the node.
- **Persistence:** all state under `${APP_DATA_DIR}/data`. No host ports published, no Docker socket,
  no privileged/host-network access.
- **Default credentials:** none — the app has no login of its own (Umbrel auth fronts it).

## Screenshots

### Logo

<img width="256" height="256" alt="logo-256" src="https://github.com/user-attachments/assets/6485f522-50cf-4d9d-b98f-491d837d14f4" />

### Web UI

<img width="2880" height="1800" alt="1" src="https://github.com/user-attachments/assets/43072792-5a91-4f3e-8b1b-8780bb248b09" />
<img width="2880" height="1800" alt="3" src="https://github.com/user-attachments/assets/93bb767a-2b27-43a0-9f39-02a41e1d35a4" />
<img width="2880" height="1800" alt="2" src="https://github.com/user-attachments/assets/a1cb4de4-ea6c-431f-81e3-cc1f35fb50fa" />
<img width="2880" height="1800" alt="4" src="https://github.com/user-attachments/assets/c5816c2f-b70b-48db-90af-700102113199" />

