### PR TITLE
Update Gupt to v2.11.0

### DIFF
--- a/gupt/docker-compose.yml
+++ b/gupt/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8000
 
   web:
-    image: ghcr.io/besoeasy/gupt:2.1.15@sha256:65d0b5a3c7eee7a03ccb8756630363d237eae826111e022bc02f4eaad6ef82dd
+    image: ghcr.io/besoeasy/gupt:2.4.4@sha256:62f75f750f8bb6ce2cd10a6dffbc734cb763923b4d609ada8d2c1ace82a146b3
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/gupt/docker-compose.yml
+++ b/gupt/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8000
 
   web:
-    image: ghcr.io/besoeasy/gupt:1.1.4@sha256:9771510a51c3e86f4699b927a9cc86e2dcaa86f7e6951b22468e21e9bda75760
+    image: ghcr.io/besoeasy/gupt:2.1.15@sha256:65d0b5a3c7eee7a03ccb8756630363d237eae826111e022bc02f4eaad6ef82dd
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/gupt/docker-compose.yml
+++ b/gupt/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8000
 
   web:
-    image: ghcr.io/besoeasy/gupt:2.4.4@sha256:62f75f750f8bb6ce2cd10a6dffbc734cb763923b4d609ada8d2c1ace82a146b3
+    image: ghcr.io/besoeasy/gupt:2.10.2@sha256:c6531724bdb5143eab952f691b7f8a07e531a67355063c1097e2ba850ce06785
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/gupt/docker-compose.yml
+++ b/gupt/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8000
 
   web:
-    image: ghcr.io/besoeasy/gupt:2.10.2@sha256:c6531724bdb5143eab952f691b7f8a07e531a67355063c1097e2ba850ce06785
+    image: ghcr.io/besoeasy/gupt:2.11.0@sha256:c852f064ff08252902a4c2815d81676025868f8a98ebc08ce6752778462fd762
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/gupt/umbrel-app.yml
+++ b/gupt/umbrel-app.yml
@@ -2,12 +2,15 @@ manifestVersion: 1
 id: gupt
 category: social
 name: Gupt
-version: "2.1.15"
+version: "2.4.4"
 releaseNotes: >-
-  This update adds last-seen status, read receipts, typing indicators, improved WebRTC calls and file transfers, smarter relay selection and queued message delivery, plus vault item expiry.
+  This is a major, backwards-incompatible update. Your Gupt identity will remain, but conversations, Vault entries, and groups created in Gupt v1 will not be available in Gupt v2. Gupt v2 also cannot communicate with Gupt v1 clients, so your contacts will need to update as well.
 
 
-  This release also changes Gupt's browser-local storage and data formats. Existing conversations, Vault entries, and groups may not appear after updating.
+  Before updating, open Gupt v1 and copy anything you need from your chats, Vault, and groups, and back up your private key.
+
+
+  Gupt v2 adds last-seen status, read receipts, typing indicators, call requests inside chats, queued message delivery, custom relays, improved relay selection and replication, and Markdown Vault notes with tags and expiry.
 tagline: Encrypted chat, secure vault, and ephemeral sharing
 description: >-
   Encrypted chat, secure vault, and ephemeral sharing — with no phone number, no email, no account, and no central server.

--- a/gupt/umbrel-app.yml
+++ b/gupt/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: gupt
 category: social
 name: Gupt
-version: "2.4.4"
+version: "2.10.2"
 releaseNotes: >-
   This is a major, backwards-incompatible update. Your Gupt identity will remain, but conversations, Vault entries, and groups created in Gupt v1 will not be available in Gupt v2. Gupt v2 also cannot communicate with Gupt v1 clients, so your contacts will need to update as well.
 
@@ -10,7 +10,10 @@ releaseNotes: >-
   Before updating, open Gupt v1 and copy anything you need from your chats, Vault, and groups, and back up your private key.
 
 
-  Gupt v2 adds last-seen status, read receipts, typing indicators, call requests inside chats, queued message delivery, custom relays, improved relay selection and replication, and Markdown Vault notes with tags and expiry.
+  Gupt v2 adds redesigned chats with search, voice and video calls with screen sharing, encrypted media uploads with multi-server failover, last-seen status, read receipts, typing indicators, queued message delivery, improved relay selection, and upgraded Vault and Share tools.
+
+
+  Voice and video calls, screen sharing, and offline notifications require HTTPS and will become available on Umbrel once built-in HTTPS support lands.
 tagline: Encrypted chat, secure vault, and ephemeral sharing
 description: >-
   Encrypted chat, secure vault, and ephemeral sharing — with no phone number, no email, no account, and no central server.

--- a/gupt/umbrel-app.yml
+++ b/gupt/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: gupt
 category: social
 name: Gupt
-version: "2.10.2"
+version: "2.11.0"
 releaseNotes: >-
   This is a major, backwards-incompatible update. Your Gupt identity will remain, but conversations, Vault entries, and groups created in Gupt v1 will not be available in Gupt v2. Gupt v2 also cannot communicate with Gupt v1 clients, so your contacts will need to update as well.
 
@@ -13,7 +13,7 @@ releaseNotes: >-
   Gupt v2 adds redesigned chats with search, voice and video calls with screen sharing, encrypted media uploads with multi-server failover, last-seen status, read receipts, typing indicators, queued message delivery, improved relay selection, and upgraded Vault and Share tools.
 
 
-  Voice and video calls, screen sharing, and offline notifications require HTTPS and will become available on Umbrel once built-in HTTPS support lands.
+  Encrypted chats, groups, Vault, and Share work on current Umbrel LAN URLs. Voice and video calls, screen sharing, and offline notifications require HTTPS and will become available once built-in HTTPS support lands.
 tagline: Encrypted chat, secure vault, and ephemeral sharing
 description: >-
   Encrypted chat, secure vault, and ephemeral sharing — with no phone number, no email, no account, and no central server.

--- a/gupt/umbrel-app.yml
+++ b/gupt/umbrel-app.yml
@@ -2,9 +2,12 @@ manifestVersion: 1
 id: gupt
 category: social
 name: Gupt
-version: "1.1.4"
+version: "2.1.15"
 releaseNotes: >-
-  This update adds a secure vault for passwords, bookmarks, and notes, plus anonymous file sharing.
+  This update adds last-seen status, read receipts, typing indicators, improved WebRTC calls and file transfers, smarter relay selection and queued message delivery, plus vault item expiry.
+
+
+  This release also changes Gupt's browser-local storage and data formats. Existing conversations, Vault entries, and groups may not appear after updating.
 tagline: Encrypted chat, secure vault, and ephemeral sharing
 description: >-
   Encrypted chat, secure vault, and ephemeral sharing — with no phone number, no email, no account, and no central server.


### PR DESCRIPTION
## Summary

Updates Gupt from 1.1.4 to 2.11.0.

Release: https://github.com/besoeasy/gupt/releases/tag/2.11.0  
Image: `ghcr.io/besoeasy/gupt:2.11.0@sha256:c852f064ff08252902a4c2815d81676025868f8a98ebc08ce6752778462fd762`

This is a major, backwards-incompatible upgrade. The user's identity remains, but conversations, Vault entries, and groups created in Gupt v1 are not available in Gupt v2. Gupt v1 and v2 clients also cannot communicate with each other. The release notes warn users to copy anything they need and back up their private key before updating.

## Testing

- `npm run lint:apps -- gupt --check-images`
- Confirmed the image index contains `linux/amd64` and `linux/arm64` images.
- Tested an update from 1.1.4 to 2.11.0 on an amd64 Umbrel device over its normal LAN HTTP app URL.
- Confirmed the existing identity was preserved.
- Confirmed direct messages, private groups, and Vault creation/read work over plain HTTP without `crypto.subtle` or `crypto.randomUUID`.
- Restarted the app through Umbrel and confirmed the Vault item, direct message, and group message persisted.
- Voice/video calls, screen sharing, and offline notifications still require HTTPS.
