### PR TITLE
Add BitGarth

### DIFF
--- a/bitgarth/docker-compose.yml
+++ b/bitgarth/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8080
 
   web:
-    image: bitgarth/bitgarth:0.2.0@sha256:763070f1211232ff431e15b847736e4c17f8b44d2214763036f3e4b0cc660ae0
+    image: bitgarth/bitgarth:0.2.1@sha256:c37abd12671368af8f6bffd4be281f4f74025d10ba3f6f3ac72a0aec07c1c67c
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/bitgarth/docker-compose.yml
+++ b/bitgarth/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: bitgarth_web_1
+      APP_PORT: 8080
+
+  web:
+    image: bitgarth/bitgarth:0.2.0@sha256:763070f1211232ff431e15b847736e4c17f8b44d2214763036f3e4b0cc660ae0
+    restart: on-failure
+    stop_grace_period: 1m
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+    environment:
+      BITGARTH_CHANNEL: umbrel

--- a/bitgarth/docker-compose.yml
+++ b/bitgarth/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8080
 
   web:
-    image: bitgarth/bitgarth:0.2.1@sha256:c37abd12671368af8f6bffd4be281f4f74025d10ba3f6f3ac72a0aec07c1c67c
+    image: bitgarth/bitgarth:0.2.2@sha256:f493410916abadb38a05a23fd23a69424b04c5d5bc17a8f2ac32c0b7efefdfbd
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/bitgarth/docker-compose.yml
+++ b/bitgarth/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8080
 
   web:
-    image: bitgarth/bitgarth:0.2.2@sha256:f493410916abadb38a05a23fd23a69424b04c5d5bc17a8f2ac32c0b7efefdfbd
+    image: bitgarth/bitgarth:0.3.0@sha256:5bbedf1754ba98297fc4f71f5195d99b852f1b36379636164aad182cef7a443c
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/bitgarth/umbrel-app.yml
+++ b/bitgarth/umbrel-app.yml
@@ -1,0 +1,44 @@
+manifestVersion: 1
+id: bitgarth
+category: finance
+name: BitGarth
+version: "0.2.0"
+tagline: Local-first crypto portfolio tracker
+description: >-
+  BitGarth is a local-first portfolio tracker for your own Bitcoin and
+  Ethereum wallets. Create local users on your Umbrel — no central BitGarth
+  account, email address, seed phrase, or private key is required.
+
+
+  Add Bitcoin xpubs and Ethereum addresses for balance sync, track manual
+  assets, see your net worth in your own currency, and export plain-text
+  accounting files for hledger and ledger-cli.
+
+
+  Your wallet data, labels, settings, and saved API keys stay in an encrypted
+  local database protected by your password. BitGarth cannot unlock it for
+  you, so keep a backup.
+
+
+  An optional paid plan adds Bitcoin and Ethereum transaction-history backfill
+  and reports to support tax filing. Upgrading does not create a central user
+  account: BitGarth verifies payment and subscription identifiers that are
+  separate from local app users with its entitlement service, while your
+  portfolio and transaction data stay in your app instance.
+releaseNotes: ""
+
+developer: FernTrail B.V.
+website: https://bitgarth.app
+dependencies: []
+repo: ""
+support: mailto:hello@bitgarth.app
+
+port: 5555
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+submitter: FernTrail B.V.
+submission: https://github.com/getumbrel/umbrel-apps/pull/5894

--- a/bitgarth/umbrel-app.yml
+++ b/bitgarth/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bitgarth
 category: finance
 name: BitGarth
-version: "0.2.0"
+version: "0.2.1"
 tagline: Local-first crypto portfolio tracker
 description: >-
   BitGarth is a local-first portfolio tracker for your own Bitcoin and

--- a/bitgarth/umbrel-app.yml
+++ b/bitgarth/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bitgarth
 category: finance
 name: BitGarth
-version: "0.2.1"
+version: "0.2.2"
 tagline: Local-first crypto portfolio tracker
 description: >-
   BitGarth is a local-first portfolio tracker for your own Bitcoin and

--- a/bitgarth/umbrel-app.yml
+++ b/bitgarth/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bitgarth
 category: finance
 name: BitGarth
-version: "0.2.2"
+version: "0.3.0"
 tagline: Local-first crypto portfolio tracker
 description: >-
   BitGarth is a local-first portfolio tracker for your own Bitcoin and
@@ -30,7 +30,7 @@ releaseNotes: ""
 developer: FernTrail B.V.
 website: https://bitgarth.app
 dependencies: []
-repo: ""
+repo: https://github.com/BitGarth/bitgarth
 support: mailto:hello@bitgarth.app
 
 port: 5555


### PR DESCRIPTION
## Type

New app

## App

App ID: `bitgarth`
Upstream project: https://bitgarth.app
Version: 0.4.0

## Summary

Adds BitGarth, a local-first portfolio tracker for your own Bitcoin and Ethereum wallets (finance category). Local user accounts only - no central account, email, seed phrase, or private key required. Users add Bitcoin xpubs and Ethereum addresses for balance sync, track manual assets, and can export plain-text accounting files for hledger/ledger-cli. Wallet data is stored in an encrypted local SQLite database.

The package is ported from the developer's community app store ([FernTrail](https://github.com/FernTrail/ferntrail-umbrel-app-store)), where it is already functional: single `web` service behind `app_proxy`, image `bitgarth/bitgarth:0.4.0` pinned to its multi-arch index digest (amd64 + arm64 verified), data persisted via a `${APP_DATA_DIR}/data:/data` bind mount, manifest port 5555 (internal 8080, verified free in the host port space).

The app supports exporting and importing its wallet data in case any user needs to migrate from the community app store to the official app store.

## Verification

My primary testing is done by running the app on an Umbrel Home device via the community app store. This includes testing app upgrades. Other testing includes running it directly via docker, which allows me to test both docker architectures.

The testing below was done with the provided Claude skill (using the version at the time) on the same Umbrel Home device:

- `npm run lint:apps -- bitgarth --check-images`: no issues; `git diff --check` clean
- Fresh install through Umbrel (`umbreld client apps.install.mutate`), app reached `ready`
- Startup logs: BitGarth 0.2.0 on internal port 8080, SQLite database created inside the `${APP_DATA_DIR}/data` bind mount, all migrations applied; app_proxy proxying to `bitgarth_web_1:8080` on port 5555
- `http://umbrel.local:5555/` correctly redirects to Umbrel auth (no auth whitelist); app root serves the UI
- Browser click-through via the Umbrel UI: created a local user, logged in, logged out, logged back in
- Main functionality in the browser: added a test wallet with three accounts — a Bitcoin xpub, an Ethereum address, and a manual XMR account with a manually set balance of 1 XMR. Bitcoin and Ethereum balances synced accurately; after enabling CoinGecko, fiat conversion happened automatically
- Restarted the app from the Umbrel UI and verified the wallet and all three accounts were still there after logging back in
- API verification against the app container: first-run entry mode `Register`, user registration with terms/privacy acknowledgement, authenticated session via `/api/v1/auth/me`
- Restart through Umbrel (`apps.restart.mutate`): app returns to `ready`, login afterwards returns the same user ID — data persists across restart
- Settled logs contain no errors, warnings, or panics

Environment tested:
- [x] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64

Known lint warnings or caveats:

- No lint warnings
- arm64 covered by the image multi-arch manifest check (`docker buildx imagetools inspect`), not a runtime install
- Optional paid-plan/entitlement flow not tested (external payment service)

## Notes

Permissions, dependencies, migrations, default credentials, or caveats:

- No manifest permissions, no dependencies, no exports/hooks/templates
- No host-published ports; web UI only, behind `app_proxy` with Umbrel auth enabled
- No default credentials — first-run local account creation in the app (`defaultUsername`/`defaultPassword` empty)
- The app talks to external services for balance/price sync (e.g. mempool/Etherscan/CoinGecko endpoints, configurable in-app) and to BitGarth's entitlement service only for the optional paid plan
- The [BitGarth application source code](https://github.com/BitGarth/bitgarth)
is published under the Functional Source License 1.1 (FSL-1.1-ALv2). Each
release becomes available under the Apache License 2.0 on its second
anniversary.
- Logo: https://bitgarth.app/assets/favicon/icon-512.png

### Screenshots

![BitGarth screenshot 1](https://raw.githubusercontent.com/FernTrail/ferntrail-umbrel-app-store/main/ferntrail-bitgarth/gallery/1.jpg)

![BitGarth screenshot 2](https://raw.githubusercontent.com/FernTrail/ferntrail-umbrel-app-store/main/ferntrail-bitgarth/gallery/2.jpg)

![BitGarth screenshot 3](https://raw.githubusercontent.com/FernTrail/ferntrail-umbrel-app-store/main/ferntrail-bitgarth/gallery/3.jpg)

![BitGarth screenshot 4](https://raw.githubusercontent.com/FernTrail/ferntrail-umbrel-app-store/main/ferntrail-bitgarth/gallery/4.jpg)

![BitGarth screenshot 5](https://raw.githubusercontent.com/FernTrail/ferntrail-umbrel-app-store/main/ferntrail-bitgarth/gallery/5.jpg)
