### PR TITLE
Update Bitcoin Regtest Dashboard to v1.0.4

### DIFF
--- a/bitcoin-regtest-dashboard/docker-compose.yml
+++ b/bitcoin-regtest-dashboard/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   # Bitcoin Core in regtest mode (self-contained, no dependencies)
   bitcoin:
-    image: ghcr.io/getumbrel/docker-bitcoind:v30.2@sha256:75ad7da4eaa2a56b92e5703ff39fa86aa7b9012c50749ca082f018a761d136cd
+    image: ghcr.io/getumbrel/docker-bitcoind:v31.0@sha256:89185fc2792a9824cbe18f7ad4ead02a3a9a14adf5b34eb42f60ebec36201fa0
     user: "1000:1000"
     restart: on-failure
     entrypoint: ["/bin/sh", "-c"]
@@ -71,7 +71,7 @@ services:
 
   # Bitcoin Regtest Dashboard
   dashboard:
-    image: coreylphillips/bitcoin-regtest-dashboard:v1.0.3@sha256:f1ccffc2002f107559338f015097e49af7f547eababfcd1f53f0f2bdbd159c88
+    image: coreylphillips/bitcoin-regtest-dashboard:v1.0.4@sha256:d71e099ec53426cecd05899a7f8efe2b73bfc1d0c21750ac53dc2b2dad107820
     user: "1000:1000"
     restart: on-failure
     environment:

--- a/bitcoin-regtest-dashboard/umbrel-app.yml
+++ b/bitcoin-regtest-dashboard/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bitcoin-regtest-dashboard
 category: bitcoin
 name: Bitcoin Regtest Dashboard
-version: "1.0.3-1"
+version: "1.0.4"
 tagline: Development toolkit for Bitcoin regtest
 description: >-
   A self-contained development dashboard with its own Bitcoin Core regtest node and Electrs instance. No external dependencies required.
@@ -10,6 +10,7 @@ description: >-
 
   Features include:
     - Mine blocks instantly with one click
+    - Auto-mine blocks until stopped or for a set duration
     - Generate new addresses (all types supported)
     - Send Bitcoin to any address
     - View and manage UTXOs
@@ -23,7 +24,9 @@ description: >-
   Perfect for Bitcoin developers who need quick access to regtest node functionality
   for testing wallets, applications, and Bitcoin integrations.
 releaseNotes: >-
-  Fixes a port conflict that could prevent Bitcoin Regtest Dashboard from running alongside Samourai Server.
+  - Added an auto-mine feature to mine blocks at a set interval, either until stopped or for a chosen duration
+
+  - Upgraded Bitcoin Core to v31.0
 developer: Corey Phillips
 website: https://github.com/coreyphillips/bitcoin-regtest-dashboard
 dependencies: []


### PR DESCRIPTION
## Type

App update

## App

App ID: bitcoin-regtest-dashboard
Upstream project: https://github.com/coreyphillips/bitcoin-regtest-dashboard
Version: 1.0.4 (from 1.0.3-1)

## Summary

Updates Bitcoin Regtest Dashboard to v1.0.4:

- Adds an auto-mine feature to mine blocks at a set interval, either until stopped (the default) or for a chosen duration. It runs on the server, so mining continues even if the dashboard tab is closed.
- Upgrades the bundled Bitcoin Core node from v30.2 to v31.0, matching the version in the official Bitcoin Node app.

Image changes:

- dashboard: `coreylphillips/bitcoin-regtest-dashboard` v1.0.3 to v1.0.4 (built for amd64 and arm64)
- bitcoin: `ghcr.io/getumbrel/docker-bitcoind` v30.2 to v31.0

## Verification

Umbrel testing performed: Verified the app via docker compose against a real Bitcoin Core v31.0 regtest node. Confirmed the node reports `/Satoshi:31.0.0/`, existing manual mining still works, and the new auto-mine start, stop, and status endpoints behave correctly for both indefinite and fixed-duration runs, with validation rejecting out of range values. Not yet installed and tested as an app on umbrelOS.

Environment tested:
- [x] Umbrel device
- [x] Local umbrelOS test environment
- [x] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64

Known lint warnings or caveats: None.

## Notes

No new permissions, dependencies, migrations, or default credentials. The app stays self-contained, bundling its own Bitcoin Core regtest node and Electrs instance.
