### PR TITLE
Add PearCal Seeder

### DIFF
--- a/pearcal-seeder/docker-compose.yml
+++ b/pearcal-seeder/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   app:
     # Published, public, multi-arch (amd64 + arm64), pinned by manifest-list digest.
-    image: ghcr.io/peerloomllc/pearcal-seeder:1.0.33@sha256:36b9e9407b053c71b840f29a5f0423a67f15c2806827687b2cbec9dd69586c45
+    image: ghcr.io/peerloomllc/pearcal-seeder:1.0.34@sha256:6273ea9b8bb34a841768598587b601ef02a7b066625952633f08b24bb76111c6
     restart: on-failure
     stop_grace_period: 1m
     security_opt:

--- a/pearcal-seeder/docker-compose.yml
+++ b/pearcal-seeder/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: pearcal-seeder_app_1
+      APP_PORT: 8731
+
+  app:
+    # Published, public, multi-arch (amd64 + arm64), pinned by manifest-list digest.
+    image: ghcr.io/peerloomllc/pearcal-seeder:1.0.33@sha256:36b9e9407b053c71b840f29a5f0423a67f15c2806827687b2cbec9dd69586c45
+    restart: on-failure
+    stop_grace_period: 1m
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      SEEDER_HOST: 0.0.0.0
+      SEEDER_PORT: "8731"
+      SEEDER_NO_AUTH: "1"
+      SEEDER_NO_UPDATE_CHECK: "1"
+    volumes:
+      # Seeder identity, per-group enrollments, retention state, logs.
+      - ${APP_DATA_DIR}/data:/data

--- a/pearcal-seeder/umbrel-app.yml
+++ b/pearcal-seeder/umbrel-app.yml
@@ -1,0 +1,49 @@
+manifestVersion: 1
+id: pearcal-seeder
+category: networking
+name: PearCal Seeder
+version: "1.0.33"
+tagline: Keep your PearCal groups in sync 24/7
+description: >-
+  Run a blind seeder for your PearCal groups on your Umbrel so their calendars
+  stay in sync even when every phone is offline.
+
+
+  PearCal is a peer-to-peer calendar app with no accounts and no servers: a
+  group's events live only on its members' devices and sync directly between
+  them. That means a group is only reachable while at least one member's phone
+  is online. This app runs the PearCal seed-mode worklet as an always-on
+  background service that replicates each enrolled group's encrypted blocks, so
+  members stay caught up regardless of who's online.
+
+
+  It is a "blind" seeder: the blocks it stores and serves stay encrypted, so
+  your Umbrel keeps a group's data available without ever being able to read the
+  events, notes, or members inside it. Group members stay in control — they
+  admit the seeder when it enrolls and can revoke it group-wide at any time.
+
+
+  To enroll a group: open the seeder dashboard, then in the PearCal phone app
+  mint a seed invite for the group (Profile → Advanced → Blind peer) and paste
+  it in, or scan the dashboard's QR code from the app.
+releaseNotes: >-
+  First release of the PearCal Seeder for Umbrel. It runs the blind-seeder
+  worklet as an always-on background service with a dashboard for enrolling
+  groups, pairing by QR or invite link, and watching replication — reporting
+  only blind-safe metrics (bytes, blocks, writers, peers), never the encrypted
+  contents it cannot read.
+developer: PeerLoom
+website: https://peerloomllc.com
+dependencies: []
+repo: https://github.com/peerloomllc/pearcal-native
+support: https://github.com/peerloomllc/pearcal-native/issues
+port: 8732
+gallery:
+  - 1.webp
+  - 2.webp
+  - 3.webp
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: PeerLoom
+submission: https://github.com/getumbrel/umbrel-apps

--- a/pearcal-seeder/umbrel-app.yml
+++ b/pearcal-seeder/umbrel-app.yml
@@ -46,4 +46,4 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: PeerLoom
-submission: https://github.com/getumbrel/umbrel-apps
+submission: https://github.com/getumbrel/umbrel-apps/pull/5891

--- a/pearcal-seeder/umbrel-app.yml
+++ b/pearcal-seeder/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: pearcal-seeder
 category: networking
 name: PearCal Seeder
-version: "1.0.33"
+version: "1.0.34"
 tagline: Keep your PearCal groups in sync 24/7
 description: >-
   Run a blind seeder for your PearCal groups on your Umbrel so their calendars
@@ -26,22 +26,14 @@ description: >-
   To enroll a group: open the seeder dashboard, then in the PearCal phone app
   mint a seed invite for the group (Profile → Advanced → Blind peer) and paste
   it in, or scan the dashboard's QR code from the app.
-releaseNotes: >-
-  First release of the PearCal Seeder for Umbrel. It runs the blind-seeder
-  worklet as an always-on background service with a dashboard for enrolling
-  groups, pairing by QR or invite link, and watching replication — reporting
-  only blind-safe metrics (bytes, blocks, writers, peers), never the encrypted
-  contents it cannot read.
+releaseNotes: ""
 developer: PeerLoom
 website: https://peerloomllc.com
 dependencies: []
 repo: https://github.com/peerloomllc/pearcal-native
 support: https://github.com/peerloomllc/pearcal-native/issues
 port: 8732
-gallery:
-  - 1.webp
-  - 2.webp
-  - 3.webp
+gallery: []
 path: ""
 defaultUsername: ""
 defaultPassword: ""


### PR DESCRIPTION
### App submission: PearCal Seeder

**PearCal Seeder** runs a *blind seeder* for [PearCal](https://github.com/peerloomllc/pearcal-native), a peer-to-peer calendar app with no accounts and no servers.

PearCal groups sync directly between members' devices, so a group's calendar is only reachable while at least one member's phone is online. This app runs the PearCal seed-mode worklet as an always-on background service on the user's Umbrel, replicating each enrolled group's **encrypted** blocks so members stay caught up regardless of who's online.

It is *blind*: the blocks it stores and serves stay encrypted, so the Umbrel keeps a group's data available without ever being able to read the events, notes, or members inside it. Group members admit the seeder when it enrolls and can revoke it group-wide at any time.

**To use it:** open the seeder dashboard, then in the PearCal phone app mint a seed invite for a group (Profile → Advanced → Blind peer) and paste it in, or scan the dashboard's QR code.

### Notes for review

- **Image:** `ghcr.io/peerloomllc/pearcal-seeder` — public, multi-arch (amd64 + arm64), pinned by manifest-list digest.
- **`security_opt: no-new-privileges:true`** (lint warning): a hardening measure — the seeder never needs elevated privileges; it only reads/writes its own data volume and speaks P2P over the network.
- **No inbound auth inside the container** (`SEEDER_NO_AUTH`): access is gated by Umbrel's `app_proxy`, matching the existing PearCircle Seeder app.
- The in-app update checker is disabled (`SEEDER_NO_UPDATE_CHECK`) since updates come through the App Store.
- Developer: PeerLoom. Same submitter as the existing PearCircle Seeder app.

Gallery images will be provided as requested.