### PR TITLE
bitcoin-cash-node 29.1.37: review-note fixes for the onion peers panel

### DIFF
--- a/bitcoin-cash-node/docker-compose.yml
+++ b/bitcoin-cash-node/docker-compose.yml
@@ -55,7 +55,7 @@ services:
         ipv4_address: ${APP_BITCOIN_CASH_NODE_NODE_IP}
 
   web:
-    image: ghcr.io/danhaus93-ops/bchn-dashboard:cb9552cffab7b5bc68f7b3e24b7ee2b6e67069de@sha256:b8078dbae9ab70cdca31fbc8c44999d9a167b5c7079e10a1ef62bc59bb84dacd
+    image: ghcr.io/danhaus93-ops/bchn-dashboard:8bb17f3689d837dbd370ac0d35e4a158ea12b75a@sha256:7c292722411525908ddb80ac56915db88213e245ac0e3e8a683a3d4ebcd2ae24
     restart: on-failure
     user: "1000:1000"
     volumes:
@@ -64,7 +64,7 @@ services:
       - bitcoind
     environment:
       PORT: 3000
-      APP_VERSION: v29.1.36
+      APP_VERSION: v29.1.37
       TOR_IP: ${APP_BITCOIN_CASH_NODE_TOR_IP}
       RPC_HOST: bitcoind
       RPC_PORT: "8332"

--- a/bitcoin-cash-node/umbrel-app.yml
+++ b/bitcoin-cash-node/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bitcoin-cash-node
 category: crypto
 name: Bitcoin Cash Node
-version: "29.1.36"
+version: "29.1.37"
 tagline: Run your own Bitcoin Cash full node (BCHN)
 description: >-
   Run your own Bitcoin Cash full node powered by Bitcoin Cash Node (BCHN).
@@ -28,13 +28,12 @@ description: >-
   contributions help keep development going:
   qpp8hg2n60mhhlsr2apw6l60x5vrdq0vp5pq3j4gyt
 releaseNotes: >-
-  Fixes the vanishing onion-peers list. The node's address manager hides
-  addresses after repeated failed connection attempts, so an unlucky stretch
-  of retries against offline onion services could shrink the visible list to
-  a couple of dead entries and hide the reliable ones. The seven onion seeds
-  that ship with Bitcoin Cash Node are now always listed and always tried
-  first, and the keep-connected option rotates away from unresponsive
-  services instead of retrying them forever.
+  Follow-up fixes to the onion peers panel from store review. An onion peer
+  that connected and later went offline now rotates out instead of holding
+  its slot forever, the keep-connected option can once again reach its full
+  four peers when some are already connected, and the known count now
+  matches the list exactly (duplicate entries under different ports are
+  merged).
 developer: LoneStrike Labs
 website: https://bitcoincashnode.org
 dependencies: []


### PR DESCRIPTION
Follow-up to #5914, addressing @nmfretz's review note directly:

1. A pinned peer that connected and later went offline could hold its pin slot forever (tracking was dropped on connect). The retirement clock now keeps running while the peer is live, so a peer that dies rotates out 20 minutes after it was last seen connected.
2. The pin budget double-counted connected pinned peers (present in both the live set and the pinned set), which could leave fewer than four pins. It now counts the union.
3. Pinned-but-untracked addresses are re-armed each reconcile pass.

Also fixes a field report from the same install: the known-onion count could disagree with the rendered list (addrman can return one address under two ports). The list is now deduped by address, so the count tracks reality.

Regression tests cover all four behaviors.