### PR TITLE
pogolo: update to 1.1.4-hotfix

### DIFF
--- a/pogolo/docker-compose.yml
+++ b/pogolo/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   pogolo:
-    image: 0xf0xx0/pogolo:v1.1.4-hotfix@sha256:8ff8f4e2d269fcd43b02011792063a5ef10815cdb46202280ab2a2c8a3997bb2
+    image: 0xf0xx0/pogolo:v1.1.4-hotfix@sha256:4a2b1d4bf1a7d9c6f8f2adabd0ce2129e6be504dbd62e8df5053b8ad01973b68
     restart: on-failure
     user: "1000:1000"
     stop_grace_period: 30s

--- a/pogolo/docker-compose.yml
+++ b/pogolo/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   pogolo:
-    image: 0xf0xx0/pogolo:v1.1.4-hotfix@sha256:4a2b1d4bf1a7d9c6f8f2adabd0ce2129e6be504dbd62e8df5053b8ad01973b68
+    image: 0xf0xx0/pogolo:v1.1.4-hotfix@sha256:5b828e603d47d9f4de17bc0d36424b4f9aa45c193496c196d1b989620abf1411
     restart: on-failure
     user: "1000:1000"
     stop_grace_period: 30s

--- a/pogolo/docker-compose.yml
+++ b/pogolo/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   pogolo:
-    image: 0xf0xx0/pogolo:v1.1.4-hotfix@sha256:5b828e603d47d9f4de17bc0d36424b4f9aa45c193496c196d1b989620abf1411
+    image: 0xf0xx0/pogolo:v1.1.4-hotfix@sha256:0fb1d4696d4456ad4d5f44dae8f75fe959ea1200aac5af88ceefe289f7dfba4a
     restart: on-failure
     user: "1000:1000"
     stop_grace_period: 30s

--- a/pogolo/docker-compose.yml
+++ b/pogolo/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   pogolo:
-    image: 0xf0xx0/pogolo:v1.1.4@sha256:d98604dd5b5ac53f3ddfe131323a5326627d846698d349bd6848c002179b79d6
+    image: 0xf0xx0/pogolo:v1.1.4-hotfix@sha256:8ff8f4e2d269fcd43b02011792063a5ef10815cdb46202280ab2a2c8a3997bb2
     restart: on-failure
     user: "1000:1000"
     stop_grace_period: 30s

--- a/pogolo/umbrel-app.yml
+++ b/pogolo/umbrel-app.yml
@@ -1,7 +1,7 @@
 manifestVersion: 1.1
 name: pogolo
 id: pogolo
-version: "1.1.4"
+version: "1.1.4-hotfix"
 category: bitcoin
 dependencies:
   - bitcoin
@@ -16,13 +16,7 @@ description: >-
 
   think of this as public-pool but minimal and for self-sovereign nerds
 releaseNotes: |-
-  - Adds a ZMQ hashblock listener for faster block and reorg updates.
-
-  - Adds a Prometheus metrics endpoint at `/metrics`.
-
-  - Improves share rejection messages around stale jobs and job changes.
-
-  - Fixes duplicate-share handling, race conditions, difficulty target calculation, and full `addr.worker` handling.
+  - Fixes improper share version validation
 developer: 0xf0xx0
 website: https://github.com/0xf0xx0/pogolo
 repo: https://github.com/0xf0xx0/pogolo


### PR DESCRIPTION
## Type

App update

## App

App ID: pogolo
Upstream project: github.com/0xf0xx0/pogolo
Version: 1.1.4-hotfix

## Summary

Fixes an issue during share validation

## Verification

Umbrel testing performed:

Environment tested:
- [ ] Umbrel device
- [x] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64

Known lint warnings or caveats:

## Notes

Permissions, dependencies, migrations, default credentials, or caveats:

For new apps, include screenshots and a logo reference. Umbrel will create the final App Store gallery assets.
