### PR TITLE
bassin: bump ckpool image to v1.1.1

### DIFF
--- a/bassin/docker-compose.yml
+++ b/bassin/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - APP_BITCOIN_ZMQ_HASHBLOCK_PORT=${APP_BITCOIN_ZMQ_HASHBLOCK_PORT}
 
   ckpool:
-    image: ghcr.io/getumbrel/docker-ckpool-solo:590fb2a@sha256:4e6b8f4f9c7d74c2111a6e082a2bbdc936fa510989a81e7cef714d1da944336b
+    image: ghcr.io/getumbrel/docker-ckpool-solo@sha256:499f0d4f72b93130bde06463b6aab25fa80f1f2349bab0e28f1c9a59b02f745b
     command: '-k -B -c /config/ckpool.conf'
     user: "1000:1000"
     depends_on:

--- a/bassin/docker-compose.yml
+++ b/bassin/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - ${APP_DATA_DIR}/data/www:/www
 
   ui:
-    image: ghcr.io/duckaxe/bassin-ui:580689d@sha256:ece16d859295c01f3c7bdaf78679f5b3477073af93937c367ae6174191c0de19
+    image: ghcr.io/blockdyor/bassin-ui:latest@sha256:11edec02ba3e3e32f4cf42b98fb7dd70d043c481cbdaeb5b311f08950da8eb2f
     entrypoint: /bin/sh -c "cp -r /ui/* /www/"
     user: "1000:1000"
     volumes:

--- a/bassin/docker-compose.yml
+++ b/bassin/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - APP_BITCOIN_ZMQ_HASHBLOCK_PORT=${APP_BITCOIN_ZMQ_HASHBLOCK_PORT}
 
   ckpool:
-    image: ghcr.io/getumbrel/docker-ckpool-solo@sha256:499f0d4f72b93130bde06463b6aab25fa80f1f2349bab0e28f1c9a59b02f745b
+    image: ghcr.io/getumbrel/docker-ckpool-solo:v1.1.1@sha256:499f0d4f72b93130bde06463b6aab25fa80f1f2349bab0e28f1c9a59b02f745b
     command: '-k -B -c /config/ckpool.conf'
     user: "1000:1000"
     depends_on:

--- a/bassin/docker-compose.yml
+++ b/bassin/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - ${APP_DATA_DIR}/data/www:/www
 
   ui:
-    image: ghcr.io/blockdyor/bassin-ui:latest@sha256:11edec02ba3e3e32f4cf42b98fb7dd70d043c481cbdaeb5b311f08950da8eb2f
+    image: ghcr.io/duckaxe/bassin-ui:580689d@sha256:ece16d859295c01f3c7bdaf78679f5b3477073af93937c367ae6174191c0de19
     entrypoint: /bin/sh -c "cp -r /ui/* /www/"
     user: "1000:1000"
     volumes:

--- a/bassin/umbrel-app.yml
+++ b/bassin/umbrel-app.yml
@@ -1,30 +1,24 @@
 manifestVersion: 1.1
-version: "2.1.0-hotfix"
+version: "2.1.1"
 id: bassin
 name: Bassin
 tagline: Solo Bitcoin Mining Pool (ckPool)
 description: >-
   A zero-fee Bitcoin solo mining pool for Umbrel. Run your own ckPool at home.
-
-
   No setup, no hassle.
     - Make sure your Bitcoin node is fully synchronized and running
     - Install the app, then follow the on-screen instructions
     - Be part of decentralized mining
-
   
   Check out the FAQ page: https://github.com/duckaxe/bassin/wiki/FAQ
-
-
   For academic and research purposes only.
 category: bitcoin
 dependencies:
   - bitcoin
 releaseNotes: >-
-  🚨 CRITICAL SECURITY UPDATE - Please update immediately.
-
-
-  A security issue was discovered with the previous ckpool software used by this app. It has been replaced with a new version built from a verified source: https://github.com/getumbrel/docker-ckpool-solo
+  Updated ckpool to v1.1.1, now built directly from Con Kolivas' main
+  ckpool repository (previously ckpool-solo, which has been merged
+  upstream into the main project).
 port: 5008
 submitter: duckaxe
 developer: duckaxe

--- a/bassin/umbrel-app.yml
+++ b/bassin/umbrel-app.yml
@@ -1,5 +1,5 @@
 manifestVersion: 1.1
-version: "2.1.1"
+version: "2.1.2"
 id: bassin
 name: Bassin
 tagline: Solo Bitcoin Mining Pool (ckPool)
@@ -16,16 +16,10 @@ category: bitcoin
 dependencies:
   - bitcoin
 releaseNotes: >-
-  Updated ckpool to v1.1.1, now built directly from Con Kolivas' main
-  ckpool repository (previously ckpool-solo, which has been merged
-  upstream into the main project).
-
-
   **What's changed:**
-    - Bumped ckpool image from a pinned commit to the tagged v1.1.1 release.
-    - Image now builds from ckolivas/ckpool instead of the deprecated
-      ckolivas/ckpool-solo repository.
-    - Corrected image reference to include both tag and digest.
+    - Replaced an unsafe HTML-injection pattern in the UI's number formatting
+      with safe React rendering. No visual or functional change, purely a
+      hardening fix.
 port: 5008
 submitter: duckaxe
 developer: duckaxe

--- a/bassin/umbrel-app.yml
+++ b/bassin/umbrel-app.yml
@@ -16,16 +16,15 @@ category: bitcoin
 dependencies:
   - bitcoin
 releaseNotes: >-
-  Updated ckpool to v1.1.1, now built directly from Con Kolivas' main
-  ckpool repository (previously ckpool-solo, which has been merged
-  upstream into the main project).
+  Updates Bassin's mining backend to ckpool v1.1.1 and moves it to the
+  actively maintained ckpool codebase.
 
 
   **What's changed:**
-    - Bumped ckpool image from a pinned commit to the tagged v1.1.1 release.
-    - Image now builds from ckolivas/ckpool instead of the deprecated
-      ckolivas/ckpool-solo repository.
-    - Corrected image reference to include both tag and digest.
+    - Improved pool performance and share processing.
+    - Better difficulty adjustment for bursty and higher-hashrate miners.
+    - Added compatibility for upcoming Bitcoin consensus changes, along with
+      stability and miner-protocol fixes.
 port: 5008
 submitter: duckaxe
 developer: duckaxe

--- a/bassin/umbrel-app.yml
+++ b/bassin/umbrel-app.yml
@@ -19,6 +19,13 @@ releaseNotes: >-
   Updated ckpool to v1.1.1, now built directly from Con Kolivas' main
   ckpool repository (previously ckpool-solo, which has been merged
   upstream into the main project).
+
+
+  **What's changed:**
+    - Bumped ckpool image from a pinned commit to the tagged v1.1.1 release.
+    - Image now builds from ckolivas/ckpool instead of the deprecated
+      ckolivas/ckpool-solo repository.
+    - Corrected image reference to include both tag and digest.
 port: 5008
 submitter: duckaxe
 developer: duckaxe

--- a/bassin/umbrel-app.yml
+++ b/bassin/umbrel-app.yml
@@ -1,5 +1,5 @@
 manifestVersion: 1.1
-version: "2.1.2"
+version: "2.1.1"
 id: bassin
 name: Bassin
 tagline: Solo Bitcoin Mining Pool (ckPool)
@@ -16,10 +16,16 @@ category: bitcoin
 dependencies:
   - bitcoin
 releaseNotes: >-
+  Updated ckpool to v1.1.1, now built directly from Con Kolivas' main
+  ckpool repository (previously ckpool-solo, which has been merged
+  upstream into the main project).
+
+
   **What's changed:**
-    - Replaced an unsafe HTML-injection pattern in the UI's number formatting
-      with safe React rendering. No visual or functional change, purely a
-      hardening fix.
+    - Bumped ckpool image from a pinned commit to the tagged v1.1.1 release.
+    - Image now builds from ckolivas/ckpool instead of the deprecated
+      ckolivas/ckpool-solo repository.
+    - Corrected image reference to include both tag and digest.
 port: 5008
 submitter: duckaxe
 developer: duckaxe

--- a/bassin/umbrel-app.yml
+++ b/bassin/umbrel-app.yml
@@ -4,13 +4,19 @@ id: bassin
 name: Bassin
 tagline: Solo Bitcoin Mining Pool (ckPool)
 description: >-
-  A zero-fee Bitcoin solo mining pool for Umbrel. Run your own ckPool at home.
-  No setup, no hassle.
+  Run your own zero-fee Bitcoin solo mining pool at home with Bassin, powered
+  by ckPool.
+
+
+  Getting started:
     - Make sure your Bitcoin node is fully synchronized and running
-    - Install the app, then follow the on-screen instructions
-    - Be part of decentralized mining
-  
-  Check out the FAQ page: https://github.com/duckaxe/bassin/wiki/FAQ
+    - Install Bassin and follow the on-screen instructions
+    - Connect your miners and help make Bitcoin mining more decentralized
+
+  For more information, check out the FAQ:
+  https://github.com/duckaxe/bassin/wiki/FAQ
+
+
   For academic and research purposes only.
 category: bitcoin
 dependencies:


### PR DESCRIPTION
## Type
App update

## App
App ID: bassin
Upstream project: https://github.com/getumbrel/docker-ckpool-solo
Version: 2.1.1

## Summary
Bumps the ckpool image used by Bassin from the pinned commit `590fb2a`
to the tagged release `v1.1.1`.

This picks up an upstream change where the Dockerfile's clone source
switched from `ckolivas/ckpool-solo` to `ckolivas/ckpool` on Bitbucket.
The solo mining functionality appears to have been folded into the
main ckpool project, so ckpool-solo is no longer maintained separately.

Reference commit:
https://github.com/getumbrel/docker-ckpool-solo/commit/3fa548f43c2df2d47355100ddc31f207cc38e042

Changed files:
- `bassin/docker-compose.yml`: updated ckpool image tag and digest to
  `v1.1.1`
- `bassin/umbrel-app.yml`: version bumped to `2.1.1`, release notes
  updated

## Verification
Umbrel testing performed: Ran locally on a DTV Electronics CM4Rat
(Raspberry Pi CM5, 8GB RAM) running umbrelOS. Confirmed the ckpool
container pulls and starts on the new image tag.

Environment tested:
- [ ] Umbrel device
- [x] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [ ] amd64
- [x] arm64

Known lint warnings or caveats: none known

## Notes
No changes to permissions, dependencies, or default credentials.
Version bumped as a patch release (from `2.1.0-hotfix` to `2.1.1`),
since this is a routine dependency update rather than a security fix
like the previous release.