### PR TITLE
bitcoin-cash-node 29.1.36: fix vanishing onion-peers list

### DIFF
--- a/bitcoin-cash-node/docker-compose.yml
+++ b/bitcoin-cash-node/docker-compose.yml
@@ -55,7 +55,7 @@ services:
         ipv4_address: ${APP_BITCOIN_CASH_NODE_NODE_IP}
 
   web:
-    image: ghcr.io/danhaus93-ops/bchn-dashboard:e9b9860b8b9a87178a9bca1985b4793b694ceb8d@sha256:cbb3fc4bd5bf43906993165d9fdcfc60a4978bdbfc33ce8994ea1f4449ac6312
+    image: ghcr.io/danhaus93-ops/bchn-dashboard:cb9552cffab7b5bc68f7b3e24b7ee2b6e67069de@sha256:b8078dbae9ab70cdca31fbc8c44999d9a167b5c7079e10a1ef62bc59bb84dacd
     restart: on-failure
     user: "1000:1000"
     volumes:
@@ -64,7 +64,7 @@ services:
       - bitcoind
     environment:
       PORT: 3000
-      APP_VERSION: v29.1.34
+      APP_VERSION: v29.1.36
       TOR_IP: ${APP_BITCOIN_CASH_NODE_TOR_IP}
       RPC_HOST: bitcoind
       RPC_PORT: "8332"

--- a/bitcoin-cash-node/umbrel-app.yml
+++ b/bitcoin-cash-node/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bitcoin-cash-node
 category: crypto
 name: Bitcoin Cash Node
-version: "29.1.34"
+version: "29.1.36"
 tagline: Run your own Bitcoin Cash full node (BCHN)
 description: >-
   Run your own Bitcoin Cash full node powered by Bitcoin Cash Node (BCHN).
@@ -27,7 +27,14 @@ description: >-
   Donations are never expected. If LoneStrike Labs apps are useful to you,
   contributions help keep development going:
   qpp8hg2n60mhhlsr2apw6l60x5vrdq0vp5pq3j4gyt
-releaseNotes: ""
+releaseNotes: >-
+  Fixes the vanishing onion-peers list. The node's address manager hides
+  addresses after repeated failed connection attempts, so an unlucky stretch
+  of retries against offline onion services could shrink the visible list to
+  a couple of dead entries and hide the reliable ones. The seven onion seeds
+  that ship with Bitcoin Cash Node are now always listed and always tried
+  first, and the keep-connected option rotates away from unresponsive
+  services instead of retrying them forever.
 developer: LoneStrike Labs
 website: https://bitcoincashnode.org
 dependencies: []


### PR DESCRIPTION
Dashboard fix, field-diagnosed on a live node yesterday.

`getnodeaddresses` excludes addresses the address manager has marked terrible after repeated failed attempts. A stretch of automatic retries against two offline onion services buried 21 of 23 known onion addresses -- including all seven of BCHN's own fixed seeds -- leaving the panel showing only dead entries while Tor itself was healthy end to end. A manual `addnode` to one seed connected in under 90 seconds and the panel healed as its gossip refreshed the address manager.

Two changes so it cannot recur: the seven fixed onion seeds (contrib/seeds/nodes_main.txt) are always merged into the list, marked and sorted first, immune to address-manager decay; and the keep-connected option now retires a pin that has not landed in 20 minutes with a one-hour cooldown instead of retrying dead services forever (which was itself deepening the decay that hid good addresses).

Web image pin updated to the release containing the fix; regression tests cover the decayed-address-manager scenario.