### PR TITLE
Update EE Gateway to 0.10.6

### DIFF
--- a/ee-gateway/docker-compose.yml
+++ b/ee-gateway/docker-compose.yml
@@ -8,10 +8,9 @@
 # network (which it needs to reach the Bluetooth radio) while the UI stays on
 # Umbrel's app network behind app_proxy.
 #
-# Credentials are NOT passed as environment variables here. The user enters the
-# upstream network's org id and API token once in the UI setup wizard, which
-# writes them to config.json in the shared volume; the worker reads that file
-# every scan cycle.
+# Credentials are NOT passed as environment variables here. The user enters an
+# encryptedenergy.com API token once in the UI setup wizard, which writes it to
+# config.json in the shared volume; the worker reads that file every scan cycle.
 #
 # umbreld creates ${APP_DATA_DIR}/data owned by root, but both app containers
 # run as uid 1000 and so cannot write it. The init_perms service fixes ownership

--- a/ee-gateway/docker-compose.yml
+++ b/ee-gateway/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   # extra download, and it is the only place root is used. This is NOT privileged
   # mode; the app containers themselves stay non-root.
   init_perms:
-    image: encryptedenergy/ee-gateway-worker:0.7.6@sha256:b3098383cbdf7be72d4e43e5f4581ae7b5f0ae4d3cb71e6e0136711c54a89df2
+    image: encryptedenergy/ee-gateway-worker:0.7.7@sha256:678688523b9357b87308aae532b8f57a0a5769eb43ad33911ad0c345220eb17b
     user: "0:0"
     entrypoint: ["sh", "-c", "chown -R 1000:1000 /data"]
     restart: on-failure
@@ -48,7 +48,7 @@ services:
   # Runs as uid 1000 (set in the image). init: true so SIGTERM reaches Flask
   # for a clean shutdown.
   ui:
-    image: encryptedenergy/ee-gateway-ui:0.6.3@sha256:2a5c2bb43daf5d22ad5f284d4cb6236c89365d83b31848acb8223c724e9bca75
+    image: encryptedenergy/ee-gateway-ui:0.6.4@sha256:c30e4b2a2bd640005499e4fe564a04f6650b920c0726b15e2437eaa41ffb25eb
     init: true
     restart: on-failure
     depends_on:
@@ -59,7 +59,7 @@ services:
     environment:
       EE_DATA_DIR: /data
       EE_UI_PORT: 8080
-      EE_GATEWAY_VERSION: "0.10.5"
+      EE_GATEWAY_VERSION: "0.10.6"
 
   # BLE scan + GPS-stamped cloud ingest worker. It reaches the host's
   # Bluetooth radio through bluetoothd over the D-Bus system bus, talks to
@@ -68,7 +68,7 @@ services:
   # Python process runs as uid 1000; gpsd starts as root only to open the
   # serial device, then drops to user nobody.
   worker:
-    image: encryptedenergy/ee-gateway-worker:0.7.6@sha256:b3098383cbdf7be72d4e43e5f4581ae7b5f0ae4d3cb71e6e0136711c54a89df2
+    image: encryptedenergy/ee-gateway-worker:0.7.7@sha256:678688523b9357b87308aae532b8f57a0a5769eb43ad33911ad0c345220eb17b
     init: true
     restart: on-failure
     depends_on:

--- a/ee-gateway/umbrel-app.yml
+++ b/ee-gateway/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ee-gateway
 category: networking
 name: EE Gateway
-version: "0.10.5"
+version: "0.10.6"
 tagline: Self-hosted Bluetooth gateway for open BLE networks
 description: >-
   EE Gateway turns your Umbrel into a self-hosted Bluetooth gateway for
@@ -27,18 +27,23 @@ description: >-
   encryptedenergy.com. It is an independent community project and is not
   affiliated with any specific BLE network.
 releaseNotes: >-
-  Fixes the (0.0, 0.0) fixed-location bug. Two coordinated changes:
-  the UI's location form no longer accepts (0, 0) as a valid coordinate
-  pair (they're the classic "unset" tell), and the worker's GpsClient
-  ignores any (0, 0) it finds in config.json and falls back to gpsd.
-  Prevents the failure mode where every packet gets rejected upstream
-  with an opaque HTTP 422.
+  Setup gets much easier. You can now type a street address or
+  landmark and the gateway looks up the coordinates for you, on both
+  the setup wizard and the location settings page. Coordinate entry
+  also accepts what people actually paste: the full "lat, lon" pair
+  copied from Google Maps dropped into either field, degree symbols,
+  N/S/E/W letters, and European decimal commas all work now.
 
 
-  Also adds EE_GPS_BAUD env var for u-blox M10-based receivers
-  (EVK-M102, NEO-M9N modules) that need a 38400 baud hint to gpsd.
-  Unset by default; standard consumer dongles (BU-353N, VK-172)
-  continue to work with gpsd's auto-probe.
+  Setup is also one field shorter: the organization ID is gone. Your
+  API token alone connects the gateway; existing installs are
+  unaffected and need no changes.
+
+
+  Reliability fix for busy gateways: when the EE cloud answers a
+  packet upload with HTTP 408 (request timeout) or 429 (rate limited),
+  the worker now keeps that packet queued and retries it on the next
+  pass instead of dropping it permanently. Worker 0.7.7, UI 0.6.4.
 developer: encryptedenergy.com
 website: https://encryptedenergy.com
 dependencies: []

--- a/ee-gateway/umbrel-app.yml
+++ b/ee-gateway/umbrel-app.yml
@@ -18,9 +18,9 @@ description: >-
 
   Two containers do the work: a worker that scans over Bluetooth and ingests
   packets upstream, and a small web dashboard for first-time setup and live
-  status. You'll need a free encryptedenergy.com account to create the
-  organization ID and API token used during setup. Enter those once in the
-  setup wizard, and the gateway runs on its own.
+  status. You'll need a free encryptedenergy.com account to create the API
+  token used during setup. Enter it once in the setup wizard, and the gateway
+  runs on its own.
 
 
   EE Gateway is free and open-source software (GPL-3.0-only), built by


### PR DESCRIPTION
Setup gets much easier: address geocoding on both location forms (type a street address or landmark and the gateway looks up the coordinates via OpenStreetMap), coordinate entry accepts pasted Google Maps "lat, lon" pairs, degree symbols, N/S/E/W letters, and European decimal commas, and the organization ID field is gone (the API token alone connects the gateway; existing installs unaffected). Also a worker reliability fix: HTTP 408/429 responses from the EE cloud are retried instead of the packet being dropped.

No permission or manifest-structure changes — image digest bumps + release notes only.

Full changelog: https://github.com/Encrypted-Energy/gateway/releases/tag/v0.10.6