### PR TITLE
Add msgvault

### DIFF
--- a/msgvault/docker-compose.yml
+++ b/msgvault/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: msgvault_server_1
+      APP_PORT: 8080
+      # The msgvault CLI and MCP/API clients (e.g. `msgvault export-token` ->
+      # POST /api/v1/auth/token/{email}) cannot present Umbrel's browser session,
+      # so they must bypass app_proxy's session auth. These paths are all guarded
+      # by msgvault's own api_key, so this is safe; /docs stays behind Umbrel auth
+      # since it is a browser page.
+      PROXY_AUTH_WHITELIST: "/api/v1/*,/openapi.json,/openapi.yaml"
+
+  server:
+    image: ghcr.io/kenn-io/msgvault:0.18.0@sha256:0f8d8db70ca3b5a63ec049f017f86497be2d2b1748409afa4cd50619a6eae732
+    user: "1000:1000"
+    restart: on-failure
+    stop_grace_period: 1m
+    environment:
+      # Umbrel injects a deterministic per-install secret as APP_PASSWORD and
+      # shows it on the app's info screen. msgvault uses it as the API key that
+      # guards its non-loopback HTTP API (sent as Authorization: Bearer or
+      # X-Api-Key). /health stays public so the image healthcheck still works.
+      MSGVAULT_API_KEY: "${APP_PASSWORD}"
+    # The image entrypoint is `msgvault`, so override it to write a first-run
+    # config.toml before starting the daemon: bind on all interfaces so the
+    # app_proxy can reach the server, pin the API port to 8080 (the default is
+    # an ephemeral port), and set the API key. The file is only written when
+    # absent, so any later hand edits (extra sync schedules, etc.) survive.
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        CONFIG="$${MSGVAULT_HOME:-/data}/config.toml"
+        if [ ! -f "$$CONFIG" ]; then
+          umask 077
+          printf '[server]\nbind_addr = "0.0.0.0"\napi_port = 8080\napi_key = "%s"\n' "$$MSGVAULT_API_KEY" > "$$CONFIG"
+        fi
+        exec msgvault serve
+    volumes:
+      - ${APP_DATA_DIR}/data:/data

--- a/msgvault/umbrel-app.yml
+++ b/msgvault/umbrel-app.yml
@@ -1,0 +1,53 @@
+manifestVersion: 1
+id: msgvault
+category: files
+name: msgvault
+version: "0.18.0"
+tagline: Archive a lifetime of email and chat, searchable offline
+description: >-
+  msgvault keeps a private, offline-first copy of your whole message history on
+  your Umbrel. It ingests your mail and chats into an embedded SQLite archive,
+  then gives you fast full-text search, DuckDB-powered analytics, and an API you
+  can point an AI assistant at — all running locally, with no hosted service in
+  the loop.
+
+
+  Setup note: msgvault links your accounts from the msgvault command-line app on
+  your own computer, not from this screen. Install the msgvault CLI, run its
+  setup wizard to sign in to Gmail, an IMAP mailbox, Microsoft 365 / Teams, and
+  other providers, then export the resulting token to this server with
+  `msgvault export-token you@example.com --to http://umbrel.local:8480 --api-key
+  <API KEY>`. This server then keeps those accounts synced on a schedule. The
+  API key is the auto-generated password shown on this app's info screen.
+
+
+  Sources: Gmail and any IMAP mailbox, Microsoft Teams, and — via the CLI's
+  importers — Discord, Beeper, Granola, Circleback, Google Voice, and
+  WhatsApp / iMessage / SMS exports. Everything lands in one deduplicated
+  archive with attachments preserved on disk as plain files.
+
+
+  Local by default: full-text search across hundreds of thousands of messages,
+  millisecond DuckDB aggregate queries, and an MCP server so Claude Desktop or
+  any MCP-capable agent can query decades of correspondence conversationally.
+  Your messages stay yours — no mailbox network access is required once the
+  archive is built.
+
+
+  This app runs the msgvault HTTP server. Opening it lands on the interactive
+  API docs at `/docs`; there is no dashboard-style web UI yet. Authenticate API
+  and CLI requests with the app's password as a Bearer token (`Authorization:
+  Bearer <API KEY>`) or an `X-Api-Key` header.
+releaseNotes: ""
+developer: kenn.io
+website: https://msgvault.io
+dependencies: []
+repo: https://github.com/kenn-io/msgvault
+support: https://discord.gg/fDnmxB8Wkq
+port: 8480
+gallery: []
+path: ""
+defaultUsername: ""
+deterministicPassword: true
+submitter: salmonumbrella
+submission: https://github.com/getumbrel/umbrel-apps/pull/0000

--- a/msgvault/umbrel-app.yml
+++ b/msgvault/umbrel-app.yml
@@ -50,4 +50,4 @@ path: ""
 defaultUsername: ""
 deterministicPassword: true
 submitter: salmonumbrella
-submission: https://github.com/getumbrel/umbrel-apps/pull/0000
+submission: https://github.com/getumbrel/umbrel-apps/pull/5909


### PR DESCRIPTION
## Type

New app

## App

- App ID: `msgvault`
- Upstream project: https://github.com/kenn-io/msgvault
- Version: 0.18.0

## Summary

msgvault archives email and chat for offline full-text search, DuckDB analytics, and AI query over an OpenAPI HTTP API. It syncs Gmail, IMAP, and Microsoft 365 / Teams, and imports Discord, WhatsApp, iMessage, and other exports. Everything runs locally.

One container, one `/data` volume, no dependencies. The multi-arch image (`ghcr.io/kenn-io/msgvault`) runs as a non-root user and ships its own healthcheck. The compose entrypoint writes `config.toml` on first run (bind `0.0.0.0`, port 8080, API key from `APP_PASSWORD`) because the daemon is config-file-only and defaults to loopback. Account linking is CLI-first — users complete OAuth on their computer and push the token with `msgvault export-token` — and the app opens to the API docs at `/docs`; there is no dashboard UI yet (upstream issue kenn-io/msgvault#488).

## Verification

Environment tested:
- [x] Umbrel device
- [ ] Local umbrelOS test environment
- [x] Not runtime tested

Architecture tested:
- [ ] amd64
- [ ] arm64

Known lint warnings or caveats: none.

## Logo and screenshots

Logo: [msgvault favicon (SVG)](https://www.msgvault.io/assets/static/favicon.svg). The app's landing page (`/docs`), captured from the pinned image with this package's config:

![msgvault API docs](https://raw.githubusercontent.com/salmonumbrella/umbrel-apps/msgvault-pr-assets/msgvault-docs.png)

The msgvault TUI, which runs on the user's computer against this server (from upstream's `docs-generated-assets` branch):

![msgvault TUI senders view](https://raw.githubusercontent.com/kenn-io/msgvault/docs-generated-assets/tui-senders.svg)
