### PR TITLE
Add Lively

### DIFF
--- a/lively/docker-compose.yml
+++ b/lively/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: lively_web_1
+      APP_PORT: 8080
+      # v1.1 (external WS clients): PROXY_AUTH_WHITELIST: "/rooms/*"
+
+  web:
+    image: ghcr.io/ryanwaits/lively:0.1.0@sha256:72bfc538a9a13834da6cc33444661f98ecbee1bde756b6d5f68ab91646c139f4
+    restart: on-failure
+    stop_grace_period: 30s
+    user: "1000:1000"
+    environment:
+      PORT: 8080
+      DATA_DIR: /data
+    volumes:
+      - ${APP_DATA_DIR}/data:/data

--- a/lively/docker-compose.yml
+++ b/lively/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       # v1.1 (external WS clients): PROXY_AUTH_WHITELIST: "/rooms/*"
 
   web:
-    image: ghcr.io/ryanwaits/lively:0.1.1@sha256:4480667080b5b6da22e57a94a17efacd2a6fc17750dc94a6b2b9b08e00569aa4
+    image: ghcr.io/ryanwaits/lively:0.2.0@sha256:bbd7a5f3c664c7507ac794f1a4f2fdd5b739775ed81982a3abd8d4f3196c487b
     restart: on-failure
     stop_grace_period: 30s
     user: "1000:1000"

--- a/lively/docker-compose.yml
+++ b/lively/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       # v1.1 (external WS clients): PROXY_AUTH_WHITELIST: "/rooms/*"
 
   web:
-    image: ghcr.io/ryanwaits/lively:0.1.0@sha256:72bfc538a9a13834da6cc33444661f98ecbee1bde756b6d5f68ab91646c139f4
+    image: ghcr.io/ryanwaits/lively:0.1.1@sha256:4480667080b5b6da22e57a94a17efacd2a6fc17750dc94a6b2b9b08e00569aa4
     restart: on-failure
     stop_grace_period: 30s
     user: "1000:1000"

--- a/lively/umbrel-app.yml
+++ b/lively/umbrel-app.yml
@@ -1,0 +1,26 @@
+manifestVersion: 1
+id: lively
+category: files
+name: Lively
+version: "0.1.0"
+tagline: Self-hosted realtime collaboration — whiteboard, Notion-style docs, markdown, and todos
+description: >-
+  Lively is an open-source realtime collaboration framework — a self-hosted
+  alternative to Liveblocks. This app bundles four collaborative tools that run
+  entirely on your Umbrel: a shared whiteboard, a Notion-style block editor, a
+  live markdown editor, and a shared todo list. Live cursors, presence,
+  undo/redo, and conflict-free editing (CRDTs) — no accounts, no cloud, your
+  data stays home.
+releaseNotes: ""
+developer: Ryan Waits
+website: https://github.com/ryanwaits/lively
+dependencies: []
+repo: https://github.com/ryanwaits/lively
+support: https://github.com/ryanwaits/lively/issues
+port: 8401
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: Ryan Waits
+submission: https://github.com/getumbrel/umbrel-apps/pull/TBD

--- a/lively/umbrel-app.yml
+++ b/lively/umbrel-app.yml
@@ -23,4 +23,4 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: Ryan Waits
-submission: https://github.com/getumbrel/umbrel-apps/pull/TBD
+submission: https://github.com/getumbrel/umbrel-apps/pull/5852

--- a/lively/umbrel-app.yml
+++ b/lively/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lively
 category: files
 name: Lively
-version: "0.1.1"
+version: "0.2.0"
 tagline: Self-hosted realtime collaboration — whiteboard, Notion-style docs, markdown, and todos
 description: >-
   Lively is an open-source realtime collaboration framework — a self-hosted

--- a/lively/umbrel-app.yml
+++ b/lively/umbrel-app.yml
@@ -11,11 +11,7 @@ description: >-
   live markdown editor, and a shared todo list. Live cursors, presence,
   undo/redo, and conflict-free editing (CRDTs) — no accounts, no cloud, your
   data stays home.
-releaseNotes: >-
-  Fixes a Todo app sync bug where changes to existing tasks (completing,
-  editing) made after a page refresh or reconnect neither synced to other
-  sessions nor persisted. The amd64 image now ships Bun's baseline build,
-  removing the AVX2 CPU requirement.
+releaseNotes: ""
 developer: Ryan Waits
 website: https://github.com/ryanwaits/lively
 dependencies: []

--- a/lively/umbrel-app.yml
+++ b/lively/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lively
 category: files
 name: Lively
-version: "0.1.0"
+version: "0.1.1"
 tagline: Self-hosted realtime collaboration — whiteboard, Notion-style docs, markdown, and todos
 description: >-
   Lively is an open-source realtime collaboration framework — a self-hosted

--- a/lively/umbrel-app.yml
+++ b/lively/umbrel-app.yml
@@ -11,7 +11,11 @@ description: >-
   live markdown editor, and a shared todo list. Live cursors, presence,
   undo/redo, and conflict-free editing (CRDTs) — no accounts, no cloud, your
   data stays home.
-releaseNotes: ""
+releaseNotes: >-
+  Fixes a Todo app sync bug where changes to existing tasks (completing,
+  editing) made after a page refresh or reconnect neither synced to other
+  sessions nor persisted. The amd64 image now ships Bun's baseline build,
+  removing the AVX2 CPU requirement.
 developer: Ryan Waits
 website: https://github.com/ryanwaits/lively
 dependencies: []


### PR DESCRIPTION
## Type

New app

## App

- **App ID:** `lively`
- **Upstream project:** https://github.com/ryanwaits/lively
- **Version:** `0.1.1`

## Summary

I built Lively because I wanted a shared whiteboard and a place to keep notes and
todos that lived on my own hardware, instead of reaching for another SaaS account
every time. It started as a small open-source realtime-collaboration framework — a
self-hosted alternative to Liveblocks — and Umbrel felt like the natural home for
it.

This app bundles four tools built on that framework into a single container: a
shared whiteboard, a Notion-style block editor, a live markdown editor, and a
shared todo list. Live cursors, presence, undo/redo, and conflict-free (CRDT)
editing. No accounts, no cloud, no third-party API calls — everything runs on the
Umbrel and all data stays under `${APP_DATA_DIR}/data`.

**How it's built:** one container, one service. A single Bun server handles the
WebSocket rooms (`/rooms/*`), a small JSON API (`/api/boards`, `/api/config`) and
`/health`, and serves the four apps as static Next.js exports plus a landing page.
Persistence is plain files on the `/data` volume (JSON snapshots + binary Yjs) —
no database, no sidecar. The web UI is only ever exposed through `app_proxy`.

**Access:** works on your LAN or over Tailscale; v1 rides Umbrel's own auth, so
collaboration is among people who share access to the Umbrel. The full
access-model and roadmap (including scoped room tokens to invite guests without
sharing your login) is in the project README.

- **Image:** `ghcr.io/ryanwaits/lively:0.1.0@sha256:72bfc538a9a13834da6cc33444661f98ecbee1bde756b6d5f68ab91646c139f4`
  — multi-arch (linux/amd64 + linux/arm64), public on GHCR, built in CI from the
  tagged release.

## Verification

**Umbrel testing performed:** Installed on a real umbrelOS 1.7.3 instance from a
local app store. Verified: the app opens through `app_proxy` behind Umbrel auth,
all four apps load, real-time WebSocket collaboration works across two browsers,
data persists to the `/data` volume and **survives a reboot** (room files came
back byte-identical), and **uninstall is clean** (no orphaned containers or data).
Separately load-tested the WebSocket path against the real `getumbrel/app-proxy`
image: a fully idle socket held open for 150s (3× the client heartbeat) without
being dropped.

**Environment tested:**
- [ ] Umbrel device
- [x] Local umbrelOS test environment
- [ ] Not runtime tested

**Architecture tested:**
- [x] amd64
- [ ] arm64

_arm64 was not tested on a device; the arm64 image is built by the same CI
pipeline from the same commit and was smoke-tested natively (server boot + full
collaboration + reboot persistence) on Apple Silicon, but I don't have an arm64
Umbrel to confirm on-device._

**Known lint warnings or caveats:**
- `npm run lint:apps -- lively --check-images` passes clean.
- The bundled Bun runtime needs AVX2. On real amd64/arm64 hardware it runs
  natively; only under pure CPU *emulation* did the test VM need `-cpu max` to
  expose it. Bun ships a baseline (non-AVX2) build if an ancient CPU ever needs
  it — happy to switch the base image if you'd prefer maximum compatibility.
- The multi-arch manifest includes a buildx provenance-attestation entry (shows
  as `unknown/unknown`). I can re-release with `provenance: false` if you'd rather
  it not be there.

## Notes

- **Permissions / dependencies:** none. `dependencies: []`, no privileged access,
  no Docker socket, no host network. Runs as `user: "1000:1000"`.
- **Default credentials:** none — there are no app-level accounts; access is
  gated by Umbrel's own auth.
- **Data:** single bind-mount at `${APP_DATA_DIR}/data`; `stop_grace_period: 30s`
  lets the server flush pending writes on shutdown.
- **Privacy:** no runtime CDN calls — fonts and JS are self-hosted/vendored
  (verified by grepping the built static output). No telemetry, no external API
  calls.
- **Assets:** `gallery: []` in the manifest — happy for the Umbrel team to
  produce the final store assets. A 256×256 SVG icon and gallery screenshots of
  all four apps are attached to this PR.

## Screenshots & icon

**Icon** (256×256 SVG): [`icon.svg`](https://raw.githubusercontent.com/ryanwaits/lively/main/apps/umbrel/store/icon.svg) — happy for the Umbrel team to produce the final store assets.

**Whiteboard** — infinite canvas, sticky notes, live cursors & presence
![Whiteboard](https://raw.githubusercontent.com/ryanwaits/lively/main/apps/umbrel/store/gallery/gallery-whiteboard.png)

**Notes** — Notion-style block editor
![Notes](https://raw.githubusercontent.com/ryanwaits/lively/main/apps/umbrel/store/gallery/gallery-notes.png)

**Markdown** — collaborative markdown editor
![Markdown](https://raw.githubusercontent.com/ryanwaits/lively/main/apps/umbrel/store/gallery/gallery-markdown.png)

**Todo** — shared realtime todo list
![Todo](https://raw.githubusercontent.com/ryanwaits/lively/main/apps/umbrel/store/gallery/gallery-todo.png)

