### PR TITLE
Update Sonarr to 4.0.19.2979 and Radarr to 6.3.0.10514

### DIFF
--- a/radarr/docker-compose.yml
+++ b/radarr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/radarr:6.1.1@sha256:581f159c2b67436863cb4da30e158ef6f6b8878472abbba79ee5d5f7e6b7d28d
+    image: linuxserver/radarr:6.3.0@sha256:2b2c1c05eb3f648d2c80dfab9486147dd7bb0ad4d77fa972fc1c5de8f1da3738
     environment:
       - PUID=1000
       - PGID=1000

--- a/radarr/umbrel-app.yml
+++ b/radarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: radarr
 category: media
 name: Radarr
-version: "6.1.1.10360-1"
+version: "6.3.0.10514"
 tagline: Your movie collection manager
 description: >-
   Radarr is a movie collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new movies and will interface with clients and indexers to grab, sort, and rename them. It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available. Note that only one type of a given movie is supported. If you want both an 4k version and 1080p version of a given movie you will need multiple instances.
@@ -28,7 +28,21 @@ gallery:
   - 3.jpg
 path: ""
 releaseNotes: >-
-  This Umbrel packaging update creates Radarr's expected Transmission category folder on startup, avoiding an out-of-the-box health warning about the missing `/downloads/complete/radarr` directory.
+  This update brings Radarr up to v6.3.0.10514.
+
+
+  Improvements since the previous release:
+
+  - Improved qBittorrent authentication with API key support and basic auth fixes.
+
+  - Added Postgres connection string options and bumped .NET to 8.0.27.
+
+  - Fixed importing new items from Simkl lists and custom formats with year metadata for imported files.
+
+  - Bumped FFProbe to 5.1.10.
+
+
+  Full release notes for Radarr can be found at https://github.com/Radarr/Radarr/releases
 defaultUsername: ""
 defaultPassword: ""
 torOnly: false

--- a/sonarr/docker-compose.yml
+++ b/sonarr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   server:
-    image: linuxserver/sonarr:4.0.17@sha256:76414c033f290d3c9f1f9dfad71150abe71d92592369a3377a5903d579e6e2b2
+    image: linuxserver/sonarr:4.0.19@sha256:4b025354d338999e03bf6dbdadcdde94815d39d4a5aba5de3cdc86a56d7d6c51
     environment:
       - PUID=1000
       - PGID=1000

--- a/sonarr/umbrel-app.yml
+++ b/sonarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: sonarr
 category: media
 name: Sonarr
-version: "4.0.17.2952-1"
+version: "4.0.19.2979"
 tagline: Smart PVR for newsgroup and bittorrent users
 description: >-
   Sonarr is a PVR for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.
@@ -28,7 +28,17 @@ gallery:
   - 3.jpg
 path: ""
 releaseNotes: >-
-  This Umbrel packaging update creates Sonarr's expected Transmission category folder on startup, avoiding an out-of-the-box health warning about the missing `/downloads/complete/tv-sonarr` directory.
+  This update brings Sonarr up to v4.0.19.2979.
+
+
+  Improvements since the previous release:
+
+  - Fixed basic authentication with qBittorrent download clients.
+
+  - Reuse authentication cookies for qBittorrent calls and backported additional qBittorrent fixes to v4.
+
+
+  Full release notes for Sonarr can be found at https://github.com/Sonarr/Sonarr/releases
 defaultUsername: ""
 defaultPassword: ""
 torOnly: false


### PR DESCRIPTION
This PR updates the **Sonarr** and **Radarr** packages to their latest upstream stable releases. Both are straight image bumps on the existing LinuxServer.io publisher and tag scheme — no compose, env, hook, permission, dependency, or persistence changes.

## Sonarr

- **Old version:** `4.0.17.2952` (packaging revision `-1`)
- **New version:** `4.0.19.2979`
- **Image:** `linuxserver/sonarr:4.0.17` → `4.0.19`, digest pinned to `sha256:4b025354d338999e03bf6dbdadcdde94815d39d4a5aba5de3cdc86a56d7d6c51`
- **Upstream release:** https://github.com/Sonarr/Sonarr/releases/tag/v4.0.19.2979
- **User-visible changes:** fixed basic authentication with qBittorrent; reuse authentication cookies for qBittorrent calls; backported additional qBittorrent fixes to v4.

## Radarr

- **Old version:** `6.1.1.10360` (packaging revision `-1`)
- **New version:** `6.3.0.10514`
- **Image:** `linuxserver/radarr:6.1.1` → `6.3.0`, digest pinned to `sha256:2b2c1c05eb3f648d2c80dfab9486147dd7bb0ad4d77fa972fc1c5de8f1da3738`
- **Upstream release:** https://github.com/Radarr/Radarr/releases/tag/v6.3.0.10514
- **User-visible changes (6.2.1 + 6.3.0):** improved qBittorrent authentication (API key support and basic auth fixes); Postgres connection string options; .NET bumped to 8.0.27; fixed importing new items from Simkl lists; fixed custom formats with year metadata for imported files; FFProbe bumped to 5.1.10.

## Breaking changes / migrations

None. No changes to bind mounts, data paths, templates, hooks, exports, runtime user, permissions, dependencies, or `app_proxy`. Existing `/config` and `/downloads` mounts are unchanged, so installed users keep all state.

## Verification

- **Image checks:** both tags pull publicly, digests pinned to their multi-arch manifest lists, and both provide `linux/amd64` + `linux/arm64`. Versions confirmed against the LinuxServer API (`sonarr 4.0.19.2979-ls319`, `radarr 6.3.0.10514-ls311`).
- **Lint:** `npm run lint:apps -- sonarr radarr --check-images` → *No issues found.*
- **`git diff --check`:** clean.
- **Runtime update-path test:** _in progress_ — testing the Umbrel update path (install currently shipped package → update → verify UI, existing config/state preserved, restart, logs) on a real Umbrel device. Environment and architecture will be recorded here once the test completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
