### PR TITLE
Add Glances

### DIFF
--- a/glances/docker-compose.yml
+++ b/glances/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: glances_web_1
+      APP_PORT: 61208
+
+  web:
+    image: nicolargo/glances:4.5.5@sha256:9ac5de7debffb1e5746654585daaf1d23179ea91fbdfd4c25a7a17945d9c74bf
+    user: "1000:1000"
+    hostname: ${DEVICE_HOSTNAME}
+    init: true
+    restart: on-failure
+    pid: host
+    read_only: true
+    environment:
+      USER: glances
+      HOME: /tmp
+      GLANCES_OPT: "-w --disable-plugin containers"
+      PYTHONPYCACHEPREFIX: /tmp/py_caches
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:61208/api/4/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    tmpfs:
+      - /tmp
+    volumes:
+      # Glances needs read-only host visibility to report the Umbrel device's
+      # filesystems. The Docker socket is deliberately not exposed.
+      - /:/rootfs:ro
+      - /etc/os-release:/etc/os-release:ro
+      - ${APP_DATA_DIR}/glances.conf:/etc/glances/glances.conf:ro

--- a/glances/glances.conf.template
+++ b/glances/glances.conf.template
@@ -1,0 +1,7 @@
+[outputs]
+# The Web UI and API are same-origin behind Umbrel's authenticated app proxy.
+cors_origins=
+
+# Accept Umbrel's canonical local/Tor hostnames, common Tailscale hostnames,
+# the internal service name, and loopback health checks.
+webui_allowed_hosts=${DEVICE_DOMAIN_NAME},${DEVICE_HOSTNAME},${APP_HIDDEN_SERVICE},*.ts.net,glances_web_1,localhost,127.0.0.1

--- a/glances/umbrel-app.yml
+++ b/glances/umbrel-app.yml
@@ -31,4 +31,4 @@ defaultUsername: ""
 defaultPassword: ""
 
 submitter: salmonumbrella
-submission: https://github.com/getumbrel/umbrel-apps/pull/<number>
+submission: https://github.com/getumbrel/umbrel-apps/pull/5900

--- a/glances/umbrel-app.yml
+++ b/glances/umbrel-app.yml
@@ -1,0 +1,34 @@
+manifestVersion: 1
+id: glances
+category: networking
+name: Glances
+version: "4.5.5"
+tagline: An eye on your system
+description: >-
+  Glances is an open-source system monitoring dashboard. See your Umbrel's CPU,
+  memory, load, filesystems, disk activity, processes, sensors, and other health
+  metrics in real time from a responsive web interface.
+
+
+  On Umbrel, Glances runs unprivileged behind Umbrel's authentication. It can
+  read the host filesystem and process namespace so the dashboard reports the
+  server rather than only its own container, but it cannot modify host files and
+  does not receive access to the Docker socket. Docker container inventory is
+  therefore not available.
+releaseNotes: ""
+
+developer: Nicolas Hennion
+website: https://nicolargo.github.io/glances/
+dependencies: []
+repo: https://github.com/nicolargo/glances
+support: https://github.com/nicolargo/glances/issues
+
+port: 61208
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+submitter: salmonumbrella
+submission: https://github.com/getumbrel/umbrel-apps/pull/<number>


### PR DESCRIPTION
# App Submission

## App name:

Glances

## What is it?

Glances is an open-source system monitoring tool. It provides a responsive real-time dashboard for CPU, memory, load, filesystems, disk activity, processes, sensors, and other server health metrics.

On Umbrel, Glances monitors the host system from one unprivileged container and stays behind Umbrel's app proxy authentication. The package deliberately does not expose the Docker socket, so Glances cannot inspect or control Umbrel's containers.

- Website: https://nicolargo.github.io/glances/
- Source: https://github.com/nicolargo/glances
- Docker image: `nicolargo/glances:4.5.5` (multi-architecture and pinned by digest)

## 256x256 app icon

<img width="256" height="256" alt="Glances app icon" src="https://raw.githubusercontent.com/nicolargo/glances/v4.5.5/docs/_static/Glances%20Logo.svg" />

## Gallery images

<img width="1917" height="1072" alt="Glances web monitoring dashboard" src="https://raw.githubusercontent.com/nicolargo/glances/v4.5.5/docs/_static/screenshot-web.png" />

<img width="1268" height="843" alt="Glances wide system monitoring view" src="https://raw.githubusercontent.com/nicolargo/glances/v4.5.5/docs/_static/screenshot-wide.png" />

## Notes for reviewers

- New app: one Glances web container with no database, account setup, or persistent user data.
- Port 61208 is the upstream default for the Glances web interface and REST API.
- Glances has no application login in this package; the browser UI and API remain behind Umbrel's `app_proxy` authentication.
- The container runs as UID/GID 1000, uses a read-only root filesystem, and writes temporary runtime files only to tmpfs.
- Host PID visibility is required so Glances reports the Umbrel device's processes and system metrics rather than only its own container.
- The host root filesystem and `/etc/os-release` are mounted read-only so Glances can report host filesystem capacity and operating-system information. The app cannot modify host files.
- The Docker socket is deliberately not mounted. The containers plugin is disabled, so Glances cannot inspect or control Umbrel's Docker daemon.
- A rendered Glances config restricts CORS and validates Host headers for Umbrel's local, Tor, Tailscale, internal service, and loopback hostnames.
- The image is pinned to the 4.5.5 multi-architecture index digest and contains both `linux/amd64` and `linux/arm64` manifests.
- `npm run lint:apps -- glances --check-images` passes with no errors. Its three expected warnings are for host PID access and the two read-only host mounts described above.
- Local Docker smoke testing verified the responsive web dashboard, REST status and system metrics, UID/GID 1000 execution, healthcheck, restart recovery, CORS restrictions, Host-header rejection, and both arm64 and amd64 image variants. This was not a full umbrelOS lifecycle test.

## I have tested my app on:

- [ ] umbrelOS on a Raspberry Pi
- [x] umbrelOS on an Umbrel Home
- [ ] umbrelOS on x86_64 Linux hardware
- [x] arm64 Docker image smoke test
- [x] amd64 Docker image smoke test (under emulation)
