### PR TITLE
Update Go Brrr Pool to 1.2.1-patch.1

### DIFF
--- a/.claude/skills/umbrel-package-app/SKILL.md
+++ b/.claude/skills/umbrel-package-app/SKILL.md
@@ -170,8 +170,6 @@ Widgets are glanceable cards on the Umbrel home screen for app status, progress,
 Use `app_proxy` for normal browser-based apps.
 
 - Define an `app_proxy` service with environment only.
-- Treat `app_proxy` as declarative Umbrel gateway configuration, not as a runtime Compose service. Current umbrelOS releases consume this block in umbreld and do not create an `app_proxy` container or Docker DNS name.
-- Never use `depends_on: app_proxy`, connect to `<app-id>_app_proxy_1`, or use the app proxy as an internal API endpoint. Point same-app and cross-app traffic at the real upstream service instead.
 - Treat manifest `port` and app_proxy `APP_PORT` as different values: manifest `port` is the host-facing app_proxy port; `APP_PORT` is the internal web service port.
 - Set `APP_HOST` to the Umbrel-injected container name: `<app-id>_<service-name>_1`.
 - Set `APP_PORT` to the internal port the web service listens on.
@@ -250,6 +248,7 @@ Values available after app env is sourced:
 - `APP_DATA_DIR`: installed app data root, `${UMBREL_ROOT}/app-data/<app-id>`.
 - `APP_DOMAIN`: local `.local` domain for the Umbrel device; use with a port when upstream needs a browser-facing app URL.
 - `APP_HIDDEN_SERVICE`: app Tor hidden-service hostname when Umbrel remote Tor access is enabled. It may be a placeholder such as `not-enabled.onion` or `notyetset.onion` before a hidden service exists.
+- `APP_PROXY_HOSTNAME`: internal hostname of the generated `app_proxy` service.
 - `APP_PROXY_PORT`: manifest `port`, the host-facing app URL port.
 - `APP_SEED`: stable per-install derived value for the app; see Generated Secrets.
 - `APP_PASSWORD`: stable per-install derived value for local app credentials when the package wires the app login/admin password to this value; see Generated Secrets.

--- a/.claude/skills/umbrel-package-app/SKILL.md
+++ b/.claude/skills/umbrel-package-app/SKILL.md
@@ -170,6 +170,8 @@ Widgets are glanceable cards on the Umbrel home screen for app status, progress,
 Use `app_proxy` for normal browser-based apps.
 
 - Define an `app_proxy` service with environment only.
+- Treat `app_proxy` as declarative Umbrel gateway configuration, not as a runtime Compose service. Current umbrelOS releases consume this block in umbreld and do not create an `app_proxy` container or Docker DNS name.
+- Never use `depends_on: app_proxy`, connect to `<app-id>_app_proxy_1`, or use the app proxy as an internal API endpoint. Point same-app and cross-app traffic at the real upstream service instead.
 - Treat manifest `port` and app_proxy `APP_PORT` as different values: manifest `port` is the host-facing app_proxy port; `APP_PORT` is the internal web service port.
 - Set `APP_HOST` to the Umbrel-injected container name: `<app-id>_<service-name>_1`.
 - Set `APP_PORT` to the internal port the web service listens on.
@@ -248,7 +250,6 @@ Values available after app env is sourced:
 - `APP_DATA_DIR`: installed app data root, `${UMBREL_ROOT}/app-data/<app-id>`.
 - `APP_DOMAIN`: local `.local` domain for the Umbrel device; use with a port when upstream needs a browser-facing app URL.
 - `APP_HIDDEN_SERVICE`: app Tor hidden-service hostname when Umbrel remote Tor access is enabled. It may be a placeholder such as `not-enabled.onion` or `notyetset.onion` before a hidden service exists.
-- `APP_PROXY_HOSTNAME`: internal hostname of the generated `app_proxy` service.
 - `APP_PROXY_PORT`: manifest `port`, the host-facing app URL port.
 - `APP_SEED`: stable per-install derived value for the app; see Generated Secrets.
 - `APP_PASSWORD`: stable per-install derived value for local app credentials when the package wires the app login/admin password to this value; see Generated Secrets.

--- a/gobrrr-pool/exports.sh
+++ b/gobrrr-pool/exports.sh
@@ -3,5 +3,5 @@ export APP_GOBRRR_POOL_MEMPOOL_API_URL=""
 
 # Prefer the local API when the Mempool app is installed.
 if "${UMBREL_ROOT}/scripts/app" ls-installed | grep --quiet "^mempool$"; then
-  export APP_GOBRRR_POOL_MEMPOOL_API_URL="http://mempool_app_proxy_1:3006/api"
+  export APP_GOBRRR_POOL_MEMPOOL_API_URL="http://mempool_web_1:3006/api"
 fi

--- a/gobrrr-pool/umbrel-app.yml
+++ b/gobrrr-pool/umbrel-app.yml
@@ -32,8 +32,8 @@ description: >-
 
   Homescreen widget developed by RodB.
 releaseNotes: >-
-  Restores local Mempool integration on newer umbrelOS versions that no longer
-  run the legacy app-proxy sidecar.
+  This maintenance update improves long-term compatibility with the optional
+  local Mempool integration. Go Brrr Pool itself is unchanged.
 developer: GoBrrr
 website: https://gobrrr.me
 dependencies:

--- a/gobrrr-pool/umbrel-app.yml
+++ b/gobrrr-pool/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: gobrrr-pool
 category: bitcoin
 name: Go Brrr Pool
-version: "1.2.1"
+version: "1.2.1-patch.1"
 tagline: Bitcoin Solo Mining, Done Right!
 description: >-
   Go Brrr Pool is a self-hosted solo Bitcoin mining pool powered by ckpool-solo.
@@ -32,19 +32,8 @@ description: >-
 
   Homescreen widget developed by RodB.
 releaseNotes: >-
-  ckpool engine updated to the latest upstream release: new high-performance
-  stratum message engine, numerous memory-leak and stability fixes.
-
-
-  Mempool is now optional. Go Brrr Pool uses your local Mempool app when
-  installed and otherwise falls back to the public mempool.space API.
-
-
-  The dashboard now shows whether it is connected to Bitcoin Core or Bitcoin
-  Knots — thanks @BuffaloDyl.
-
-
-  Leaderboard best-diff color improved for readability — thanks @rafxo.
+  Restores local Mempool integration on newer umbrelOS versions that no longer
+  run the legacy app-proxy sidecar.
 developer: GoBrrr
 website: https://gobrrr.me
 dependencies:


### PR DESCRIPTION
Point Go Brrr Pool directly at the Mempool `web` service instead of the historical `mempool_app_proxy_1` sidecar hostname.