### PR TITLE
Update Hashrate Autopilot to 1.17.4

### DIFF
--- a/hashrate-autopilot/docker-compose.yml
+++ b/hashrate-autopilot/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3010
 
   web:
-    image: ghcr.io/rdouma/hashrate-autopilot:1.17.2@sha256:7346288b77e979ff654a31337d2028b870e7076accdc8a86518764e87ddd2632
+    image: ghcr.io/rdouma/hashrate-autopilot:1.17.4@sha256:d43ce6aedf9166c73687c80aaf5b863bd650328fdd8eb6ad76c4ce25012936fd
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/hashrate-autopilot/umbrel-app.yml
+++ b/hashrate-autopilot/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: hashrate-autopilot
 category: bitcoin
 name: Hashrate Autopilot
-version: "1.17.2"
+version: "1.17.4"
 tagline: Autopilot for renting hashrate to mine on Ocean Mining
 
 description: >-
@@ -73,16 +73,25 @@ defaultPassword: ""
 submitter: Remco Douma
 submission: https://github.com/getumbrel/umbrel-apps/pull/5685
 releaseNotes: >-
-  v1.17.2 - Lightning payouts no longer missing from Profit & Loss.
+  v1.17.4 - a daemon-stability fix, corrected Lightning payout amounts, and a new FAQ (everything since v1.17.2).
 
 
-  New: Ocean's payout API turns out not to report Lightning payouts at all (confirmed by Ocean support), so anyone paid over Lightning saw a too-low collected figure and an inflated loss rate. The autopilot now deduces those payouts from your unpaid earnings dropping to zero - confirmed over two consecutive readings so a brief API glitch can't fake one, and only when no matching entry exists in Ocean's own ledger. A deduced payout shows as "type not known yet" for its first 24 hours (a late-arriving on-chain record replaces it automatically), then as "probably Lightning". Your history is backfilled on upgrade, and deduced payouts render on the chart as a ghost gem whose tooltip explains the deduction and marks the amount as approximate.
+  Fixed: The daemon no longer crash-loops when your Electrum server (electrs, Fulcrum, or ElectrumX) restarts or drops an idle connection while it is mid-request - previously that could crash the daemon and restart it in a loop, spamming Telegram. It now handles a dropped connection cleanly and retries.
 
 
-  Fixed: Timeline notes survive the Profit & Loss hard reset - rebuilding your finances no longer erases the personal notes you attached to payout events.
+  Fixed: Removed a misleading "Telegram 2FA tap required" note shown after placing a bid - the autopilot bids through Braiins' API with your owner token, which needs no Telegram confirmation (that step exists only in Braiins' own web interface).
+
+
+  Fixed: Deduced Lightning payouts no longer overcount a partial sweep - when Ocean credits a freshly found block and then pays out only the older balance, the payout is now recorded as the actual balance decrease rather than the full pre-drop reading, and any amounts already stored self-correct on the next scan.
+
+
+  Fixed: The Bitaxe miners card now respects your number-format locale instead of a hard-coded decimal point.
+
+
+  New: A short, plain-language FAQ covering setup and topology (including what to put in the Stratum host field), payouts and Profit & Loss, bidding, and what you need running: https://github.com/rdouma/hashrate-autopilot/blob/main/FAQ.md
 
 
   Migrating from the community-store version (rdouma-hashrate-autopilot)? One-time five-minute guide: https://github.com/rdouma/hashrate-autopilot/blob/main/docs/migrating-from-community-store.md
 
 
-  Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.17.2
+  Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.17.4


### PR DESCRIPTION
### Type
App update

### App
Hashrate Autopilot (`hashrate-autopilot`) - 1.17.2 → 1.17.4

### Summary
Stability + docs update. Notable since the last accepted version (1.17.2):

- **Fixed:** the daemon no longer crash-loops when the Electrum server (electrs / Fulcrum / ElectrumX) restarts or drops an idle connection mid-request. Previously that surfaced as an uncaught `write EPIPE` that crashed the daemon and restarted it in a loop; it now handles the dropped connection cleanly and retries.
- **Fixed:** removed a misleading "Telegram 2FA tap required" note from bid creation. The app places bids via Braiins' API using the account owner token, which needs no Telegram confirmation (that step exists only in Braiins' web interface).
- **Fixed (1.17.3):** deduced Lightning payout amounts no longer overcount a partial sweep - the recorded amount is the actual unpaid-balance decrease, not the full pre-drop reading.
- **Fixed (1.17.3):** the Bitaxe miners card respects the number-format locale instead of a hard-coded decimal point.
- **New:** a plain-language FAQ (setup/topology, payouts & P&L, bidding, requirements).

Full release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.17.4

### Verification
- Image is **multi-arch** (`linux/amd64`, `linux/arm64`), built by CI from the tagged release and **digest-pinned** in `docker-compose.yml` (`1.17.4@sha256:d43ce6ae…`). It is the same build already live on the community store.
- `docker-compose.yml` is unchanged from the last accepted version except the image tag + digest.
- I have not re-run a full clean Umbrel-device install for this exact build; leaving the tested-environment checkboxes for a maintainer to confirm.
