### PR TITLE
Update Vaultwarden to v1.37.0

### DIFF
--- a/vaultwarden/docker-compose.yml
+++ b/vaultwarden/docker-compose.yml
@@ -8,10 +8,10 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: vaultwarden/server:1.36.0@sha256:d626d04934cd1192ad8ced1adb975099fca78cec33ab467d2d3c923cde7f3b0c
+    image: vaultwarden/server:1.37.0@sha256:e6443e3d5ed8fcee2204b89ec778d7f24d0173bcc42d1ea34f990304f5f63f51
     user: "1000:1000"
     entrypoint: /bin/sh
-    # Bitwarden Web Vault v2026.4.1 rejects non-HTTPS API and notification URLs.
+    # Bitwarden Web Vault (v2026.4.1+, currently v2026.6.4) rejects non-HTTPS API and notification URLs.
     # Umbrel's Tor hidden service is served over http://*.onion, which Tor Browser
     # treats as a secure context. Patch only the copied web vault bundle so onion
     # access still works, while plain HTTP remains blocked for non-onion hosts.

--- a/vaultwarden/umbrel-app.yml
+++ b/vaultwarden/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: vaultwarden
 category: files
 name: Vaultwarden
-version: "1.36.0"
+version: "1.37.0"
 tagline: Unofficial Bitwarden® compatible server
 description: >-
   Vaultwarden is an unofficial Bitwarden-compatible server for self-hosting your encrypted password vault on Umbrel. It works with many official Bitwarden clients and provides a lightweight alternative to the official Bitwarden server.
@@ -54,11 +54,11 @@ releaseNotes: >-
 
 
   This release includes:
-    - Multiple security fixes for organizations, collections, SSO, refresh tokens, user and organization enumeration, and icon fetching
-    - Improved compatibility with newer Bitwarden desktop and mobile clients
-    - Web Vault updated to v2026.4.1
-    - Item archiving support
-    - Fixes for 2FA, recovery codes, favicon fetching, SSO, and organization behavior
+    - Support for the latest Bitwarden clients (version 2026.7.0 and newer), fixing clients that could log in but not load any vault items
+    - Eight security fixes, including SSRF via the icon endpoint, cross-organization cipher access, organization policy bypasses, Send access-count bypass, and unauthenticated WebSocket flooding
+    - Web Vault updated to v2026.6.4
+    - Email two-factor authentication support for the Bitwarden CLI
+    - Trusted proxy support and unauthenticated rate limiting
 
 
   Full release notes are available at https://github.com/dani-garcia/vaultwarden/releases

--- a/vaultwarden/umbrel-app.yml
+++ b/vaultwarden/umbrel-app.yml
@@ -54,14 +54,14 @@ releaseNotes: >-
 
 
   This release includes:
-    - Support for the latest Bitwarden clients (version 2026.7.0 and newer), fixing clients that could log in but not load any vault items
-    - Eight security fixes, including SSRF via the icon endpoint, cross-organization cipher access, organization policy bypasses, Send access-count bypass, and unauthenticated WebSocket flooding
+    - Support for Bitwarden clients v2026.7.0 and newer, fixing an issue where clients could log in but show an empty vault
+    - Eight security fixes covering icon fetching, organization access controls, Bitwarden Send limits, and WebSocket abuse
     - Web Vault updated to v2026.6.4
     - Email two-factor authentication support for the Bitwarden CLI
-    - Trusted proxy support and unauthenticated rate limiting
+    - Improved reverse-proxy security and rate limiting for unauthenticated requests
 
 
-  Full release notes are available at https://github.com/dani-garcia/vaultwarden/releases
+  Full release notes are available at https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0
 developer: Daniel García
 website: https://github.com/dani-garcia
 dependencies: []


### PR DESCRIPTION
Updates Vaultwarden from 1.36.0 to [1.37.0](https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0).

**Why this is time-sensitive:** upstream states this release *"is required for support with clients with version 2026.7.0+"*. Bitwarden browser extensions have already auto-updated to 2026.7.0, and against 1.36.0 they log in successfully but load an empty vault (no credentials shown). Reproduced on Firefox extension 2026.7.0 against this app's current 1.36.0.

Also includes eight medium-severity security fixes (SSRF via the icon endpoint, cross-organization cipher access, organization policy bypasses, Send access-count bypass, unauthenticated WebSocket flooding, and others) and Web Vault v2026.6.4.

**Onion web-vault patch verified:** the entrypoint in `docker-compose.yml` sed-patches `app/main.*.js` and hard-fails via `grep -Fq` if the target string is missing. I downloaded `bw_web_v2026.6.4.tar.gz` (the web vault bundled in 1.37.0) and confirmed `&&!this.platformUtilsService.isDev()` is present (3 occurrences), so the patch still applies cleanly. The comment above the patch was updated to reflect the current web vault version.

Image digest `sha256:e6443e3d5ed8fcee2204b89ec778d7f24d0173bcc42d1ea34f990304f5f63f51` taken from Docker Hub for `vaultwarden/server:1.37.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)