### PR TITLE
Update Hashrate Autopilot to 1.17.0

### DIFF
--- a/hashrate-autopilot/docker-compose.yml
+++ b/hashrate-autopilot/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3010
 
   web:
-    image: ghcr.io/rdouma/hashrate-autopilot:1.16.0@sha256:d44526468eca52d24ac592869ea552c07f3dbdb7acdc3e44df2ad31518a69a46
+    image: ghcr.io/rdouma/hashrate-autopilot:1.17.0@sha256:8f952ab293975694b2c8169b7c5db18d0bc32636336d884712f3d89753bc665a
     restart: on-failure
     stop_grace_period: 1m
     volumes:
@@ -25,3 +25,9 @@ services:
       BHA_ELECTRS_HOST: "$APP_ELECTRS_NODE_IP"
       BHA_ELECTRS_PORT: "$APP_ELECTRS_NODE_PORT"
       BHA_PAYOUT_SOURCE: "electrs"
+      # At-rest encryption key for DB-stored secrets (#331). APP_SEED is
+      # the device-derived per-app secret Umbrel injects; it lives outside
+      # this app's data folder, so an app-data backup never carries the
+      # key. If unset the daemon would fall back to a keyfile next to the
+      # database (still encrypted, but inside app-data).
+      BHA_SECRET_KEY: "${APP_SEED}"

--- a/hashrate-autopilot/umbrel-app.yml
+++ b/hashrate-autopilot/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: hashrate-autopilot
 category: bitcoin
 name: Hashrate Autopilot
-version: "1.16.0"
+version: "1.17.0"
 tagline: Autopilot for renting hashrate to mine on Ocean Mining
 
 description: >-
@@ -71,16 +71,16 @@ defaultPassword: ""
 submitter: Remco Douma
 submission: https://github.com/getumbrel/umbrel-apps/pull/5685
 releaseNotes: >-
-  v1.16.0 - the Timeline release: one unified event log, alert recoveries, Excel export, and two controller-safety fixes.
+  v1.17.0 - the security release: your secrets are now encrypted at rest, you can change your password and rotate tokens in-app, and Profit & Loss counts Lightning payouts.
 
 
-  New: the former "History" page is rebuilt as **Timeline**, a single chronological feed of everything that happened - bid actions, alert conditions with their durations, on-chain payouts, Braiins deposits, every pool block (yours crowned), difficulty retargets, public-IP changes, config edits, and daemon restarts. Every row opens a detail panel; rows and chart markers jump to each other with a sonar ping. Alert **recoveries** now log as emerald "resolved" rows the moment the condition heals. **Excel export** streams the current filtered Timeline to a formatted .xlsx (frozen header, autofilter, your display units, your language) with no row cap. **Follow (live tail)** pins newest events to the top and polls all sources faster - a live console during an incident. Daemon restarts show on the price chart as an emerald power marker. Timeline columns, detail panels, chart tooltips, decision reasons, and the Excel export are all denomination-aware (sats/BTC/USD, TH/PH/EH).
+  Security: your Braiins tokens, bitcoind RPC password, Telegram token, and DDNS credential are now AES-256-GCM encrypted in the database instead of plaintext, and your dashboard password is stored as a one-way hash. A copied database or a backup no longer hands over your secrets. The config-change history no longer records credential values, and any previously logged are scrubbed on upgrade. Existing installs encrypt themselves on the first start of this version; there is nothing for you to do. This protects the data-leaves-the-box cases; by design it cannot protect against someone who already controls the machine.
 
 
-  Fixes: a transient failure fetching Braiins's bid list could make the autopilot post a duplicate bid - creating now requires a confirmed-successful fetch and an empty local ledger. Stop-spend protection during a DATUM outage now keys on the mandatory stratum probe instead of the optional stats API, so the protection works without the stats API configured and a stats-API blip can no longer cancel healthy bids. Pool-block alerts now report the exact TIDES credit Ocean recorded instead of a ~1%-high estimate. Wallet-runway alert threshold accepts fractional days via env var; BIP 110 block amounts render with fixed 8 decimals; unpaid-line block dots explain the balance step they sit on.
+  New: change your dashboard password and rotate your Braiins owner and read-only tokens right from Config, Pool & Payout, Security & credentials. The password change is instant, and a new token is checked against Braiins before it is saved so a typo cannot break bidding. Profit & Loss now reads "collected" from Ocean's own payout ledger, so both on-chain and Lightning payouts count, split by rail, and a payout you have already spent still shows up - no Bitcoin node required for that number anymore.
 
 
   Migrating from the community-store version (rdouma-hashrate-autopilot)? One-time five-minute guide: https://github.com/rdouma/hashrate-autopilot/blob/main/docs/migrating-from-community-store.md
 
 
-  Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.16.0
+  Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.17.0


### PR DESCRIPTION
## Type

App update

## App

App ID: hashrate-autopilot
Upstream project: https://github.com/rdouma/hashrate-autopilot
Version: 1.17.0

## Summary

Security release. Credentials the app stores in its SQLite database (Braiins API tokens, bitcoind RPC password, Telegram token, DDNS credential) are now AES-256-GCM encrypted at rest instead of plaintext, and the dashboard password is stored as a one-way scrypt hash. The config-change audit log no longer records credential values (and scrubs any previously logged on upgrade). Users can now change the dashboard password and rotate their Braiins tokens from the dashboard itself, and Profit & Loss counts Lightning payouts via Ocean's earnpay ledger. Existing installs upgrade their stored data in place on first start.

This bump also adds `BHA_SECRET_KEY: "${APP_SEED}"` to the compose so the at-rest encryption key is the device-derived per-app secret, which lives outside the app's data directory. Without it the app falls back to a keyfile next to the database (still encrypted, but inside app-data); using `APP_SEED` keeps an app-data backup from ever carrying the key.

Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.17.0

## Verification

Umbrel testing performed: installed 1.17.0 as an in-place update over the prior version on a real Umbrel device and verified the new in-app password change end to end. The image is pinned by digest.

Environment tested:
- [x] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [ ] amd64
- [ ] arm64

The runtime test above was on the maintainer's own Umbrel device (its native architecture). The published multi-arch image is built and CI-verified for both amd64 and arm64; the digest pinned here is the multi-arch index.

Known lint warnings or caveats: none.

## Notes

- New env var: `BHA_SECRET_KEY: "${APP_SEED}"` (rationale in Summary).
- No new dependencies, no default credentials, no port change (still 3018 / internal 3010).
- Migration: on first start the app transparently encrypts its existing plaintext secrets and hashes the stored password. If the key is ever unavailable it treats the affected secret as unset and prompts re-entry rather than failing to boot.
