### PR TITLE
feat: add Cloudflare Tunnel widgets

### DIFF
--- a/cloudflared/umbrel-app.yml
+++ b/cloudflared/umbrel-app.yml
@@ -39,3 +39,27 @@ dependencies: []
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+widgets:
+  - id: status
+    type: three-stats
+    refresh: 15000
+    endpoint: web:3000/api/widgets/status
+    example:
+      items:
+        - icon: circle-check
+          subtext: Status
+          text: Connected
+        - icon: route
+          subtext: Routes
+          text: "2"
+        - icon: versions
+          subtext: Version
+          text: 2026.6.1
+  - id: routes
+    type: list
+    refresh: 15000
+    endpoint: web:3000/api/widgets/routes
+    example:
+      items:
+        - text: app.example.com
+          subtext: http://app:3000


### PR DESCRIPTION
Adds two umbrelOS dashboard widgets for Cloudflare Tunnel:

- `status`: three stats for connection state, route count, and cloudflared version
- `routes`: list of up to five public routes

The endpoints are implemented in the companion repository https://github.com/VitalyArt/umbrel-cloudflared.