### PR TITLE
Add Executor

### DIFF
--- a/executor/docker-compose.yml
+++ b/executor/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.7"
+services:
+  app_proxy:
+    environment:
+      APP_HOST: executor_web_1
+      APP_PORT: 4788
+      # MCP clients cannot present Umbrel's browser session. Executor applies
+      # its own OAuth or bearer authentication to these protocol endpoints.
+      PROXY_AUTH_WHITELIST: "/mcp,/mcp/*,/.well-known/*,/api/auth/mcp/*,/api/auth/device/*,/api/auth/cli-login"
+
+  web:
+    image: ghcr.io/usefulsoftwareco/executor-selfhost:v1.5.34@sha256:4a5997d38c38bf2c4554297fcf021e9c7089dbf3e5a27c92cb0657580f0c484a
+    user: "1000:1000"
+    restart: on-failure
+    stop_grace_period: 1m
+    environment:
+      EXECUTOR_WEB_BASE_URL: "http://${DEVICE_DOMAIN_NAME}:${APP_PROXY_PORT}"
+    volumes:
+      - ${APP_DATA_DIR}/data:/data

--- a/executor/umbrel-app.yml
+++ b/executor/umbrel-app.yml
@@ -1,0 +1,39 @@
+manifestVersion: 1
+id: executor
+category: developer
+name: Executor
+version: "1.5.34"
+tagline: Connect any AI agent to every tool
+description: >-
+  Executor is an open-source integration layer for AI agents. Configure MCP
+  servers, OpenAPI specifications, GraphQL APIs, authentication, and per-tool
+  policies once, then share the resulting tool catalog with any MCP-compatible
+  agent.
+
+
+  Open Executor after installation and create the owner account. The first
+  account becomes the owner; after setup, new users can only join with
+  single-use invite links created from the Admin page.
+
+
+  Executor runs as a single container with an embedded SQLite database and
+  QuickJS sandbox. Sandboxed tools cannot access loopback or private network
+  addresses by default. All application data, credentials, encryption keys, and
+  policies remain on your Umbrel.
+releaseNotes: ""
+
+developer: Useful Software Co
+website: https://executor.sh
+dependencies: []
+repo: https://github.com/UsefulSoftwareCo/executor
+support: https://github.com/UsefulSoftwareCo/executor/issues
+
+port: 4788
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+submitter: salmonumbrella
+submission: https://github.com/getumbrel/umbrel-apps/pull/5896


### PR DESCRIPTION
# App Submission

## App name:

Executor

## What is it?

Executor is a self-hosted integration layer for AI agents. Connect MCP servers, OpenAPI specifications, and GraphQL APIs once, configure authentication and per-tool policies, then expose one governed tool catalog to any MCP-compatible agent.

It runs as a single container with an embedded SQLite database and QuickJS sandbox. The first account created becomes the owner, and additional users join through single-use invite links created from the Admin page.

- Website: https://executor.sh
- Source: https://github.com/UsefulSoftwareCo/executor
- Docker image: `ghcr.io/usefulsoftwareco/executor-selfhost:v1.5.34` (multi-architecture and pinned by digest)

## 256x256 app icon

<img width="256" height="256" alt="Executor app icon — full-bleed black square with white Executor mark" src="https://raw.githubusercontent.com/salmonumbrella/umbrel-apps/executor-assets/.github/pr-assets/executor-icon.svg" />

The submitted SVG uses an opaque 256×256 black canvas with the original Executor mark in vector paths. It is full-bleed for umbrelOS rounded-square clipping, with no circular alpha mask or translucent side gutters.

## Gallery images

<img width="2160" height="1350" alt="Executor — connect any agent to every tool" src="https://executor.sh/og-image.png" />

<img width="1024" height="686" alt="Executor integrations workspace" src="https://raw.githubusercontent.com/UsefulSoftwareCo/executor/main/apps/docs/images/desktop-app.png" />

## Notes for reviewers

- New app: one self-contained container with SQLite, QuickJS tool execution, the browser UI, and the MCP server.
- Port 4788 is the upstream default.
- No default credentials — the first user creates the owner account in the browser after installation.
- The database, generated encryption keys, authentication state, integrations, credentials, and policies persist under `${APP_DATA_DIR}/data`.
- Executor's sandbox cannot access loopback or private network addresses by default.
- The browser UI remains behind Umbrel's `app_proxy` authentication. MCP and related OAuth/device-auth routes bypass the browser-session gate because MCP clients cannot present an Umbrel browser session; Executor still validates its own OAuth or bearer authorization on those routes.
- `EXECUTOR_WEB_BASE_URL` uses Umbrel's canonical device hostname and app proxy port.
- `npm run lint:apps -- executor --check-images` passes with no issues.
- Additional official gallery imagery has been requested from `@RhysSullivan` in https://github.com/UsefulSoftwareCo/executor/issues/1289.

## I have tested my app on:

- [x] umbrelOS on a Raspberry Pi
- [x] umbrelOS on an Umbrel Home
- [x] umbrelOS on x86_64 Linux hardware
- [x] arm64 Docker image smoke test

