### PR TITLE
gobrrr-pool: update to 1.2.1

### DIFF
--- a/gobrrr-pool/docker-compose.yml
+++ b/gobrrr-pool/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   ckpool:
-    image: ghcr.io/gobrrrme/gobrrr-ckpool:v1.1.0@sha256:9e831a5100039d9c8246dafabacf9101f60a4a7828bdc94ce0a14a389cc55188
+    image: ghcr.io/gobrrrme/gobrrr-ckpool:v1.2.1@sha256:7f255e43f4b8f27c1ad0aee1247e9534828f372929a2af9f8735418c5e44e86c
     restart: on-failure
     stop_grace_period: 1m
     healthcheck:
@@ -37,7 +37,7 @@ services:
       - HIGHDIFF=1000000
 
   webui:
-      image: ghcr.io/gobrrrme/gobrrr-pool-webui:v1.1.0@sha256:957ef2cd646a56a9783d437728b0bb7c855d9e980a704bd9b16cca1f1f026828
+      image: ghcr.io/gobrrrme/gobrrr-pool-webui:v1.2.1@sha256:82512e24d816c287c6c2f2badad41656d74318fbcc5b095961656e119f02e2f1
       restart: on-failure
       stop_grace_period: 30s
       volumes:

--- a/gobrrr-pool/docker-compose.yml
+++ b/gobrrr-pool/docker-compose.yml
@@ -49,7 +49,7 @@ services:
         - PORT=21421
         - CKPOOL_SOCKET_DIR=/tmp/ckpool
         - CKPOOL_LOGS_DIR=/var/log/ckpool
-        - MEMPOOL_API_URL=http://${APP_MEMPOOL_IP}:${APP_MEMPOOL_PORT}/api
+        - MEMPOOL_API_URL=${APP_GOBRRR_POOL_MEMPOOL_API_URL}
         - STRATUM_PORT=21420
         - BITCOIN_RPC_HOST=${APP_BITCOIN_NODE_IP}
         - BITCOIN_RPC_PORT=${APP_BITCOIN_RPC_PORT}

--- a/gobrrr-pool/exports.sh
+++ b/gobrrr-pool/exports.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Umbrel sources transitive dependency exports into one flat env. Reassert the
+# app-selected Bitcoin provider here so generic APP_BITCOIN_* vars match the
+# direct dependency choice instead of a downstream transitive dependency.
+SETTINGS_FILE="${EXPORTS_APP_DIR}/settings.yml"
+selected_bitcoin_dependency="bitcoin"
+
+if [[ -f "${SETTINGS_FILE}" ]]; then
+  selected_bitcoin_dependency=$(yq e '.dependencies.bitcoin // "bitcoin"' "${SETTINGS_FILE}" 2>/dev/null || echo "bitcoin")
+fi
+
+SELECTED_PROVIDER_EXPORTS_DIR="${UMBREL_ROOT}/app-data/${selected_bitcoin_dependency}"
+SELECTED_PROVIDER_EXPORTS_FILE="${SELECTED_PROVIDER_EXPORTS_DIR}/exports.sh"
+
+if [[ -f "${SELECTED_PROVIDER_EXPORTS_FILE}" ]]; then
+  previous_exports_app_id="${EXPORTS_APP_ID:-}"
+  previous_exports_app_dir="${EXPORTS_APP_DIR:-}"
+  previous_exports_app_data_dir="${EXPORTS_APP_DATA_DIR:-}"
+
+  EXPORTS_APP_ID="${selected_bitcoin_dependency}"
+  EXPORTS_APP_DIR="${SELECTED_PROVIDER_EXPORTS_DIR}"
+  EXPORTS_APP_DATA_DIR="${SELECTED_PROVIDER_EXPORTS_DIR}/data"
+
+  . "${SELECTED_PROVIDER_EXPORTS_FILE}"
+
+  provider_prefix=$(printf '%s' "${selected_bitcoin_dependency}" | tr '[:lower:]-' '[:upper:]_')
+  while IFS= read -r provider_var; do
+    suffix="${provider_var#APP_${provider_prefix}_}"
+    generic_var="APP_BITCOIN_${suffix}"
+    export "${generic_var}=${!provider_var}"
+  done < <(compgen -v | grep "^APP_${provider_prefix}_")
+
+  EXPORTS_APP_ID="${previous_exports_app_id}"
+  EXPORTS_APP_DIR="${previous_exports_app_dir}"
+  EXPORTS_APP_DATA_DIR="${previous_exports_app_data_dir}"
+fi

--- a/gobrrr-pool/exports.sh
+++ b/gobrrr-pool/exports.sh
@@ -1,5 +1,7 @@
-export APP_GOBRRR_POOL_MEMPOOL_API_URL="https://mempool.space/api"
+# Leave empty to use the web UI's built-in public mempool.space API.
+export APP_GOBRRR_POOL_MEMPOOL_API_URL=""
 
+# Prefer the local API when the Mempool app is installed.
 if "${UMBREL_ROOT}/scripts/app" ls-installed | grep --quiet "^mempool$"; then
   export APP_GOBRRR_POOL_MEMPOOL_API_URL="http://mempool_app_proxy_1:3006/api"
 fi

--- a/gobrrr-pool/exports.sh
+++ b/gobrrr-pool/exports.sh
@@ -1,37 +1,5 @@
-#!/bin/bash
+export APP_GOBRRR_POOL_MEMPOOL_API_URL="https://mempool.space/api"
 
-# Umbrel sources transitive dependency exports into one flat env. Reassert the
-# app-selected Bitcoin provider here so generic APP_BITCOIN_* vars match the
-# direct dependency choice instead of a downstream transitive dependency.
-SETTINGS_FILE="${EXPORTS_APP_DIR}/settings.yml"
-selected_bitcoin_dependency="bitcoin"
-
-if [[ -f "${SETTINGS_FILE}" ]]; then
-  selected_bitcoin_dependency=$(yq e '.dependencies.bitcoin // "bitcoin"' "${SETTINGS_FILE}" 2>/dev/null || echo "bitcoin")
-fi
-
-SELECTED_PROVIDER_EXPORTS_DIR="${UMBREL_ROOT}/app-data/${selected_bitcoin_dependency}"
-SELECTED_PROVIDER_EXPORTS_FILE="${SELECTED_PROVIDER_EXPORTS_DIR}/exports.sh"
-
-if [[ -f "${SELECTED_PROVIDER_EXPORTS_FILE}" ]]; then
-  previous_exports_app_id="${EXPORTS_APP_ID:-}"
-  previous_exports_app_dir="${EXPORTS_APP_DIR:-}"
-  previous_exports_app_data_dir="${EXPORTS_APP_DATA_DIR:-}"
-
-  EXPORTS_APP_ID="${selected_bitcoin_dependency}"
-  EXPORTS_APP_DIR="${SELECTED_PROVIDER_EXPORTS_DIR}"
-  EXPORTS_APP_DATA_DIR="${SELECTED_PROVIDER_EXPORTS_DIR}/data"
-
-  . "${SELECTED_PROVIDER_EXPORTS_FILE}"
-
-  provider_prefix=$(printf '%s' "${selected_bitcoin_dependency}" | tr '[:lower:]-' '[:upper:]_')
-  while IFS= read -r provider_var; do
-    suffix="${provider_var#APP_${provider_prefix}_}"
-    generic_var="APP_BITCOIN_${suffix}"
-    export "${generic_var}=${!provider_var}"
-  done < <(compgen -v | grep "^APP_${provider_prefix}_")
-
-  EXPORTS_APP_ID="${previous_exports_app_id}"
-  EXPORTS_APP_DIR="${previous_exports_app_dir}"
-  EXPORTS_APP_DATA_DIR="${previous_exports_app_data_dir}"
+if "${UMBREL_ROOT}/scripts/app" ls-installed | grep --quiet "^mempool$"; then
+  export APP_GOBRRR_POOL_MEMPOOL_API_URL="http://mempool_app_proxy_1:3006/api"
 fi

--- a/gobrrr-pool/umbrel-app.yml
+++ b/gobrrr-pool/umbrel-app.yml
@@ -44,7 +44,6 @@ developer: GoBrrr
 website: https://gobrrr.me
 dependencies:
   - bitcoin
-  - mempool
 repo: https://github.com/gobrrrme/GoBrrr-Pool
 support: https://github.com/gobrrrme/GoBrrr-Pool/issues
 port: 21421

--- a/gobrrr-pool/umbrel-app.yml
+++ b/gobrrr-pool/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: gobrrr-pool
 category: bitcoin
 name: Go Brrr Pool
-version: "1.1.0"
+version: "1.2.1"
 tagline: Bitcoin Solo Mining, Done Right!
 description: >-
   Go Brrr Pool is a self-hosted solo Bitcoin mining pool powered by ckpool-solo.
@@ -30,7 +30,16 @@ description: >-
 
 
   Homescreen widget developed by RodB.
-releaseNotes: ""
+releaseNotes: >-
+  ckpool engine updated to the latest upstream release: new high-performance
+  stratum message engine, numerous memory-leak and stability fixes.
+
+  Fixed Bitcoin provider selection so the app follows the node chosen in its
+  settings (e.g. Bitcoin Knots) instead of a transitive dependency — thanks
+  @BuffaloDyl. The dashboard now shows whether it is connected to Bitcoin Core
+  or Bitcoin Knots.
+
+  Leaderboard best-diff color improved for readability — thanks @rafxo.
 developer: GoBrrr
 website: https://gobrrr.me
 dependencies:

--- a/gobrrr-pool/umbrel-app.yml
+++ b/gobrrr-pool/umbrel-app.yml
@@ -12,8 +12,9 @@ description: >-
 
   Features a customizable real-time web dashboard with hashrate monitoring,
   worker statistics, pool-wide leaderboard, efficiency dashboard, and local
-  mempool API integration. ZMQ enables instant block notifications and automatic
-  difficulty adjustment accepts diff proposals from miners.
+  mempool API integration, using your local Mempool app when installed. ZMQ
+  enables instant block notifications and automatic difficulty adjustment
+  accepts diff proposals from miners.
 
 
   Two stratum ports: port 21420 for standard mining, port 21422 for
@@ -34,10 +35,14 @@ releaseNotes: >-
   ckpool engine updated to the latest upstream release: new high-performance
   stratum message engine, numerous memory-leak and stability fixes.
 
-  Fixed Bitcoin provider selection so the app follows the node chosen in its
-  settings (e.g. Bitcoin Knots) instead of a transitive dependency — thanks
-  @BuffaloDyl. The dashboard now shows whether it is connected to Bitcoin Core
-  or Bitcoin Knots.
+
+  Mempool is now optional. Go Brrr Pool uses your local Mempool app when
+  installed and otherwise falls back to the public mempool.space API.
+
+
+  The dashboard now shows whether it is connected to Bitcoin Core or Bitcoin
+  Knots — thanks @BuffaloDyl.
+
 
   Leaderboard best-diff color improved for readability — thanks @rafxo.
 developer: GoBrrr


### PR DESCRIPTION


<!--
Title format:
- Update GoBrrrPool to v1.2.1
-->

## Type
App update

## App
App ID: gobrrr-pool
Upstream project: https://github.com/gobrrrme/GoBrrr-Pool
Version: 1.2.1

## Summary
- ckpool updated to latest upstream (yyjson stratum engine, memory-leak and deadlock fixes)
- exports.sh: follow the app-selected Bitcoin provider (Knots support), courtesy of @BuffaloDyl (gobrrrme/GoBrrr-Pool#5)
- webui shows Bitcoin Core vs Knots, leaderboard color tweak (@rafxo)
- images pinned to v1.2.1 digests

## Verification
Umbrel testing performed: fresh install via community store on umbrelOS, verified dashboard, homescreen widget, node-implementation detection, and both stratum ports (21420 / high-diff 21422) with live miners against Bitcoin Core.

Environment tested:
- [x] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64

Known lint warnings or caveats: `submission` field still points to the original submission PR (#5449), happy to update it to this PR's URL if required.

## Notes
No new permissions, dependencies unchanged (bitcoin, mempool), no data migrations, existing installs upgrade in place. Multi-arch images (amd64 + arm64) are built in CI.

@nmfretz please push the required updates to make mempool optional, as discussed [here](https://github.com/getumbrel/umbrel-apps/pull/5449#issuecomment-4656874527).

Thanks again for your help!