### PR TITLE
Add GlassHome

### DIFF
--- a/glasshome/docker-compose.yml
+++ b/glasshome/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   app_proxy:
     environment:

--- a/glasshome/docker-compose.yml
+++ b/glasshome/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: glasshome_server_1
+      APP_PORT: 3123
+      # GlassHome has its own account system, and its companion mobile apps
+      # pair with the server over the same origin without Umbrel auth cookies.
+      PROXY_AUTH_ADD: "false"
+
+  server:
+    image: ghcr.io/glasshome/dash:1.0.0-beta.10@sha256:cfa093010261a464db246964451fbd04d4f5bdff4004c41f83ccb046bb5e4567
+    restart: on-failure
+    environment:
+      PORT: 3123
+      DATA_DIR: /data
+    volumes:
+      - ${APP_DATA_DIR}/data:/data

--- a/glasshome/docker-compose.yml
+++ b/glasshome/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     environment:
       APP_HOST: glasshome_server_1
       APP_PORT: 3123
-      # GlassHome has its own auth (Home Assistant OAuth pairing), and its
-      # add-device flow opens the app on devices with no Umbrel session.
+      # GlassHome has its own authenticated device sessions, and its new-device
+      # pairing flow must work on devices that do not have an Umbrel session.
       PROXY_AUTH_ADD: "false"
 
   server:

--- a/glasshome/docker-compose.yml
+++ b/glasshome/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     environment:
       APP_HOST: glasshome_server_1
       APP_PORT: 3123
-      # GlassHome has its own account system, and its companion mobile apps
-      # pair with the server over the same origin without Umbrel auth cookies.
+      # GlassHome has its own auth (Home Assistant OAuth pairing), and its
+      # add-device flow opens the app on devices with no Umbrel session.
       PROXY_AUTH_ADD: "false"
 
   server:

--- a/glasshome/docker-compose.yml
+++ b/glasshome/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: ghcr.io/glasshome/dash:1.0.0-beta.10@sha256:cfa093010261a464db246964451fbd04d4f5bdff4004c41f83ccb046bb5e4567
+    image: ghcr.io/glasshome/dash:1.0.0@sha256:a00a5537447b1df187d6516a722de7913ca2514a5610d4a825010df09777663a
     restart: on-failure
     environment:
       PORT: 3123

--- a/glasshome/umbrel-app.yml
+++ b/glasshome/umbrel-app.yml
@@ -5,14 +5,6 @@ name: GlassHome
 version: "1.0.0-beta.10"
 tagline: A beautiful, local-first dashboard for Home Assistant
 description: >-
-  Note: GlassHome requires a Home Assistant instance it can reach on your
-  network. You can install the Home Assistant app on your Umbrel, or connect to
-  an existing Home Assistant server. On first launch a setup wizard connects
-  GlassHome to Home Assistant: paste your Home Assistant address and authorize
-  in the Home Assistant popup. A demo mode with simulated entities lets you
-  explore before connecting.
-
-
   GlassHome is a local-first dashboard for Home Assistant that you design by
   dragging and dropping widgets in the UI, with no YAML. It talks to Home
   Assistant directly on your network over WebSocket; your entity data, Home
@@ -31,6 +23,14 @@ description: >-
   prompt (requires the one-time GlassHome Pro purchase)
 
   - All data stays on your device in a local SQLite database
+
+
+  GlassHome requires a Home Assistant instance it can reach on your network. You
+  can install the Home Assistant app on your Umbrel, or connect to an existing
+  Home Assistant server. On first launch a setup wizard connects GlassHome to
+  Home Assistant: paste your Home Assistant address and authorize in the Home
+  Assistant popup. A demo mode with simulated entities lets you explore before
+  connecting.
 releaseNotes: ""
 developer: GlassHome
 website: https://glasshome.app

--- a/glasshome/umbrel-app.yml
+++ b/glasshome/umbrel-app.yml
@@ -1,0 +1,47 @@
+manifestVersion: 1
+id: glasshome
+category: automation
+name: GlassHome
+version: "1.0.0-beta.10"
+tagline: A beautiful, local-first dashboard for Home Assistant
+description: >-
+  Note: GlassHome requires a Home Assistant instance it can reach on your
+  network. You can install the Home Assistant app on your Umbrel, or connect to
+  an existing Home Assistant server. On first launch you create your GlassHome
+  account and enter your Home Assistant address.
+
+
+  GlassHome is a modern dashboard for Home Assistant that you design by
+  dragging and dropping widgets, with no YAML and no configuration files. It
+  connects directly to Home Assistant over WebSocket and runs entirely on your
+  own hardware: no cloud relay, no telemetry.
+
+
+  Highlights:
+
+  - Drag-and-drop dashboard editor with widgets for lights, climate, media,
+  sensors, cameras, and more
+
+  - Area-based dashboards that mirror the rooms in your home
+
+  - Seven built-in themes, each with light and dark modes
+
+  - Community widgets from the GlassHome Hub, sandboxed with a per-widget
+  permission model
+
+  - Companion mobile apps that pair with your server by scanning a QR code
+
+  - All data stays on your device in a local SQLite database
+releaseNotes: ""
+developer: GlassHome
+website: https://glasshome.app
+dependencies: []
+repo: https://github.com/glasshome/dash
+support: https://discord.gg/FJYdeDmrzv
+port: 3123
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: Ihsen Bouallegue
+submission: https://github.com/getumbrel/umbrel-apps/pull/TBD

--- a/glasshome/umbrel-app.yml
+++ b/glasshome/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: glasshome
 category: automation
 name: GlassHome
-version: "1.0.0-beta.10"
+version: "1.0.0"
 tagline: A beautiful, local-first dashboard for Home Assistant
 description: >-
   GlassHome is a local-first dashboard for Home Assistant that you design by

--- a/glasshome/umbrel-app.yml
+++ b/glasshome/umbrel-app.yml
@@ -39,7 +39,10 @@ dependencies: []
 repo: https://github.com/glasshome/homeassistant-addon
 support: https://discord.gg/FJYdeDmrzv
 port: 3123
-gallery: []
+gallery:
+  - 1.webp
+  - 2.webp
+  - 3.webp
 path: ""
 defaultUsername: ""
 defaultPassword: ""

--- a/glasshome/umbrel-app.yml
+++ b/glasshome/umbrel-app.yml
@@ -7,36 +7,35 @@ tagline: A beautiful, local-first dashboard for Home Assistant
 description: >-
   Note: GlassHome requires a Home Assistant instance it can reach on your
   network. You can install the Home Assistant app on your Umbrel, or connect to
-  an existing Home Assistant server. On first launch you create your GlassHome
-  account and enter your Home Assistant address.
+  an existing Home Assistant server. On first launch a setup wizard connects
+  GlassHome to Home Assistant: paste your Home Assistant address and authorize
+  in the Home Assistant popup. A demo mode with simulated entities lets you
+  explore before connecting.
 
 
-  GlassHome is a modern dashboard for Home Assistant that you design by
-  dragging and dropping widgets, with no YAML and no configuration files. It
-  connects directly to Home Assistant over WebSocket and runs entirely on your
-  own hardware: no cloud relay, no telemetry.
+  GlassHome is a local-first dashboard for Home Assistant that you design by
+  dragging and dropping widgets in the UI, with no YAML. It talks to Home
+  Assistant directly on your network over WebSocket; your entity data, Home
+  Assistant address, and auth token never leave your network.
 
 
   Highlights:
 
-  - Drag-and-drop dashboard editor with widgets for lights, climate, media,
-  sensors, cameras, and more
+  - Drag-and-drop dashboard editor
 
   - Area-based dashboards that mirror the rooms in your home
 
-  - Seven built-in themes, each with light and dark modes
+  - Seven theme presets, each with light and dark modes
 
-  - Community widgets from the GlassHome Hub, sandboxed with a per-widget
-  permission model
-
-  - Companion mobile apps that pair with your server by scanning a QR code
+  - Community widgets from the GlassHome Hub, gated by a per-widget permission
+  prompt (requires the one-time GlassHome Pro purchase)
 
   - All data stays on your device in a local SQLite database
 releaseNotes: ""
 developer: GlassHome
 website: https://glasshome.app
 dependencies: []
-repo: https://github.com/glasshome/dash
+repo: https://github.com/glasshome/homeassistant-addon
 support: https://discord.gg/FJYdeDmrzv
 port: 3123
 gallery: []

--- a/glasshome/umbrel-app.yml
+++ b/glasshome/umbrel-app.yml
@@ -44,4 +44,4 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: Ihsen Bouallegue
-submission: https://github.com/getumbrel/umbrel-apps/pull/TBD
+submission: https://github.com/getumbrel/umbrel-apps/pull/5853

--- a/glasshome/umbrel-app.yml
+++ b/glasshome/umbrel-app.yml
@@ -25,11 +25,12 @@ description: >-
   - All data stays on your device in a local SQLite database
 
 
-  GlassHome requires a Home Assistant instance it can reach on your network. You
-  can install the Home Assistant app on your Umbrel, or connect to an existing
-  Home Assistant server. On first launch a setup wizard connects GlassHome to
-  Home Assistant: paste your Home Assistant address and authorize in the Home
-  Assistant popup. A demo mode with simulated entities lets you explore before
+  GlassHome requires a reachable Home Assistant instance. If Home Assistant is
+  installed on this Umbrel, enter the Umbrel's LAN address with port 8123, for
+  example `http://192.168.1.50:8123`. For Home Assistant running elsewhere,
+  enter its LAN or HTTPS address. The address must also open in the browser you
+  use to complete setup. GlassHome will then guide you through Home Assistant
+  authorization. A demo mode with simulated entities lets you explore before
   connecting.
 releaseNotes: ""
 developer: GlassHome


### PR DESCRIPTION
# Add GlassHome

## App

- **App**: GlassHome, version `1.0.0`
- **Upstream**: https://glasshome.app (docs: https://glasshome.app/docs, public install repo: https://github.com/glasshome/homeassistant-addon)
- **What it is**: A local-first dashboard for Home Assistant, designed in the UI by dragging and dropping widgets (no YAML). It talks to Home Assistant directly on the LAN over WebSocket; entity data, the HA address, and the auth token never leave the network. Area-based dashboards, seven theme presets with light and dark modes, and community widgets from the GlassHome Hub (Pro).
- **Image**: `ghcr.io/glasshome/dash:1.0.0-beta.10@sha256:a00a5537447b1df187d6516a722de7913ca2514a5610d4a825010df09777663a` (multi-arch index digest, `linux/amd64` + `linux/arm64`, publicly pullable). Same image used by the Home Assistant add-on and the documented Docker install (https://glasshome.app/docs/docker). The application source repo is currently private; the image is built and published by its release CI, and I am the upstream developer.
- **Version note**: upstream is in a public beta series; `1.0.0-beta.10` is the current release and the tag the upstream Docker docs point users at. I will keep the package updated as releases ship.

## Package notes

- Single `server` service behind `app_proxy` (internal port 3123, manifest port 3123).
- `PROXY_AUTH_ADD: "false"`: GlassHome has its own authentication (pairing with Home Assistant via OAuth), and its add-device flow opens the app on new devices that have no Umbrel session, which Umbrel proxy auth would block.
- Persistence: SQLite database and all app state live in `/data`, bind-mounted from `${APP_DATA_DIR}/data`.
- No host access: no privileged mode, no host networking, no device mounts, no Docker socket, no extra capabilities, no permissions.
- No default credentials. First launch opens a setup wizard: paste the Home Assistant address and authorize via the Home Assistant OAuth popup. A demo mode with simulated entities works without a Home Assistant connection.
- Requires a reachable Home Assistant instance for real use (the Umbrel Home Assistant app or any other install). Not declared as a manifest dependency since HA commonly runs on separate hardware.
- No `dependencies`, `exports.sh`, hooks, templates, or widgets.

## Testing

- `npm run lint:apps -- glasshome --check-images`: no issues.
- `git diff --check`: clean.
- Runtime, fresh install through umbrelOS: containerized umbrelOS `1.7.3` (`ghcr.io/getumbrel/umbrelos:1.7.3`, privileged container), architecture `amd64`.
  - Installed through `umbreld` from a synced app-store source; app reached `ready`.
  - Opened the app through the `app_proxy` route; the web UI loads.
  - Created a session through the app's auth API on the app route and verified it.
  - Restarted the app through Umbrel; session persisted, SQLite data present under `${APP_DATA_DIR}/data`.
  - Container logs clean: production hardening active (`NODE_ENV=production`, CSP locked), server bound on the internal port.
- Testing caveat: the test host already used port 3123, so the runtime test ran with manifest `port: 3124`; everything else was identical to this package. 3123 has no conflict in the App Store per the linter.
- Not runtime-tested: `arm64` (multi-arch manifest verified; the same image ships to Raspberry Pi and other aarch64 users via the Home Assistant add-on and Docker installs) and the live Home Assistant OAuth pairing (needs an HA instance; it is upstream's standard onboarding flow).

## Assets

- Icon (logo on brand background, 1024x1024): https://glasshome.app/assets/glasshome_logo_tile.png
- Flat logo: https://glasshome.app/assets/glasshome_logo.png
- Gallery images (2880x1800 JPG):
  - https://glasshome.app/assets/promo/hero.jpg
  - https://glasshome.app/assets/promo/themes.jpg
  - https://glasshome.app/assets/promo/local-first.jpg
- Raw theme screenshots, if preferred: https://glasshome.app/assets/screenshots/ (e.g. home-midnight-glass-dark-desktop.webp)
