### PR TITLE
pearcircle-seeder: update to 1.0.25

### DIFF
--- a/pearcircle-seeder/docker-compose.yml
+++ b/pearcircle-seeder/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8730
 
   app:
-    image: ghcr.io/peerloomllc/pearcircle-seeder:1.0.24@sha256:3b3e0cf6068b154a7a12205da5969e4fc8151ec4e054a7dfeea0cd375f1af690
+    image: ghcr.io/peerloomllc/pearcircle-seeder:1.0.25@sha256:6ca24a7db11540d6b4fc0c49b857008b0d8ec5e987a14014903d9a609d6f8ed1
     restart: on-failure
     stop_grace_period: 1m
     security_opt:

--- a/pearcircle-seeder/umbrel-app.yml
+++ b/pearcircle-seeder/umbrel-app.yml
@@ -19,27 +19,30 @@ description: >-
   stay caught up regardless of who's online.
 
 
-  It is a "blind" seeder: the blocks it stores and serves stay encrypted, so
-  your Umbrel keeps a circle's data available without ever being able to read
-  the locations, places, or members inside it. Circle members stay in control —
-  they admit the seeder when it enrolls and can revoke it at any time, and each
-  circle has its own retention window (forever, 30 days, 7 days, or 24 hours).
+  It is designed as a "blind" seeder: when circle members publish encrypted
+  data, your Umbrel keeps it available without being able to read the locations,
+  places, or members inside it. The seeder warns you if an affected or outdated
+  member publishes a readable, unencrypted last-known position. Circle members
+  stay in control — they admit the seeder when it enrolls and can revoke it at
+  any time, and each circle has its own retention window (forever, 30 days, 7
+  days, or 24 hours).
 
 
   To enroll a circle: open the seeder dashboard, then in the PearCircle phone
   app mint a seed invite for the circle and paste it in.
 releaseNotes: >-
-  This update brings the seeder in line with PearCircle 1.0.24. PearCircle now
-  offers an optional, direct-first connection relay for phones on networks that
-  block peer-to-peer traffic. The relay forwards encrypted data without storing
-  it, can be disabled in the PearCircle phone app, and does not change how this
-  seeder stores or serves circle data.
+  This update upgrades PearCircle Seeder to 1.0.25. It adds a log warning when
+  an affected or outdated circle member publishes a last-known position without
+  encryption, and clears the warning after encrypted publishing resumes.
 
 
-  No manual action is required after updating.
+  PearCircle 1.0.25 also fixes the phone-side issue that could publish these
+  positions in the clear. Circle members should update their PearCircle apps as
+  well; updating the seeder alone cannot repair data published by an affected
+  member. No seeder data migration or reconfiguration is required.
 
 
-  Full upstream release notes: https://github.com/peerloomllc/pearcircle/releases/tag/v1.0.24
+  Full upstream release notes: https://github.com/peerloomllc/pearcircle/releases/tag/v1.0.25
 developer: PeerLoom
 website: https://peerloomllc.com
 dependencies: []

--- a/pearcircle-seeder/umbrel-app.yml
+++ b/pearcircle-seeder/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: pearcircle-seeder
 category: networking
 name: PearCircle Seeder
-version: "1.0.24"
+version: "1.0.25"
 tagline: Keep your PearCircle circles online 24/7
 description: >-
   Run a blind seeder for your PearCircle circles on your Umbrel so their


### PR DESCRIPTION
Bump PearCircle Seeder to 1.0.25 (image pinned to the multi-arch manifest-list digest).