### PR TITLE
Add Kaspa Stratum Bridge (rusty-kaspa v2.0.1)

### DIFF
--- a/rusty-kaspa-stratum-bridge/data/config/config.yaml
+++ b/rusty-kaspa-stratum-bridge/data/config/config.yaml
@@ -1,0 +1,28 @@
+# Kaspa Stratum Bridge configuration (Umbrel)
+#
+# NOTE: Comments in this file are lost if you save configuration changes
+# through the web dashboard.
+#
+# kaspad_address points at the Rusty Kaspad app's node container (gRPC).
+kaspad_address: "rusty-kaspad_kaspad_1:16110"
+block_wait_time: 1000
+print_stats: true
+log_to_file: false
+health_check_port: ""
+web_dashboard_port: ":3030"
+var_diff: true
+shares_per_min: 30
+var_diff_stats: false
+pow2_clamp: true
+extranonce_size: 2
+coinbase_tag_suffix: ""
+
+instances:
+  # Single stratum listener. VarDiff automatically tunes per-worker difficulty,
+  # so one port works for ASICs of any size. Add more instances here (with
+  # different ports) if you want fixed-difficulty listeners - remember to also
+  # publish the new ports in docker-compose.yml.
+  - stratum_port: ":5555"
+    min_share_diff: 4
+    prom_port: ""
+    log_to_file: false

--- a/rusty-kaspa-stratum-bridge/data/config/config.yaml
+++ b/rusty-kaspa-stratum-bridge/data/config/config.yaml
@@ -23,6 +23,6 @@ instances:
   # different ports) if you want fixed-difficulty listeners - remember to also
   # publish the new ports in docker-compose.yml.
   - stratum_port: ":5555"
-    min_share_diff: 4
+    min_share_diff: 64
     prom_port: ""
     log_to_file: false

--- a/rusty-kaspa-stratum-bridge/docker-compose.yml
+++ b/rusty-kaspa-stratum-bridge/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: rusty-kaspa-stratum-bridge_bridge_1
+      APP_PORT: 3030
+
+  bridge:
+    image: sondelviento/rusty-kaspa-stratum-bridge:v2.0.1@sha256:9e6267135f0bf10a5cf2068e14b4b0343085134d83cac1fa0c4a6b7d141d5c57
+    restart: on-failure
+    stop_grace_period: 1m
+    init: true
+    user: "1000:1000"
+    environment:
+      HOME: /home/kaspa
+      # Allow saving config changes from the web dashboard (persisted via the bind mount below)
+      RKSTRATUM_ALLOW_CONFIG_WRITE: "1"
+    command:
+      - /app/stratum-bridge
+      - --config=/app/conf/config.yaml
+      - --node-mode=external
+      # Rusty Kaspad app's kaspad container (gRPC)
+      - --kaspad-address=rusty-kaspad_kaspad_1:16110
+    volumes:
+      - ${APP_DATA_DIR}/data/config:/app/conf
+      - ${APP_DATA_DIR}/data/bridge:/home/kaspa
+    ports:
+      # Stratum port for miners
+      - 5555:5555

--- a/rusty-kaspa-stratum-bridge/umbrel-app.yml
+++ b/rusty-kaspa-stratum-bridge/umbrel-app.yml
@@ -76,4 +76,4 @@ defaultUsername: ""
 defaultPassword: ""
 
 submitter: jagraba
-submission: https://github.com/getumbrel/umbrel-apps/pull/XXXX
+submission: https://github.com/getumbrel/umbrel-apps/pull/5878

--- a/rusty-kaspa-stratum-bridge/umbrel-app.yml
+++ b/rusty-kaspa-stratum-bridge/umbrel-app.yml
@@ -1,0 +1,79 @@
+manifestVersion: 1
+id: rusty-kaspa-stratum-bridge
+category: crypto
+name: Kaspa Stratum Bridge
+version: "v2.0.1"
+tagline: Solo mine Kaspa with your own node
+description: >-
+  ⚙️ Please read the setup instructions at the bottom of this page. This bridge is currently
+  in BETA upstream.
+
+
+  The Kaspa Stratum Bridge is the official in-house stratum bridge from the Rusty Kaspa
+  project. It sits between your stratum-based miners (IceRiver, Bitmain/Antminer, Goldshell,
+  BzMiner and more — miner type is auto-detected) and your own Rusty Kaspad node, letting you
+  solo mine KAS without trusting a third-party pool or public node.
+
+
+  It includes a built-in web dashboard with real-time statistics: total blocks and shares,
+  active workers, network hashrate, per-worker difficulty and uptime, recently found blocks,
+  and a Prometheus-compatible metrics endpoint. Variable difficulty (VarDiff) automatically
+  tunes each worker independently.
+
+
+  🛠️ SET-UP INSTRUCTIONS
+
+
+  ### Kaspa Node:
+
+
+  This app connects automatically to your Rusty Kaspad app, which is installed alongside it.
+  Wait for your node to fully sync before mining — the node is synced when its log shows a
+  steady stream of "Accepted block" lines.
+
+
+  ### Connecting Your Miner:
+
+
+  Refer to your miner's documentation for specific setup details. In general:
+
+  - Pool URL / Stratum host: your umbrelOS device's IP address (found in Settings on the
+  umbrelOS home screen) and port 5555, e.g. stratum+tcp://192.168.4.56:5555
+
+  - Username / Worker: your Kaspa wallet address, optionally followed by a period and a
+  worker name, e.g. kaspa:qr0abc...xyz.worker1
+
+  - Password: leave blank or enter any value if your miner requires one.
+
+
+  Mining rewards for blocks you find are paid directly to the wallet address your miner
+  submits — this app never holds your funds.
+
+
+  ### Configuration:
+
+
+  Bridge settings (difficulty, VarDiff, extra stratum instances) can be viewed and edited
+  from the Config section of the web dashboard. Note that comments in the config file are
+  not preserved when saving from the dashboard.
+
+
+  For more information visit https://github.com/kaspanet/rusty-kaspa
+releaseNotes: ""
+
+developer: Kaspa developers
+website: https://kaspa.org
+dependencies:
+  - rusty-kaspad
+repo: https://github.com/kaspanet/rusty-kaspa
+support: https://github.com/kaspanet/rusty-kaspa/issues
+
+port: 3646
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+submitter: jagraba
+submission: https://github.com/getumbrel/umbrel-apps/pull/XXXX


### PR DESCRIPTION
# Add Kaspa Stratum Bridge (rusty-kaspa v2.0.1)

## App

The official in-house stratum bridge that ships with rusty-kaspa as of v2.0.x (BETA upstream). Lets miners (IceRiver, Bitmain, Goldshell, BzMiner, miner type auto-detected) solo mine KAS against the user's own node instead of trusting a third-party pool or public node.

Companion app to the existing `rusty-kaspad` package, declared via `dependencies`. The bridge runs in external node mode against `rusty-kaspad_kaspad_1:16110` over the shared Docker network.

Upstream: https://github.com/kaspanet/rusty-kaspa (tag v2.0.1, `bridge/` crate)

## Image

No official kaspanet image exists for the stratum-bridge yet, so the image is built **unmodified** from upstream's `docker/Dockerfile.stratum-bridge` at tag v2.0.1:

`sondelviento/rusty-kaspa-stratum-bridge:v2.0.1@sha256:9e6267135f0bf10a5cf2068e14b4b0343085134d83cac1fa0c4a6b7d141d5c57`

Manifest list with linux/amd64 + linux/arm64, publicly pullable. Happy to switch to an official image if/when kaspanet publishes one.

## Ports

- Manifest port 3646 → app_proxy → built-in web dashboard (container :3030)
- Raw 5555/tcp → stratum listener for miners (published directly, same pattern as DATUM's 23334)

## Notable behavior

- The dashboard is reachable immediately, but the stratum listener intentionally stays closed until the node is synced (bridge logs "waiting for sync"). This is upstream behavior and is documented in the app description.
- `RKSTRATUM_ALLOW_CONFIG_WRITE=1` allows config edits via the bridge API, persisted in `${APP_DATA_DIR}/data/config/`. Write access as the container user was verified in testing.
- The app never holds wallet keys or funds; block rewards pay directly to the address the miner submits as its stratum username.

## Testing

- Environment: Raspberry Pi (aarch64), umbrelOS 1.7.4, arch: arm64
- Fresh install through Umbrel with dependency `rusty-kaspad` installed first and fully synced to mainnet
- Opened from the Umbrel home screen → dashboard loaded through app_proxy (kaspad v2.0.1 detected, live network hashrate/difficulty/height)
- Config mount write access verified as container user (UID 1000)
- App restarted through Umbrel → came back healthy and reconnected to the node automatically (uptime reset, network height advancing)
- IceRiver KS0 Ultra connected on :5555 — miner auto-detected, 20.81 GH/s, 55 shares accepted (0 stale / 0 invalid), VarDiff active, worker Online in dashboard
- Lint: `npm run lint:apps -- rusty-kaspa-stratum-bridge --check-images` — no issues found
- amd64: image built and multi-arch pull verified; runtime tested on arm64 only

Screenshots below: dashboard after fresh install, dashboard after restart (uptime reset), connected worker with accepted shares.
<img width="1379" height="868" alt="1" src="https://github.com/user-attachments/assets/ca4e5f75-59a5-4db9-a204-009d2db5fa24" />

<img width="1456" height="826" alt="2" src="https://github.com/user-attachments/assets/12b0fbe3-b3b8-4277-a293-7fdecb40ee07" />

<img width="1538" height="605" alt="3" src="https://github.com/user-attachments/assets/3082da88-457c-4969-a3ce-381758467fac" />


App logo/branding assets: Kaspa branding from https://kaspa.org  
Happy to provide anything the gallery team needs.