### PR TITLE
Add openhabittracker

### DIFF
--- a/openhabittracker/docker-compose.yml
+++ b/openhabittracker/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: openhabittracker_server_1
+      APP_PORT: 8080
+
+  server:
+    image: jinjinov/openhabittracker:1.2.3@sha256:7e2c753c8ec7b2821e004be27f934f086c6d2f16ff5142c3b864d98731e0b507
+    restart: on-failure
+    stop_grace_period: 1m
+    environment:
+      TZ: Etc/UTC
+      AppSettings__UserName: umbrel
+      AppSettings__Email: umbrel@example.com
+      AppSettings__Password: ${APP_PASSWORD}
+      AppSettings__JwtSecret: ${APP_OPENHABITTRACKER_JWT_SECRET}
+    volumes:
+      - ${APP_DATA_DIR}/data:/app/.OpenHabitTracker
+    healthcheck:
+      # the aspnet base image ships neither curl nor wget; bash /dev/tcp works
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/8080"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s

--- a/openhabittracker/docker-compose.yml
+++ b/openhabittracker/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
       APP_HOST: openhabittracker_server_1
       APP_PORT: 8080
+      PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
     image: jinjinov/openhabittracker:1.2.3@sha256:7e2c753c8ec7b2821e004be27f934f086c6d2f16ff5142c3b864d98731e0b507

--- a/openhabittracker/exports.sh
+++ b/openhabittracker/exports.sh
@@ -1,0 +1,1 @@
+export APP_OPENHABITTRACKER_JWT_SECRET="$(derive_entropy "env-${app_entropy_identifier}-JWT_SECRET" | head -c32 | base64 | tr -d '\n')"

--- a/openhabittracker/umbrel-app.yml
+++ b/openhabittracker/umbrel-app.yml
@@ -1,0 +1,43 @@
+manifestVersion: 1
+id: openhabittracker
+name: OpenHabitTracker
+tagline: Take notes, plan tasks and track habits
+category: files
+version: "1.2.3"
+port: 8425
+description: >-
+  OpenHabitTracker is a free, ad-free, open source app for Markdown notes, tasks and habits - with no account and no telemetry.
+  This app is the self-hosted sync server: native OpenHabitTracker apps for Windows, Linux, Android, iOS and macOS log into it and keep all devices in sync, with all data on your Umbrel.
+
+
+  Habits work without streak guilt: instead of a streak that resets to zero, each habit shows how overdue it is compared to your desired interval.
+  Streaks exist as opt-in extra information, off by default.
+
+
+  - Markdown notes with categories, priorities and colors
+
+  - Tasks with checklists and time tracking
+
+  - Habits with flexible intervals, statistics and calendar backfill
+
+  - Advanced search, filter and sort
+
+  - Import your notes from Google Keep
+
+  - Data export and import: JSON, YAML, TSV, Markdown
+
+  - REST API with OpenAPI UI at /scalar/v1
+
+  - 26 themes with dark and light modes, localized to 20 languages
+releaseNotes: ""
+developer: Jinjinov
+website: https://openhabittracker.net
+dependencies: []
+repo: https://github.com/Jinjinov/OpenHabitTracker
+support: https://github.com/Jinjinov/OpenHabitTracker/issues
+gallery: []
+path: ""
+defaultUsername: umbrel
+deterministicPassword: true
+submitter: Jinjinov
+submission: https://github.com/getumbrel/umbrel-apps/pull/5872

--- a/openhabittracker/umbrel-app.yml
+++ b/openhabittracker/umbrel-app.yml
@@ -6,7 +6,7 @@ category: files
 version: "1.2.3"
 port: 8425
 description: >-
-  OpenHabitTracker is a free, ad-free, open source app for Markdown notes, tasks and habits - with no account and no telemetry.
+  OpenHabitTracker is a free, ad-free, open source app for Markdown notes, tasks and habits - with no third-party account and no telemetry.
   This app is the self-hosted sync server: native OpenHabitTracker apps for Windows, Linux, Android, iOS and macOS log into it and keep all devices in sync, with all data on your Umbrel.
 
 


### PR DESCRIPTION
## Type

New app

## App

App ID: openhabittracker
Upstream project: https://github.com/Jinjinov/OpenHabitTracker
Version: 1.2.3

## Summary

Adds OpenHabitTracker, a free, open source (GPL-3.0) app to take notes, plan tasks, and track habits. The container is a self-hosted single-user sync server that the native apps (Windows, Linux, Android, iOS, macOS) and the web app log into; all data stays on your server. Includes a REST API with an OpenAPI/Scalar UI at /scalar/v1.

## Verification

Umbrel testing performed:
- `npm run lint:apps -- openhabittracker --check-images` passes with no issues (validates the manifest and that the pinned multi-arch digest is pullable).
- The exact digest-pinned image was runtime-tested with docker using the app's environment: container came up healthy, EF migrations applied cleanly, login page returned HTTP 200.

Environment tested:
- [ ] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

(Not tested on umbrelOS itself - no device/VM available. The container was runtime-tested directly via docker as described above.)

Architecture tested:
- [x] amd64
- [ ] arm64

(arm64 is part of the pinned multi-arch manifest and verified pullable via lint --check-images; not run natively.)

## Notes

- Single-user app. deterministicPassword: true + defaultUsername: umbrel; working credentials (umbrel / generated password) are shown to the user after install. Login path is "" (app redirects to /login).
- JWT secret derived in exports.sh via derive_entropy.
- app_proxy points at openhabittracker_server_1:8080; the web UI never uses a raw host port.
- TZ hardcoded Etc/UTC (Umbrel has no per-user timezone); habit day boundaries follow UTC.
- Persistence: bind mount ${APP_DATA_DIR}/data:/app/.OpenHabitTracker. Image runs as root.
- gallery: [] and releaseNotes: "" left empty for Umbrel to populate.

Screenshots and logo:
- Logo: https://raw.githubusercontent.com/Jinjinov/OpenHabitTracker/main/OpenHabitTracker.Web/icons/icon-512.png
- Screenshot 1: https://raw.githubusercontent.com/Jinjinov/OpenHabitTracker/main/OpenHabitTracker.Web/images/desktop_2_note.png
- Screenshot 2: https://raw.githubusercontent.com/Jinjinov/OpenHabitTracker/main/OpenHabitTracker.Web/images/desktop_4_task.png
- Screenshot 3: https://raw.githubusercontent.com/Jinjinov/OpenHabitTracker/main/OpenHabitTracker.Web/images/desktop_6_habit.png
