### PR TITLE
Add Hindsight (long-term memory for AI agents)

### DIFF
--- a/hindsight/docker-compose.yml
+++ b/hindsight/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       APP_PORT: 9999
 
   server:
+    # NOTE: bump to a release that includes the instance LLM-config UI
+    # (server LLM config API) before submitting the Umbrel PR, so the app can be
+    # configured from the browser after a keyless boot below.
     image: ghcr.io/vectorize-io/hindsight:0.8.4@sha256:2c60f233eaba8f51db31adb920a560735aaf6f314e4b63c36c73159742dfa1a7
     restart: on-failure
     stop_grace_period: 1m
@@ -20,9 +23,8 @@ services:
       # Embeddings and reranking run locally on-device (no external calls).
       - HINDSIGHT_API_EMBEDDINGS_PROVIDER=local
       - HINDSIGHT_API_RERANKER_PROVIDER=local
-      # LLM used to extract and consolidate memories. Set your provider and key
-      # before storing memories. OpenAI is the default; Anthropic, Gemini, Groq
-      # and other OpenAI-compatible providers are also supported.
-      - HINDSIGHT_API_LLM_PROVIDER=openai
-      - HINDSIGHT_API_LLM_API_KEY=
-      # - HINDSIGHT_API_LLM_MODEL=gpt-4.1-mini
+      # Boot without an LLM so the app starts on a fresh install (a key-requiring
+      # provider would otherwise fail to boot). The user then sets their LLM
+      # provider + API key in the app's Settings page, which applies at runtime
+      # without a restart.
+      - HINDSIGHT_API_LLM_PROVIDER=none

--- a/hindsight/docker-compose.yml
+++ b/hindsight/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: hindsight_server_1
+      APP_PORT: 9999
+
+  server:
+    image: ghcr.io/vectorize-io/hindsight:0.8.4@sha256:2c60f233eaba8f51db31adb920a560735aaf6f314e4b63c36c73159742dfa1a7
+    restart: on-failure
+    stop_grace_period: 1m
+    user: "1000:1000"
+    volumes:
+      # Embedded PostgreSQL (pgvector) data. The image pre-creates this path for
+      # UID 1000, so a fresh Umbrel volume is seeded with correct ownership and
+      # memories persist across app updates and restarts.
+      - ${APP_DATA_DIR}/data:/home/hindsight/.pg0
+    environment:
+      # Embeddings and reranking run locally on-device (no external calls).
+      - HINDSIGHT_API_EMBEDDINGS_PROVIDER=local
+      - HINDSIGHT_API_RERANKER_PROVIDER=local
+      # LLM used to extract and consolidate memories. Set your provider and key
+      # before storing memories. OpenAI is the default; Anthropic, Gemini, Groq
+      # and other OpenAI-compatible providers are also supported.
+      - HINDSIGHT_API_LLM_PROVIDER=openai
+      - HINDSIGHT_API_LLM_API_KEY=
+      # - HINDSIGHT_API_LLM_MODEL=gpt-4.1-mini

--- a/hindsight/docker-compose.yml
+++ b/hindsight/docker-compose.yml
@@ -7,9 +7,6 @@ services:
       APP_PORT: 9999
 
   server:
-    # NOTE: bump to a release that includes the instance LLM-config UI
-    # (server LLM config API) before submitting the Umbrel PR, so the app can be
-    # configured from the browser after a keyless boot below.
     image: ghcr.io/vectorize-io/hindsight:0.8.4@sha256:2c60f233eaba8f51db31adb920a560735aaf6f314e4b63c36c73159742dfa1a7
     restart: on-failure
     stop_grace_period: 1m
@@ -23,8 +20,10 @@ services:
       # Embeddings and reranking run locally on-device (no external calls).
       - HINDSIGHT_API_EMBEDDINGS_PROVIDER=local
       - HINDSIGHT_API_RERANKER_PROVIDER=local
-      # Boot without an LLM so the app starts on a fresh install (a key-requiring
-      # provider would otherwise fail to boot). The user then sets their LLM
-      # provider + API key in the app's Settings page, which applies at runtime
-      # without a restart.
-      - HINDSIGHT_API_LLM_PROVIDER=none
+      # Use the local Ollama app as the LLM backend (declared as a dependency).
+      # ${APP_OLLAMA_URL} is exported by the Ollama app; append /v1 for its
+      # OpenAI-compatible endpoint. No API key is needed for a local model.
+      # Pull the model below in the Ollama app before storing memories.
+      - HINDSIGHT_API_LLM_PROVIDER=ollama
+      - HINDSIGHT_API_LLM_BASE_URL=${APP_OLLAMA_URL}/v1
+      - HINDSIGHT_API_LLM_MODEL=llama3.1:8b

--- a/hindsight/umbrel-app.yml
+++ b/hindsight/umbrel-app.yml
@@ -37,4 +37,4 @@ port: 8288
 gallery: []
 path: ""
 submitter: Vectorize
-submission: https://github.com/getumbrel/umbrel-apps/pull/PENDING
+submission: https://github.com/getumbrel/umbrel-apps/pull/5905

--- a/hindsight/umbrel-app.yml
+++ b/hindsight/umbrel-app.yml
@@ -13,16 +13,15 @@ description: >-
 
   This app bundles everything in a single container: the Hindsight API, the
   web-based Control Plane, and an embedded PostgreSQL (pgvector) database.
-  Embeddings and reranking run locally on-device, so retrieval works fully
-  offline and none of your stored memories leave your Umbrel.
+  Embeddings and reranking run locally on-device, and it uses your local Ollama
+  app for the LLM — so it runs fully offline and none of your data leaves your
+  Umbrel.
 
 
-  Setup: Hindsight uses an LLM to extract and consolidate memories. Before your
-  agents can store or reflect on memories, set your LLM provider and API key in
-  the app's environment (OpenAI, Anthropic, Gemini, Groq and other
-  OpenAI-compatible providers are supported). Only the text sent for
-  extraction and reflection reaches your chosen provider; your memory data and
-  embeddings stay on-device.
+  Setup: install the Ollama app (a required dependency) and pull the model
+  Hindsight uses for memory extraction — in a terminal for the Ollama app run
+  `ollama pull llama3.1:8b`. Once the model is available, your agents can store
+  and reflect on memories.
 
 
   Connect your agents to the API at port 8888 and manage banks, browse memories,
@@ -30,7 +29,8 @@ description: >-
 releaseNotes: ""
 developer: Vectorize
 website: https://hindsight.vectorize.io
-dependencies: []
+dependencies:
+  - ollama
 repo: https://github.com/vectorize-io/hindsight
 support: https://github.com/vectorize-io/hindsight/issues
 port: 8288

--- a/hindsight/umbrel-app.yml
+++ b/hindsight/umbrel-app.yml
@@ -1,0 +1,40 @@
+manifestVersion: 1
+id: hindsight
+category: ai
+name: Hindsight
+version: "0.8.4"
+tagline: Long-term memory for your AI agents
+description: >-
+  Hindsight is a self-hosted long-term memory system for AI agents. It stores
+  what your agents learn as world facts, personal experiences, and consolidated
+  mental models, then serves them back through fast, multi-strategy recall
+  (semantic, keyword, graph, and temporal) with reranking.
+
+
+  This app bundles everything in a single container: the Hindsight API, the
+  web-based Control Plane, and an embedded PostgreSQL (pgvector) database.
+  Embeddings and reranking run locally on-device, so retrieval works fully
+  offline and none of your stored memories leave your Umbrel.
+
+
+  Setup: Hindsight uses an LLM to extract and consolidate memories. Before your
+  agents can store or reflect on memories, set your LLM provider and API key in
+  the app's environment (OpenAI, Anthropic, Gemini, Groq and other
+  OpenAI-compatible providers are supported). Only the text sent for
+  extraction and reflection reaches your chosen provider; your memory data and
+  embeddings stay on-device.
+
+
+  Connect your agents to the API at port 8888 and manage banks, browse memories,
+  and run recall/reflect from the Control Plane UI.
+releaseNotes: ""
+developer: Vectorize
+website: https://hindsight.vectorize.io
+dependencies: []
+repo: https://github.com/vectorize-io/hindsight
+support: https://github.com/vectorize-io/hindsight/issues
+port: 8288
+gallery: []
+path: ""
+submitter: Vectorize
+submission: https://github.com/getumbrel/umbrel-apps/pull/PENDING


### PR DESCRIPTION
## Hindsight

Self-hosted long-term memory for AI agents. Hindsight stores what your agents learn (world facts, personal experiences, and consolidated mental models) and serves it back through fast multi-strategy recall (semantic, keyword, graph, temporal) with reranking, all running on your Umbrel.

- **App ID:** `hindsight`
- **Upstream:** https://github.com/vectorize-io/hindsight
- **Developer:** Vectorize — https://hindsight.vectorize.io

### How it works

A single container bundles the Hindsight API, the web-based Control Plane, and an embedded PostgreSQL (pgvector) database. Embeddings and reranking run locally on-device, and the LLM backend is the **Ollama** Umbrel app (declared as a dependency), so it runs fully offline with no API key. Multi-arch (`linux/amd64` + `linux/arm64`), pinned by digest; memory data persists at `${APP_DATA_DIR}` across updates and restarts.

### Setup

Install the **Ollama** app (a required dependency) and pull the model Hindsight uses for extraction: `ollama pull llama3.1:8b`. Then open Hindsight from the dashboard. The Control Plane UI is served via `app_proxy` on port 9999; agents connect to the API on 8888.

### Testing

- Installs and opens straight to the Control Plane web UI (no CLI needed).
- `npm run lint:apps -- hindsight --check-images` → **No issues found**.
- Image is multi-arch and pinned by `@sha256` digest; embedded Postgres data persists across restarts.
- LLM wired to the local Ollama app via its exported `$APP_OLLAMA_URL`.

### Host access

No special host access: `app_proxy` only (no raw `ports:`), no privileged mode, no docker socket.

### Screenshots

![Memories and banks](https://raw.githubusercontent.com/vectorize-io/hindsight/main/hindsight-docs/static/img/blog/bank-dropdown-memory-stats.png)

![Memory constellation](https://raw.githubusercontent.com/vectorize-io/hindsight/main/hindsight-docs/static/img/blog/constellation-view.png)

![Knowledge graph](https://raw.githubusercontent.com/vectorize-io/hindsight/main/hindsight-docs/static/img/blog/spreading-activation-memory-graphs.png)

### Logo

![Hindsight](https://raw.githubusercontent.com/vectorize-io/hindsight/main/hindsight-docs/static/img/logo.png)
