### PR TITLE
Update Monero daemon to v0.18.5.1

### DIFF
--- a/monero/docker-compose.yml
+++ b/monero/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     restart: unless-stopped
     stop_grace_period: 15m
     command: "${APP_MONERO_COMMAND}"
-    image: ghcr.io/sethforprivacy/simple-monerod:v0.18.5.0@sha256:54b68cae321119c794930af32e4fec6772d9bd9e5a2b1a2e2b8efcf49ae68d8f
+    image: ghcr.io/sethforprivacy/simple-monerod:v0.18.5.1@sha256:086eeb95174223ed166915d9f93dcfe4a7699efb89a30ca1569153dbf4f65f02
     ports:
       - "${APP_MONERO_P2P_PORT}:${APP_MONERO_P2P_PORT}"
       - "${APP_MONERO_RPC_PORT}:${APP_MONERO_RPC_PORT}"

--- a/monero/umbrel-app.yml
+++ b/monero/umbrel-app.yml
@@ -23,36 +23,7 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This is the v0.18.5.1 release of the Monero software. It includes a large number of bug fixes.
+  This update upgrades the Monero daemon to v0.18.5.1, a recommended maintenance release with fixes and hardening across blockchain synchronization, peer handling, transaction pool processing, and general daemon stability. It also updates RandomX to v1.2.2.
 
 
-
-  Some highlights of this release are:
-
-  - Daemon: display IPv6 connections
-  - Daemon: fix slow shutdown with Tor/I2P enabled
-  - Daemon: avoid unsafe pidfile truncation
-  - Daemon: use latest hard fork block for approximate blockchain height
-  - Daemon: restrict get_alt_blocks_hashes RPC
-  - Daemon: fix wrong block_weight in handle_get_objects
-  - Daemon: improve incoming block scan table handling
-  - Daemon: restore safe sync mode when target height drops
-  - Daemon: canonicalize Tor and I2P hostnames
-  - Daemon: fix dangling iterator in remote host checks
-  - Daemon: improve duplicate transaction handling in handle_notify_new_transactions
-  - Daemon: fix use-after-free in txpool prune
-  - ZMQ: cap aggregate receive size
-  - ZMQ: apply restricted-mode privacy filtering to get_transaction_pool
-  - Wallet: store multisig nonce erasure before returning signed txset
-  - Wallet: hardening against malicious remote nodes
-  - Wallet RPC: add missing trusted daemon check to rescan_spent
-  - Wallet RPC: fix describe_transfer source entry
-  - Wallet RPC: preserve payment ID when editing address book
-  - Wallet RPC: remove unused finalize_multisig endpoint
-  - Miner: fix thread 0 always using secure JIT
-  - RandomX: update to v1.2.2
-  - Fix memory leak with readline
-  - Fix memory leak with RandomX integration on Windows
-  - Various bug fixes and improvements
-
-  For more details navigate to https://www.getmonero.org/2026/07/08/monero-0.18.5.1-released.html
+  Full release notes can be found at https://www.getmonero.org/2026/07/08/monero-0.18.5.1-released.html

--- a/monero/umbrel-app.yml
+++ b/monero/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: monero
 category: crypto
 name: Monero Node
-version: "0.18.5.0-patch.2"
+version: "0.18.5.1"
 tagline: Run a monero node
 description: >-
   Run your monero node and independently store and validate every single Monero transaction with it.
@@ -23,7 +23,36 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+  This is the v0.18.5.1 release of the Monero software. It includes a large number of bug fixes.
 
 
-  This update enables Monero's ZMQ publisher on port 18083 for p2pool and other local clients.
+
+  Some highlights of this release are:
+
+  - Daemon: display IPv6 connections
+  - Daemon: fix slow shutdown with Tor/I2P enabled
+  - Daemon: avoid unsafe pidfile truncation
+  - Daemon: use latest hard fork block for approximate blockchain height
+  - Daemon: restrict get_alt_blocks_hashes RPC
+  - Daemon: fix wrong block_weight in handle_get_objects
+  - Daemon: improve incoming block scan table handling
+  - Daemon: restore safe sync mode when target height drops
+  - Daemon: canonicalize Tor and I2P hostnames
+  - Daemon: fix dangling iterator in remote host checks
+  - Daemon: improve duplicate transaction handling in handle_notify_new_transactions
+  - Daemon: fix use-after-free in txpool prune
+  - ZMQ: cap aggregate receive size
+  - ZMQ: apply restricted-mode privacy filtering to get_transaction_pool
+  - Wallet: store multisig nonce erasure before returning signed txset
+  - Wallet: hardening against malicious remote nodes
+  - Wallet RPC: add missing trusted daemon check to rescan_spent
+  - Wallet RPC: fix describe_transfer source entry
+  - Wallet RPC: preserve payment ID when editing address book
+  - Wallet RPC: remove unused finalize_multisig endpoint
+  - Miner: fix thread 0 always using secure JIT
+  - RandomX: update to v1.2.2
+  - Fix memory leak with readline
+  - Fix memory leak with RandomX integration on Windows
+  - Various bug fixes and improvements
+
+  For more details navigate to https://www.getmonero.org/2026/07/08/monero-0.18.5.1-released.html


### PR DESCRIPTION
Update to the v0.18.5.1 release of the Monero software. This release includes a large number of bug fixes.