### PR TITLE
bitcoin-cash-node: correct donation address to a BCH address

### DIFF
--- a/bitcoin-cash-node/umbrel-app.yml
+++ b/bitcoin-cash-node/umbrel-app.yml
@@ -26,7 +26,7 @@ description: >-
 
   Donations are never expected. If LoneStrike Labs apps are useful to you,
   contributions help keep development going:
-  bc1q6k0j7w77xftasgwx7v5nra06rs3v5txk60wgsk
+  qpp8hg2n60mhhlsr2apw6l60x5vrdq0vp5pq3j4gyt
 releaseNotes: ""
 developer: LoneStrike Labs
 website: https://bitcoincashnode.org


### PR DESCRIPTION
One-line description fix: the donation address in the merged bitcoin-cash-node app was a BTC bech32 address (`bc1q...`) -- in a Bitcoin Cash app. Replaced with the developer's Bitcoin Cash cashaddr (checksum-verified P2PKH mainnet). No version bump: description-only.