### PR TITLE
Update app Tor sidecars to 0.4.9.11 for all affected apps

### DIFF
--- a/bitcoin-knots/docker-compose.yml
+++ b/bitcoin-knots/docker-compose.yml
@@ -59,7 +59,7 @@ services:
         ipv4_address: $APP_BITCOIN_KNOTS_NODE_IP
 
   tor:
-    image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/bitcoin-knots/umbrel-app.yml
+++ b/bitcoin-knots/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - bitcoin
 category: bitcoin
 name: Bitcoin Knots
-version: "1.2.12-1"
+version: "1.2.12-patch.1"
 tagline: Run your personal node powered by Bitcoin Knots
 description: >-
   Take control of your digital sovereignty by choosing Bitcoin Knots to run your node! By using Knots, you’re supporting a version of Bitcoin that prioritizes efficiency, security, and flexibility. With Bitcoin Knots’ enhanced configuration options, you can fine-tune your node to help keep the network clean and resilient, actively reducing unnecessary load from spam or parasitic transactions.

--- a/bitcoin-knots/umbrel-app.yml
+++ b/bitcoin-knots/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - bitcoin
 category: bitcoin
 name: Bitcoin Knots
-version: "1.2.12"
+version: "1.2.12-1"
 tagline: Run your personal node powered by Bitcoin Knots
 description: >-
   Take control of your digital sovereignty by choosing Bitcoin Knots to run your node! By using Knots, you’re supporting a version of Bitcoin that prioritizes efficiency, security, and flexibility. With Bitcoin Knots’ enhanced configuration options, you can fine-tune your node to help keep the network clean and resilient, actively reducing unnecessary load from spam or parasitic transactions.
@@ -36,6 +36,9 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
+
   🚨 This version adds BIP 110 code directly into the Bitcoin Knots codebase 🚨
   
   

--- a/bitcoin/docker-compose.yml
+++ b/bitcoin/docker-compose.yml
@@ -62,7 +62,7 @@ services:
         ipv4_address: $APP_BITCOIN_NODE_IP
 
   tor:
-    image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/bitcoin/umbrel-app.yml
+++ b/bitcoin/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bitcoin
 category: bitcoin
 name: Bitcoin Node
-version: "1.3.0"
+version: "1.3.0-patch.1"
 tagline: Run your personal node powered by Bitcoin Core
 description: >-
   Run your Bitcoin node, powered by Bitcoin Core. Independently store and validate every Bitcoin transaction.
@@ -36,6 +36,9 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
+
   This update adds Bitcoin Core v31.0 and an optional IPC mining interface for Stratum V2 apps.
 
 

--- a/blockstream-blind-oracle/docker-compose.yml
+++ b/blockstream-blind-oracle/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       PINSERVER_CERT: ""
 
   tor:
-    image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/blockstream-blind-oracle/umbrel-app.yml
+++ b/blockstream-blind-oracle/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: blockstream-blind-oracle
 category: bitcoin
 name: Blockstream Blind Oracle
-version: "0.1.2"
+version: "0.1.3"
 tagline: Encrypt your wallet on Blockstream Jade
 description: >-
         Run a personal blind oracle to encrypt the wallet material on your 
@@ -33,4 +33,7 @@ deterministicPassword: false
 submitter: Blockstream
 submission: https://github.com/getumbrel/umbrel-apps/pull/950
 releaseNotes: >-
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
+
   Fixes a port conflict with AdGuard Home.

--- a/blockstream-blind-oracle/umbrel-app.yml
+++ b/blockstream-blind-oracle/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: blockstream-blind-oracle
 category: bitcoin
 name: Blockstream Blind Oracle
-version: "0.1.3"
+version: "0.1.2-patch.1"
 tagline: Encrypt your wallet on Blockstream Jade
 description: >-
         Run a personal blind oracle to encrypt the wallet material on your 

--- a/core-lightning/docker-compose.yml
+++ b/core-lightning/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       default:
         ipv4_address: ${APP_CORE_LIGHTNING_DAEMON_IP}
   tor:
-    image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/core-lightning/umbrel-app.yml
+++ b/core-lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: core-lightning
 category: bitcoin
 name: Core Lightning
-version: "26.06.2"
+version: "26.06.2-patch.1"
 tagline: Run your personal Core Lightning node
 description: >-
   Get started with the Lightning network today with Core Lightning - a
@@ -32,6 +32,9 @@ defaultPassword: ""
 submitter: Blockstream
 submission: https://github.com/getumbrel/umbrel-apps/pull/475
 releaseNotes: >-
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
+
   This updates Core Lightning to v26.06.2. CLN Application remains on v26.04.
 
 

--- a/electrs/docker-compose.yml
+++ b/electrs/docker-compose.yml
@@ -44,7 +44,7 @@ services:
         ipv4_address: $APP_ELECTRS_NODE_IP
 
   tor:
-    image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/electrs/umbrel-app.yml
+++ b/electrs/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: electrs
 category: bitcoin
 name: Electrs
-version: "0.11.1"
+version: "0.11.1-patch.1"
 tagline: A simple and efficient Electrum Server
 description: >
   Run your personal Electrum server and connect your Electrum-compatible wallet,
@@ -30,6 +30,9 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
+
   This update bumps the underlying electrs version to 0.11.1. It improves Electrum API compliance for transaction lookups, adds more flexible network magic configuration, and updates core dependencies.
 
 

--- a/electrumx/docker-compose.yml
+++ b/electrumx/docker-compose.yml
@@ -43,7 +43,7 @@ services:
         ipv4_address: $APP_ELECTRUMX_NODE_IP
 
   tor:
-    image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/electrumx/umbrel-app.yml
+++ b/electrumx/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - electrs
 category: bitcoin
 name: ElectrumX
-version: "1.16.0-patch.2"
+version: "1.16.0-patch.3"
 tagline: A lightweight Electrum server
 description: >
   Run your personal Electrum server and connect your Electrum-compatible wallet,
@@ -31,6 +31,9 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
+
   This update adds support for Backups in umbrelOS 1.5.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/1813

--- a/elements/docker-compose.yml
+++ b/elements/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       REMOTE_P2P_HOST: $APP_ELEMENTS_P2P_HIDDEN_SERVICE
   
   tor:
-    image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/elements/umbrel-app.yml
+++ b/elements/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: elements
 category: bitcoin
 name: Elements Core
-version: "23.3.3-1"
+version: "23.3.3-2"
 tagline: Liquid Network full node
 description: >-
   Elements is an open source full node implementation to run the Liquid
@@ -13,6 +13,9 @@ description: >-
 
   This app has the potential to use up to 6GB of RAM. It's important to confirm that your device meets the necessary hardware requirements before installing and running the app.
 releaseNotes: >-
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
+
   For users who have set up umbrelOS Backups, this update reduces Elements backup size and hourly backup activity by excluding re-downloadable Liquid blockchain and index data.
 
 

--- a/elements/umbrel-app.yml
+++ b/elements/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: elements
 category: bitcoin
 name: Elements Core
-version: "23.3.3-2"
+version: "23.3.3-patch.2"
 tagline: Liquid Network full node
 description: >-
   Elements is an open source full node implementation to run the Liquid

--- a/fulcrum/docker-compose.yml
+++ b/fulcrum/docker-compose.yml
@@ -59,7 +59,7 @@ services:
         ipv4_address: $APP_FULCRUM_NODE_IP
 
   tor:
-    image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/fulcrum/umbrel-app.yml
+++ b/fulcrum/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - electrs
 category: bitcoin
 name: Fulcrum
-version: "2.1.1"
+version: "2.1.1-patch.1"
 tagline: A fast and nimble Electrum Server
 description: >-
   Run your personal Electrum server and connect your Electrum-compatible wallet,
@@ -30,6 +30,9 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
+
   Fulcrum 2.1.1 is a maintenance update with bug fixes and small protocol improvements.
 
 

--- a/libre-relay/docker-compose.yml
+++ b/libre-relay/docker-compose.yml
@@ -55,7 +55,7 @@ services:
         ipv4_address: $APP_LIBRE_RELAY_NODE_IP
 
   tor:
-    image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/libre-relay/umbrel-app.yml
+++ b/libre-relay/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - bitcoin
 category: bitcoin
 name: Libre Relay
-version: "30.2-1"
+version: "30.2-2"
 tagline: Run your personal node powered by Libre Relay
 description: >-
   > "[Bitcoin] takes advantage of the nature of information being easy to spread but hard to stifle." - Satoshi Nakamoto
@@ -34,6 +34,9 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
+
   Fixes a port conflict that could prevent Libre Relay from running alongside Mattermost.
 
 

--- a/libre-relay/umbrel-app.yml
+++ b/libre-relay/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - bitcoin
 category: bitcoin
 name: Libre Relay
-version: "30.2-2"
+version: "30.2-patch.2"
 tagline: Run your personal node powered by Libre Relay
 description: >-
   > "[Bitcoin] takes advantage of the nature of information being easy to spread but hard to stifle." - Satoshi Nakamoto

--- a/lightning/docker-compose.yml
+++ b/lightning/docker-compose.yml
@@ -59,7 +59,7 @@ services:
         ipv4_address: $APP_LIGHTNING_NODE_IP
   
   tor:
-    image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/lightning/umbrel-app.yml
+++ b/lightning/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: lightning
 category: bitcoin
 name: Lightning Node
-version: "0.21.1-beta"
+version: "0.21.1-beta-patch.1"
 tagline: Run your personal Lightning Network node
 description: >-
   Run your personal Lightning Network node, and join the future of Bitcoin today.
@@ -22,6 +22,8 @@ description: >-
 
   An official app from Umbrel.
 releaseNotes: |-
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
   ⚠️ Before updating: if you manually added `protocol.custom-nodeann=39` or `protocol.custom-init=39` to your LND config for BOLT 12 or LNDK integrations, remove those lines first. LND now advertises onion messaging itself, and those old settings can prevent it from starting.
 
   This update includes LND v0.21.1-beta and the latest Lightning Node app improvements for Umbrel.

--- a/monero/docker-compose.yml
+++ b/monero/docker-compose.yml
@@ -55,7 +55,7 @@ services:
         ipv4_address: $APP_MONERO_NODE_IP
 
   tor:
-    image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/monero/umbrel-app.yml
+++ b/monero/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: monero
 category: crypto
 name: Monero Node
-version: "0.18.5.0-2"
+version: "0.18.5.0-patch.2"
 tagline: Run a monero node
 description: >-
   Run your monero node and independently store and validate every single Monero transaction with it.

--- a/monero/umbrel-app.yml
+++ b/monero/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: monero
 category: crypto
 name: Monero Node
-version: "0.18.5.0-1"
+version: "0.18.5.0-2"
 tagline: Run a monero node
 description: >-
   Run your monero node and independently store and validate every single Monero transaction with it.
@@ -23,4 +23,7 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
+
   This update enables Monero's ZMQ publisher on port 18083 for p2pool and other local clients.

--- a/samourai-server/docker-compose.yml
+++ b/samourai-server/docker-compose.yml
@@ -147,7 +147,7 @@ services:
         ipv4_address: $APP_SAMOURAI_SERVER_IP
 
   tor:
-    image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/samourai-server/umbrel-app.yml
+++ b/samourai-server/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: samourai-server
 category: bitcoin
 name: Samourai Server
-version: "1.16.1-hotfix-4"
+version: "1.16.1-hotfix-5"
 tagline: Your private backing server for Samourai Wallet
 description: >-
   ⚠️ Whirlpool functionality no longer works due to the shutdown of Samourai's Whirlpool coordinator. Dojo functionality is unaffected.
@@ -35,6 +35,9 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
+
   This update fixes a bug where Samourai Server could not connect to Bitcoin Core v28.0.
 
 

--- a/samourai-server/umbrel-app.yml
+++ b/samourai-server/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: samourai-server
 category: bitcoin
 name: Samourai Server
-version: "1.16.1-hotfix-5"
+version: "1.16.1-patch.5"
 tagline: Your private backing server for Samourai Wallet
 description: >-
   ⚠️ Whirlpool functionality no longer works due to the shutdown of Samourai's Whirlpool coordinator. Dojo functionality is unaffected.

--- a/squeaknode/docker-compose.yml
+++ b/squeaknode/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       DEBUG: "squeaknode:*"
 
   tor:
-    image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/squeaknode/umbrel-app.yml
+++ b/squeaknode/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: squeaknode
 category: social
 name: Squeaknode
-version: "0.3.4"
+version: "0.3.4-1"
 tagline: A peer-to-peer status feed with Lightning monetization
 description: >-
   Squeaknode is a peer-to-peer microblog with posts unlocked by
@@ -29,4 +29,7 @@ deterministicPassword: true
 submitter: Jonathan Zernik
 submission: https://github.com/getumbrel/umbrel/pull/385
 releaseNotes: >-
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
+
   This update fixes handling of the P2P server port configuration.

--- a/squeaknode/umbrel-app.yml
+++ b/squeaknode/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: squeaknode
 category: social
 name: Squeaknode
-version: "0.3.4-1"
+version: "0.3.4-patch.1"
 tagline: A peer-to-peer status feed with Lightning monetization
 description: >-
   Squeaknode is a peer-to-peer microblog with posts unlocked by

--- a/suredbits-wallet/docker-compose.yml
+++ b/suredbits-wallet/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - "$APP_SUREDBITS_WALLET_P2P_PORT:$APP_SUREDBITS_WALLET_P2P_PORT"
   
   tor:
-    image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/suredbits-wallet/umbrel-app.yml
+++ b/suredbits-wallet/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: suredbits-wallet
 category: bitcoin
 name: Suredbits Wallet
-version: "1.9.7-1"
+version: "1.9.7-patch.1"
 tagline: A universal DLC wallet
 description: >-
   The Suredbits Wallet is your one stop shop for building Discreet

--- a/suredbits-wallet/umbrel-app.yml
+++ b/suredbits-wallet/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: suredbits-wallet
 category: bitcoin
 name: Suredbits Wallet
-version: "1.9.7"
+version: "1.9.7-1"
 tagline: A universal DLC wallet
 description: >-
   The Suredbits Wallet is your one stop shop for building Discreet
@@ -14,6 +14,9 @@ description: >-
 
   WARNING: This is an Alpha software, don't put too much money in.
 releaseNotes: >
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
+
   - Fix bug where we weren't categorizing DLCs correctly by protocol version. 
 
 developer: Suredbits

--- a/tdex/docker-compose.yml
+++ b/tdex/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - ${APP_DATA_DIR}/caddy-data/Caddyfile:/etc/caddy/Caddyfile
 
   tor:
-   image: getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
+   image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
    user: "1000:1000"
    restart: on-failure
    volumes:

--- a/tdex/umbrel-app.yml
+++ b/tdex/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: tdex
 category: bitcoin
 name: TDEX Provider
-version: "1.0.1-hotfix"
+version: "1.0.1-hotfix-1"
 tagline: Provide liquidity on the TDEX Network, an open protocol to trade Liquid Network assets
 description: >-
   A liquidity provider holds Liquid reserves of both a BASE_ASSET-QUOTE_ASSET in his non-custodial Liquid hot-wallet,
@@ -17,6 +17,9 @@ description: >-
   constant product market-making. In short, this model generates a full order-book based on an initial price for the market.
   Every transaction that occurs on this market will adjust the prices of the market accordingly.
 releaseNotes: >-
+  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+
+
   This is a hotfix release that fixes a bug preventing new installations of the TDEX Provider app from working.
   
   

--- a/tdex/umbrel-app.yml
+++ b/tdex/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: tdex
 category: bitcoin
 name: TDEX Provider
-version: "1.0.1-hotfix-1"
+version: "1.0.1-patch.2"
 tagline: Provide liquidity on the TDEX Network, an open protocol to trade Liquid Network assets
 description: >-
   A liquidity provider holds Liquid reserves of both a BASE_ASSET-QUOTE_ASSET in his non-custodial Liquid hot-wallet,


### PR DESCRIPTION
- replace every app-owned `getumbrel/tor:0.4.7.8` reference with `ghcr.io/getumbrel/tor:0.4.9.11`
- pin the public multiarch manifest list at `sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a`
- bump each affected package using `-patch.N` notation so existing installations are offered the update without implying an upstream app-version bump
- add Tor security/connectivity release notes while retaining prior upgrade warnings for users who skip releases

Affected apps: Bitcoin Knots, Bitcoin Node, Blockstream Blind Oracle, Core Lightning, Electrs, ElectrumX, Elements Core, Fulcrum, Libre Relay, Lightning Node, Monero Node, Samourai Server, Squeaknode, Suredbits Wallet, and TDEX Provider.

These packages still use Tor 0.4.7.8, which is EOL and can no longer reliably bootstrap against the current Tor network. Tor 0.4.9.11 is the current stable security patch release. The replacement image preserves Umbrel's existing `tor` entrypoint and supports both linux/amd64 and linux/arm64.