### PR TITLE
fix(lnbits): persist extension code on the data volume

### DIFF
--- a/lnbits/docker-compose.yml
+++ b/lnbits/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       LNBITS_HOST: "0.0.0.0"
       LNBITS_PORT: 3007
       LNBITS_DATA_FOLDER: "/data"
+      LNBITS_EXTENSIONS_PATH: "/data"
       AUTH_HTTPS_ONLY: "false"
 
       # LND

--- a/lnbits/umbrel-app.yml
+++ b/lnbits/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lnbits
 category: bitcoin
 name: LNbits
-version: "1.5.6"
+version: "1.5.6-patch.1"
 tagline: Multi-user wallet management system
 description: >-
   LNbits is a simple multi-user and account system for Lightning
@@ -28,6 +28,12 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
+  This update makes LNbits extensions more reliable by keeping them installed across app restarts. It helps prevent extensions from unexpectedly becoming inactive or needing to be downloaded again after a restart.
+
+
+  LNbits may restore your installed extensions once while applying this update.
+
+
   LNbits v1.5.6 improves payment handling, reduces polling for NWC funding sources, and lowers exchange-rate request load by using the LNbits price aggregator.
 
 


### PR DESCRIPTION
## Summary
- Set `LNBITS_EXTENSIONS_PATH=/data` so installed extension code lives on the persistent app data volume (`/data/extensions/<id>/`) instead of the ephemeral container filesystem (`/app/lnbits/extensions`).
- Without this, LNbits’ boot-time `check_installed_extensions()` tries to restore missing files; on failure it calls `deactivate_extension()` and users see all extensions suddenly inactive after a restart/power loss (wallet/extension DBs under `/data` are still present).

## Why
Umbrel already mounts `${APP_DATA_DIR}/data:/data` and sets `LNBITS_DATA_FOLDER=/data`, but leaves the default extensions path (`lnbits` → `/app/lnbits/extensions`). That path does not survive container recreate.

## Test plan
- [ ] Fresh Umbrel LNbits install with this compose change
- [ ] Install a few extensions; confirm trees under `${APP_DATA_DIR}/data/extensions/`
- [ ] Recreate the web container / reboot; extensions stay active; logs should not mass `Failed to re-install extension`
- [ ] Existing installs after update: one restore-from-zip pass is OK, or pre-copy trees into `data/extensions/`