### PR TITLE
Update Hashrate Autopilot to 1.17.2

### DIFF
--- a/hashrate-autopilot/docker-compose.yml
+++ b/hashrate-autopilot/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3010
 
   web:
-    image: ghcr.io/rdouma/hashrate-autopilot:1.17.1@sha256:01b2541d5ecdf688dd459ad51b0cb8ec55a03f5beb4fba8abbada7737bd64a1b
+    image: ghcr.io/rdouma/hashrate-autopilot:1.17.2@sha256:7346288b77e979ff654a31337d2028b870e7076accdc8a86518764e87ddd2632
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/hashrate-autopilot/umbrel-app.yml
+++ b/hashrate-autopilot/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: hashrate-autopilot
 category: bitcoin
 name: Hashrate Autopilot
-version: "1.17.1"
+version: "1.17.2"
 tagline: Autopilot for renting hashrate to mine on Ocean Mining
 
 description: >-
@@ -73,16 +73,16 @@ defaultPassword: ""
 submitter: Remco Douma
 submission: https://github.com/getumbrel/umbrel-apps/pull/5685
 releaseNotes: >-
-  v1.17.1 - a current-block-height tile, a searchable Timeline with personal notes, and a Profit & Loss self-heal.
+  v1.17.2 - Lightning payouts no longer missing from Profit & Loss.
 
 
-  New: a stats-bar tile shows the latest Bitcoin block and names the pool or miner that found it, crowning your own blocks and marking Ocean and BIP 110 blocks, with a link straight to your block explorer. The Timeline's bid-id filter is now a full-text search box that matches across the bid id, the reason, your personal notes, and each row's identifiers (block heights, IPs, deposit tx ids, config values) across your entire history. You can attach a personal note to any Timeline event, and it is saved, searchable, and included in the Excel export.
+  New: Ocean's payout API turns out not to report Lightning payouts at all (confirmed by Ocean support), so anyone paid over Lightning saw a too-low collected figure and an inflated loss rate. The autopilot now deduces those payouts from your unpaid earnings dropping to zero - confirmed over two consecutive readings so a brief API glitch can't fake one, and only when no matching entry exists in Ocean's own ledger. A deduced payout shows as "type not known yet" for its first 24 hours (a late-arriving on-chain record replaces it automatically), then as "probably Lightning". Your history is backfilled on upgrade, and deduced payouts render on the chart as a ghost gem whose tooltip explains the deduction and marks the amount as approximate.
 
 
-  Improved: Profit & Loss gains a hard-reset button next to rebuild that wipes and rebuilds the Ocean payout store and the Braiins spend cache from scratch, and both controls now report what they did. The "collected" figure also self-heals - the payout history is re-fetched on every restart and periodically, so a partial fetch during an upgrade can no longer leave it permanently short. An alert's detail panel now breaks an outage into the threshold you waited out, when it fired, when it recovered, the alert duration, and the total time the condition was open, with durations rounded to the nearest minute. The Dynamic DNS test now pushes the daemon's own detected public IP.
+  Fixed: Timeline notes survive the Profit & Loss hard reset - rebuilding your finances no longer erases the personal notes you attached to payout events.
 
 
   Migrating from the community-store version (rdouma-hashrate-autopilot)? One-time five-minute guide: https://github.com/rdouma/hashrate-autopilot/blob/main/docs/migrating-from-community-store.md
 
 
-  Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.17.1
+  Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.17.2


### PR DESCRIPTION
## Type

App update

## App

App ID: hashrate-autopilot
Upstream project: https://github.com/rdouma/hashrate-autopilot
Version: 1.17.2

## Summary

Focused follow-up to the 1.17.x Profit & Loss work. New: Lightning payouts are now deduced - Ocean's payout API turns out not to report Lightning payouts at all (confirmed by Ocean support), so anyone paid over Lightning saw a too-low collected figure; the daemon now infers those payouts from a confirmed drop of unpaid earnings to zero with no matching entry in Ocean's ledger, backfills history on upgrade, and supersedes a deduced record automatically if the real settlement ever appears. Deduced payouts render on the chart as a ghost gem with an explanatory tooltip and an approximate amount. Fix: Timeline notes attached to payout events survive the P&L hard reset instead of being orphaned by the rebuild.

This is an image-digest-and-release-notes bump only - no structural compose changes, no new env vars, no new dependencies, no port change, relative to the previously accepted 1.17.1.

Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.17.2

## Verification

The published image is multi-arch (linux/amd64 + linux/arm64), CI-built from the tagged commit, and pinned here by its multi-arch index digest (`sha256:7346288b77e979ff654a31337d2028b870e7076accdc8a86518764e87ddd2632`). The compose is unchanged from the already-Umbrel-tested 1.17.1 apart from the image reference, so the install/upgrade shape is identical.

Environment tested:
- [ ] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [x] arm64

Known lint warnings or caveats: none.

## Notes

- No new env vars, no new dependencies, no port change.
- In-place update over 1.17.1; the app carries its own SQLite migrations and upgrades existing data on first start (this release adds one additive column migration).
