### PR TITLE
Update Hashrate Autopilot to 1.17.1

### DIFF
--- a/hashrate-autopilot/docker-compose.yml
+++ b/hashrate-autopilot/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3010
 
   web:
-    image: ghcr.io/rdouma/hashrate-autopilot:1.17.0@sha256:8f952ab293975694b2c8169b7c5db18d0bc32636336d884712f3d89753bc665a
+    image: ghcr.io/rdouma/hashrate-autopilot:1.17.1@sha256:01b2541d5ecdf688dd459ad51b0cb8ec55a03f5beb4fba8abbada7737bd64a1b
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/hashrate-autopilot/umbrel-app.yml
+++ b/hashrate-autopilot/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: hashrate-autopilot
 category: bitcoin
 name: Hashrate Autopilot
-version: "1.17.0"
+version: "1.17.1"
 tagline: Autopilot for renting hashrate to mine on Ocean Mining
 
 description: >-
@@ -71,16 +71,16 @@ defaultPassword: ""
 submitter: Remco Douma
 submission: https://github.com/getumbrel/umbrel-apps/pull/5685
 releaseNotes: >-
-  v1.17.0 - the security release: your secrets are now encrypted at rest, you can change your password and rotate tokens in-app, and Profit & Loss counts Lightning payouts.
+  v1.17.1 - a current-block-height tile, a searchable Timeline with personal notes, and a Profit & Loss self-heal.
 
 
-  Security: your Braiins tokens, bitcoind RPC password, Telegram token, and DDNS credential are now AES-256-GCM encrypted in the database instead of plaintext, and your dashboard password is stored as a one-way hash. A copied database or a backup no longer hands over your secrets. The config-change history no longer records credential values, and any previously logged are scrubbed on upgrade. Existing installs encrypt themselves on the first start of this version; there is nothing for you to do. This protects the data-leaves-the-box cases; by design it cannot protect against someone who already controls the machine.
+  New: a stats-bar tile shows the latest Bitcoin block and names the pool or miner that found it, crowning your own blocks and marking Ocean and BIP 110 blocks, with a link straight to your block explorer. The Timeline's bid-id filter is now a full-text search box that matches across the bid id, the reason, your personal notes, and each row's identifiers (block heights, IPs, deposit tx ids, config values) across your entire history. You can attach a personal note to any Timeline event, and it is saved, searchable, and included in the Excel export.
 
 
-  New: change your dashboard password and rotate your Braiins owner and read-only tokens right from Config, Pool & Payout, Security & credentials. The password change is instant, and a new token is checked against Braiins before it is saved so a typo cannot break bidding. Profit & Loss now reads "collected" from Ocean's own payout ledger, so both on-chain and Lightning payouts count, split by rail, and a payout you have already spent still shows up - no Bitcoin node required for that number anymore.
+  Improved: Profit & Loss gains a hard-reset button next to rebuild that wipes and rebuilds the Ocean payout store and the Braiins spend cache from scratch, and both controls now report what they did. The "collected" figure also self-heals - the payout history is re-fetched on every restart and periodically, so a partial fetch during an upgrade can no longer leave it permanently short. An alert's detail panel now breaks an outage into the threshold you waited out, when it fired, when it recovered, the alert duration, and the total time the condition was open, with durations rounded to the nearest minute. The Dynamic DNS test now pushes the daemon's own detected public IP.
 
 
   Migrating from the community-store version (rdouma-hashrate-autopilot)? One-time five-minute guide: https://github.com/rdouma/hashrate-autopilot/blob/main/docs/migrating-from-community-store.md
 
 
-  Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.17.0
+  Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.17.1

--- a/hashrate-autopilot/umbrel-app.yml
+++ b/hashrate-autopilot/umbrel-app.yml
@@ -43,13 +43,15 @@ description: >-
   reads spend from Braiins and earnings from your on-chain wallet.
 
 
-  This app declares Bitcoin Node, Electrs, and Datum Gateway as dependencies, so
-  Umbrel will prompt you to install them during setup. Once all apps run on the
-  same Umbrel, the autopilot's dashboard auto-discovers the local Datum HTTP
-  API, Electrs server, and Bitcoin RPC across Umbrel's shared Docker network -
-  zero copy/paste, the worker-count, hashrate, P&L earnings, and BIP110
-  signalling panels all populate on first boot. (Pointing at off-Umbrel
-  instances is also supported - just override the URLs in Config after setup.)
+  This app declares a Bitcoin node, an Electrum server, and Datum Gateway as
+  dependencies, so Umbrel will prompt you to install them during setup - any of
+  Umbrel's Bitcoin node apps and any Electrum server (Electrs, Fulcrum, or
+  ElectrumX) works. Once all apps run on the same Umbrel, the autopilot's
+  dashboard auto-discovers the local Datum HTTP API, Electrum server, and
+  Bitcoin RPC across Umbrel's shared Docker network - zero copy/paste, the
+  worker-count, hashrate, P&L earnings, and BIP110 signalling panels all
+  populate on first boot. (Pointing at off-Umbrel instances is also supported -
+  just override the URLs in Config after setup.)
 
 developer: Remco Douma
 website: https://github.com/rdouma/hashrate-autopilot


### PR DESCRIPTION
## Type

App update

## App

App ID: hashrate-autopilot
Upstream project: https://github.com/rdouma/hashrate-autopilot
Version: 1.17.1

## Summary

Feature + polish release. New: a current-block-height stats tile that names the pool/miner that found each block and crowns your own; the Timeline's bid-id filter is now a full-text search across bid id, reason, personal notes, and per-row identifiers (block heights, IPs, deposit tx ids, config values); personal notes can be attached to any Timeline event (saved, searchable, and included in the Excel export); and Profit & Loss gains a hard-reset control next to rebuild that wipes and rebuilds the Ocean payout store and the Braiins spend cache. Improved: the P&L "collected" figure self-heals from a partial payout backfill (re-fetched on every restart and periodically), and the alert-condition detail panel breaks an outage into threshold / fired / recovered / duration / total, with durations rounded to the nearest minute. Fix: the Dynamic DNS test push uses the daemon's own detected public IP. Also includes dependency bumps (@fastify/static v10, @fastify/cors).

This is an image-digest-and-release-notes bump only - no structural compose changes, no new env vars, no new dependencies, no port change, relative to the previously accepted 1.17.0.

Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.17.1

## Verification

The published image is multi-arch (linux/amd64 + linux/arm64), CI-built from the tagged commit, and pinned here by its multi-arch index digest (`sha256:01b2541d5ecdf688dd459ad51b0cb8ec55a03f5beb4fba8abbada7737bd64a1b`). The compose is unchanged from the already-Umbrel-tested 1.17.0 apart from the image reference, so the install/upgrade shape is identical.

Environment tested:
- [x] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [x] arm64

Known lint warnings or caveats: none.

## Notes

- No new env vars, no new dependencies, no port change.
- In-place update over 1.17.0; the app carries its own SQLite migrations and upgrades existing data on first start.
