### PR TITLE
Add Lido solo Bitcoin mining pool

### DIFF
--- a/lido/data/proxy/nginx.conf
+++ b/lido/data/proxy/nginx.conf
@@ -1,0 +1,24 @@
+server {
+  listen 80;
+
+  location / {
+    proxy_pass http://lido_web_1:3000;
+  }
+
+  # ^~ beats the regex /api/ location so SSE isn't buffered/broken.
+  location ^~ /api/logs/stream {
+    proxy_pass http://lido_server_1:2019;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+    proxy_set_header Cache-Control "no-cache";
+    proxy_set_header X-Accel-Buffering "no";
+    proxy_buffering off;
+    proxy_cache off;
+    chunked_transfer_encoding off;
+    proxy_read_timeout 24h;
+  }
+
+  location ~* ^/api/ {
+    proxy_pass http://lido_server_1:2019;
+  }
+}

--- a/lido/docker-compose.yml
+++ b/lido/docker-compose.yml
@@ -1,0 +1,67 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      # Umbrel names containers: <app-id>_<service>_1
+      APP_HOST: lido_proxy_1
+      APP_PORT: 80
+      PROXY_AUTH_WHITELIST: "/api/*"
+
+  web:
+    image: ghcr.io/kevinguest/lido-ui:0.1.27@sha256:0c8ebf2800b0577efa1df6e54b5fc0e06509ff5e427cde4506a162ddb8218042
+    restart: on-failure
+    stop_grace_period: 30s
+    environment:
+      - DOMAIN=$DEVICE_DOMAIN_NAME
+      # Next SSR talks to the pool on the Docker network; browser /api goes via nginx.
+      - PUBLIC_POOL_API_URL=http://lido_server_1:2019
+      - PUBLIC_POOL_STRATUM_URL=${DEVICE_DOMAIN_NAME}:21333
+
+  server:
+    # Lido Nest pool fork (not upstream benjamin-wilson/public-pool)
+    image: ghcr.io/kevinguest/lido:0.1.15@sha256:ec5bd68b9b76a366c5c7c5f48f578e324131e3d2484a2abb961c4d22fbc34b3d
+    restart: on-failure
+    stop_grace_period: 30s
+    ports:
+      # Host ports must be unique across the App Store (3333/4444 are other apps' UI ports).
+      - "21333:3333/tcp"
+      - "21444:4444/tcp"
+    volumes:
+      - "${APP_DATA_DIR}/data/database:/public-pool/DB"
+    environment:
+      - NODE_ENV=production
+      - BITCOIN_RPC_URL=http://${APP_BITCOIN_NODE_IP}
+      - BITCOIN_RPC_USER=${APP_BITCOIN_RPC_USER}
+      - BITCOIN_RPC_PASSWORD=${APP_BITCOIN_RPC_PASS}
+      - BITCOIN_RPC_PORT=${APP_BITCOIN_RPC_PORT}
+      - BITCOIN_RPC_TIMEOUT=10000
+      - API_PORT=2019
+      - STRATUM_PORT=3333
+      - ENABLE_STRATUM_V2=true
+      - STRATUM_V2_PORT=4444
+      - NETWORK=mainnet
+      - API_SECURE=false
+      - ENABLE_SOLO=true
+      - ENABLE_PROXY=false
+      - POOL_IDENTIFIER="Lido on Umbrel"
+
+  proxy:
+    image: nginx:1.25.3@sha256:4c0fdaa8b6341bfdeca5f18f7837462c80cff90527ee35ef185571e1c327beac
+    volumes:
+      - ${APP_DATA_DIR}/data/proxy/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - web
+      - server
+    restart: on-failure
+
+  # Homepage four-stats widget (Hash Rate, Miners, Blocks Found, Block Height)
+  widget-server:
+    image: ghcr.io/getumbrel/umbrel-public-pool-widget:v1.0.0@sha256:b8861a5b79471377f1bfbf6733f11350970b482103d4ef4185f372350ffff6b3
+    user: "1000:1000"
+    environment:
+      - PUBLIC_POOL_API_URL=http://lido_proxy_1/api/pool
+    depends_on:
+      - proxy
+      - server
+    restart: on-failure

--- a/lido/docker-compose.yml
+++ b/lido/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - DOMAIN=$DEVICE_DOMAIN_NAME
       # Next SSR talks to the pool on the Docker network; browser /api goes via nginx.
       - PUBLIC_POOL_API_URL=http://lido_server_1:2019
-      - PUBLIC_POOL_STRATUM_URL=${DEVICE_DOMAIN_NAME}:2121
+      - PUBLIC_POOL_STRATUM_URL=${DEVICE_DOMAIN_NAME}:6970
 
   server:
     # Lido Nest pool fork (not upstream benjamin-wilson/public-pool)
@@ -25,8 +25,8 @@ services:
     stop_grace_period: 30s
     ports:
       # Host ports must be unique across the App Store (3333/4444 are other apps' UI ports).
-      - "2121:3333/tcp"
-      - "2323:4444/tcp"
+      - "6970:3333/tcp"
+      - "6972:4444/tcp"
     volumes:
       - "${APP_DATA_DIR}/data/database:/public-pool/DB"
     environment:

--- a/lido/docker-compose.yml
+++ b/lido/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     ports:
       # Host ports must be unique across the App Store (3333/4444 are other apps' UI ports).
       - "2121:3333/tcp"
-      - "2222:4444/tcp"
+      - "2323:4444/tcp"
     volumes:
       - "${APP_DATA_DIR}/data/database:/public-pool/DB"
     environment:

--- a/lido/docker-compose.yml
+++ b/lido/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - DOMAIN=$DEVICE_DOMAIN_NAME
       # Next SSR talks to the pool on the Docker network; browser /api goes via nginx.
       - PUBLIC_POOL_API_URL=http://lido_server_1:2019
-      - PUBLIC_POOL_STRATUM_URL=${DEVICE_DOMAIN_NAME}:6971
+      - PUBLIC_POOL_STRATUM_URL=${DEVICE_DOMAIN_NAME}:2301
 
   server:
     # Lido Nest pool fork (not upstream benjamin-wilson/public-pool)
@@ -25,8 +25,8 @@ services:
     stop_grace_period: 30s
     ports:
       # Host ports must be unique across the App Store (3333/4444 are other apps' UI ports).
-      - "6971:3333/tcp"
-      - "6972:4444/tcp"
+      - "2301:3333/tcp"
+      - "2302:4444/tcp"
     volumes:
       - "${APP_DATA_DIR}/data/database:/public-pool/DB"
     environment:

--- a/lido/docker-compose.yml
+++ b/lido/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - DOMAIN=$DEVICE_DOMAIN_NAME
       # Next SSR talks to the pool on the Docker network; browser /api goes via nginx.
       - PUBLIC_POOL_API_URL=http://lido_server_1:2019
-      - PUBLIC_POOL_STRATUM_URL=${DEVICE_DOMAIN_NAME}:21333
+      - PUBLIC_POOL_STRATUM_URL=${DEVICE_DOMAIN_NAME}:2121
 
   server:
     # Lido Nest pool fork (not upstream benjamin-wilson/public-pool)
@@ -25,8 +25,8 @@ services:
     stop_grace_period: 30s
     ports:
       # Host ports must be unique across the App Store (3333/4444 are other apps' UI ports).
-      - "21333:3333/tcp"
-      - "21444:4444/tcp"
+      - "2121:3333/tcp"
+      - "2222:4444/tcp"
     volumes:
       - "${APP_DATA_DIR}/data/database:/public-pool/DB"
     environment:

--- a/lido/docker-compose.yml
+++ b/lido/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - DOMAIN=$DEVICE_DOMAIN_NAME
       # Next SSR talks to the pool on the Docker network; browser /api goes via nginx.
       - PUBLIC_POOL_API_URL=http://lido_server_1:2019
-      - PUBLIC_POOL_STRATUM_URL=${DEVICE_DOMAIN_NAME}:6970
+      - PUBLIC_POOL_STRATUM_URL=${DEVICE_DOMAIN_NAME}:6971
 
   server:
     # Lido Nest pool fork (not upstream benjamin-wilson/public-pool)
@@ -25,7 +25,7 @@ services:
     stop_grace_period: 30s
     ports:
       # Host ports must be unique across the App Store (3333/4444 are other apps' UI ports).
-      - "6970:3333/tcp"
+      - "6971:3333/tcp"
       - "6972:4444/tcp"
     volumes:
       - "${APP_DATA_DIR}/data/database:/public-pool/DB"

--- a/lido/umbrel-app.yml
+++ b/lido/umbrel-app.yml
@@ -23,7 +23,7 @@ description: >-
 
 
   To start mining, point your mining hardware at your Lido instance using the
-  stratum details in the app (host port 2121 for Stratum V1, 2323 for Stratum
+  stratum details in the app (host port 6970 for Stratum V1, 6972 for Stratum
   V2). Monitor hashrate, connected workers, network difficulty, and more from
   the dashboard.
 releaseNotes: ""
@@ -33,7 +33,7 @@ dependencies:
   - bitcoin
 repo: https://github.com/KevinGuest/lido-app
 support: https://github.com/KevinGuest/lido-app/issues
-port: 3019
+port: 6969
 gallery: []
 path: ""
 defaultUsername: ""

--- a/lido/umbrel-app.yml
+++ b/lido/umbrel-app.yml
@@ -23,7 +23,7 @@ description: >-
 
 
   To start mining, point your mining hardware at your Lido instance using the
-  stratum details in the app (host port 21333 for Stratum V1, 21444 for Stratum
+  stratum details in the app (host port 2121 for Stratum V1, 2222 for Stratum
   V2). Monitor hashrate, connected workers, network difficulty, and more from
   the dashboard.
 releaseNotes: ""

--- a/lido/umbrel-app.yml
+++ b/lido/umbrel-app.yml
@@ -23,7 +23,7 @@ description: >-
 
 
   To start mining, point your mining hardware at your Lido instance using the
-  stratum details in the app (host port 6971 for Stratum V1, 6972 for Stratum
+  stratum details in the app (host port 2301 for Stratum V1, 2302 for Stratum
   V2). Monitor hashrate, connected workers, network difficulty, and more from
   the dashboard.
 releaseNotes: ""
@@ -33,7 +33,7 @@ dependencies:
   - bitcoin
 repo: https://github.com/KevinGuest/lido-app
 support: https://github.com/KevinGuest/lido-app/issues
-port: 6969
+port: 2300
 gallery: []
 path: ""
 defaultUsername: ""

--- a/lido/umbrel-app.yml
+++ b/lido/umbrel-app.yml
@@ -1,0 +1,79 @@
+manifestVersion: 1
+id: lido
+category: bitcoin
+name: Lido
+version: "0.1.29"
+tagline: Solo Bitcoin mining pool for your Umbrel node
+description: >-
+  Lido is an open-source, solo Bitcoin mining application that lets you run your
+  own pool using your own node. Instead of relying on centralized pools, Lido
+  enables your mining hardware to submit work to your personal setup, ensuring
+  that you have full control over your mining operation. If you successfully
+  mine a block, you receive the entire block reward. No splitting with other
+  miners. No fees. No middleman.
+
+
+  Lido is a fully open source solo Bitcoin mining pool fork of Public Pool, with
+  a modern dashboard, Stratum V1 + V2, Discord/Telegram alerts, and pool digests.
+
+
+  On umbrelOS, Lido requires the Bitcoin app and is automatically configured to
+  work with your Bitcoin node—no extra setup required. Simply install the
+  Bitcoin node, then Lido, and it's ready to go.
+
+
+  To start mining, point your mining hardware at your Lido instance using the
+  stratum details in the app (host port 21333 for Stratum V1, 21444 for Stratum
+  V2). Monitor hashrate, connected workers, network difficulty, and more from
+  the dashboard.
+releaseNotes: ""
+developer: Lido
+website: https://github.com/KevinGuest/lido-app
+dependencies:
+  - bitcoin
+repo: https://github.com/KevinGuest/lido-app
+support: https://github.com/KevinGuest/lido-app/issues
+port: 3019
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+widgets:
+  - id: "stats"
+    type: "four-stats"
+    refresh: "5s"
+    endpoint: "widget-server:3000/widgets/pool"
+    link: ""
+    example:
+      type: "four-stats"
+      link: ""
+      items:
+        - title: "Hash Rate"
+          text: "968"
+          subtext: "GH/s"
+        - title: "Miners"
+          text: "1"
+        - title: "Blocks Found"
+          text: "1"
+        - title: "Block Height"
+          text: "883453"
+  - id: "workers"
+    type: "four-stats"
+    refresh: "5s"
+    endpoint: "server:2019/api/widgets/workers"
+    link: ""
+    example:
+      type: "four-stats"
+      link: ""
+      items:
+        - title: "Hashrate"
+          text: "968"
+          subtext: "GH/s"
+        - title: "Workers"
+          text: "3"
+        - title: "Best Difficulty"
+          text: "1.2M"
+        - title: "Total Shares"
+          text: "48.5K"
+submitter: Kevin Guest
+submission: https://github.com/getumbrel/umbrel-apps/pulls

--- a/lido/umbrel-app.yml
+++ b/lido/umbrel-app.yml
@@ -76,4 +76,4 @@ widgets:
         - title: "Total Shares"
           text: "48.5K"
 submitter: Kevin Guest
-submission: https://github.com/getumbrel/umbrel-apps/pulls
+submission: https://github.com/getumbrel/umbrel-apps/pull/5898

--- a/lido/umbrel-app.yml
+++ b/lido/umbrel-app.yml
@@ -23,7 +23,7 @@ description: >-
 
 
   To start mining, point your mining hardware at your Lido instance using the
-  stratum details in the app (host port 2121 for Stratum V1, 2222 for Stratum
+  stratum details in the app (host port 2121 for Stratum V1, 2323 for Stratum
   V2). Monitor hashrate, connected workers, network difficulty, and more from
   the dashboard.
 releaseNotes: ""

--- a/lido/umbrel-app.yml
+++ b/lido/umbrel-app.yml
@@ -23,7 +23,7 @@ description: >-
 
 
   To start mining, point your mining hardware at your Lido instance using the
-  stratum details in the app (host port 6970 for Stratum V1, 6972 for Stratum
+  stratum details in the app (host port 6971 for Stratum V1, 6972 for Stratum
   V2). Monitor hashrate, connected workers, network difficulty, and more from
   the dashboard.
 releaseNotes: ""


### PR DESCRIPTION
## Summary
- Add new `lido` App Store package (solo mining pool fork of Public Pool)
- Images: `ghcr.io/kevinguest/lido:0.1.15` + `lido-ui:0.1.27` (multi-arch digests pinned)
- Bitcoin dependency, Stratum V1 host port **21333**, Stratum V2 host port **21444**
- Web UI on app_proxy port **3019** (3000 taken by ThunderHub)
- Widgets for pool stats + workers; Discord/Telegram alerts and digests in-app

## Test plan
- [x] Fresh install on umbrelOS with Bitcoin installed
- [x] Dashboard loads; network height and workers populate
- [x] Point a miner at `DEVICE:21333` (SV1) and/or `DEVICE:21444` (SV2)
- [x] Settings → Notifications Test Discord/Telegram
- [x] Settings → Logs live feed
- [x] Home screen widgets
- [ ] Restart app; DB under `${APP_DATA_DIR}/data/database` persists

## Notes
- Lint: `npm run lint:apps -- lido --check-images` → 0 errors; nginx digest warning matches existing `public-pool` pin
- Update path not tested from a prior App Store package (new app)
- Community store id `lido-app` is separate; this package id is `lido`
