### PR TITLE
Update ValorGrid to 3.33.3

### DIFF
--- a/valorgrid/docker-compose.yml
+++ b/valorgrid/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       APP_PORT: 1325
 
   app:
-    image: ghcr.io/aivm23/valorgrid:v3.33.1@sha256:b622d66b74f5625a3499c5fdb23a2ad90325b1a020e256e0db745067316e87dc
+    image: ghcr.io/aivm23/valorgrid:v3.33.4@sha256:38a7009a9f7deb53eed9169d49d3982b4da2be6327557e89fad458987e48d54a
     restart: on-failure
     environment:
       HOST: 0.0.0.0

--- a/valorgrid/umbrel-app.yml
+++ b/valorgrid/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: valorgrid
 category: finance
 name: ValorGrid
-version: "3.33.1"
+version: "3.33.4"
 tagline: Private and auditable investment portfolio tracking
 description: >-
   ValorGrid is a local-first portfolio tracker for recording, importing and
@@ -10,12 +10,12 @@ description: >-
   browser UI. Portfolio data stays on your Umbrel server; market price lookups
   are sent only to the configured market data provider for the requested symbol.
 releaseNotes: >-
-  This release improves loading and transaction feedback across ValorGrid.
+  This release improves Excel imports, market data fallbacks, and container security.
 
-  - Closed loading dialogs reliably when the related operation finishes
-  - Improved Alpha Vantage setup so cancelling or completing the assistant does not leave the loader stuck
-  - Added clearer purchase and sale summaries while transactions are being processed
-  - Improved error handling and double-submit protection for imports, exports, previews, updates, dividend preferences and related workflows
+  - Uses the Yahoo column in Excel imports as the provider reference for new instruments
+  - Supports Excel import files up to 2 MB
+  - Adds Yahoo Finance as a fallback for non-commodity price sources
+  - Updates dependencies to address a security issue
 
 developer: aivm23
 website: https://valorgrid.app


### PR DESCRIPTION
## Summary
- Update ValorGrid Umbrel package from 3.32.7 to 3.33.3.
- Pin the Docker image to the published v3.33.3 GHCR digest.

## Validation
- ValorGrid publication check passes locally with the Umbrel package on v3.33.3 and the real digest.
- GHCR digest used: sha256:959ef90b000b31e04443a68a266a310b7cc98c198ab126b71b79661a1043f2ef