### PR TITLE
Add Rayfish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "umbrel-apps-fork",
+  "name": "umbrel-apps",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "umbrel-apps",
+  "name": "umbrel-apps-fork",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/rayfish/docker-compose.yml
+++ b/rayfish/docker-compose.yml
@@ -1,0 +1,24 @@
+# Rayfish is a mesh VPN: the daemon must own a host TUN interface and the
+# host route table so the whole Umbrel (and its other apps) is reachable
+# over the mesh. That requires host networking plus NET_ADMIN/NET_RAW and
+# /dev/net/tun, the same access pattern as the Tailscale app. Because of
+# host networking there is no app_proxy; the manifest port 8480 is served
+# by the container itself (the ray gui dashboard behind a local proxy).
+version: "3.7"
+
+services:
+  web:
+    network_mode: "host"
+    image: ghcr.io/rayfish/rayfish-umbrel:f3a5e28@sha256:06867c9d5fdd8920d1ea4e15aa06f5c5254ceb83eff9fc6a3b0a18c589f23956
+    restart: on-failure
+    stop_grace_period: 1m
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    volumes:
+      # Identity, settings.toml, and per-network config; must survive
+      # restarts and updates.
+      - ${APP_DATA_DIR}/data/config:/etc/rayfish
+      - ${APP_DATA_DIR}/data/logs:/var/log/rayfish

--- a/rayfish/umbrel-app.yml
+++ b/rayfish/umbrel-app.yml
@@ -43,4 +43,4 @@ defaultUsername: ""
 defaultPassword: ""
 
 submitter: Dario
-submission: https://github.com/getumbrel/umbrel-apps/pull/TBD
+submission: https://github.com/getumbrel/umbrel-apps/pull/5926

--- a/rayfish/umbrel-app.yml
+++ b/rayfish/umbrel-app.yml
@@ -1,0 +1,46 @@
+manifestVersion: 1
+id: rayfish
+category: networking
+name: Rayfish
+version: "f3a5e28"
+tagline: Your machines, on one private network, anywhere
+description: >-
+  Rayfish is a peer-to-peer mesh VPN that puts your Umbrel, laptop, phone, and
+  your friends' machines on one private network, even when they are scattered
+  behind different NATs. There is no control server, no account, and nothing
+  else to host: peers discover each other through a DHT and connect directly,
+  with end-to-end encryption and NAT hole-punching from iroh.
+
+
+  Create a network on your Umbrel, hand out an invite code, and reach every
+  peer by name (umbrel.mynet.ray) or by its stable virtual IP. Rayfish's
+  built-in per-device firewall keeps inbound traffic closed until you open it:
+  use the dashboard's "Share services" toggle to let your network's peers
+  reach the services running on your Umbrel from anywhere.
+
+
+  Note: because the app uses host networking to create the VPN interface, its
+  dashboard on port 8480 is reachable by other devices on your local network
+  without umbrelOS authentication, like the Tailscale app's web UI. Install it
+  on home networks you trust.
+
+
+  Rayfish is experimental, pre-1.0 software. Use it for your homelab and
+  friends, not for anything critical.
+releaseNotes: ""
+
+developer: Rayfish
+website: https://github.com/rayfish/rayfish
+dependencies: []
+repo: https://github.com/rayfish/rayfish
+support: https://github.com/rayfish/rayfish/issues
+
+port: 8480
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+submitter: Dario
+submission: https://github.com/getumbrel/umbrel-apps/pull/TBD


### PR DESCRIPTION
**App**: Rayfish (`rayfish`), packaged at upstream commit `f3a5e28`
**Upstream**: https://github.com/rayfish/rayfish — a peer-to-peer mesh VPN over [iroh](https://iroh.computer); no control server or account, peers discover each other via DHT and connect directly with end-to-end encryption.

**Image**: `ghcr.io/rayfish/rayfish-umbrel:f3a5e28@sha256:06867c9d5fdd8920d1ea4e15aa06f5c5254ceb83eff9fc6a3b0a18c589f23956` — multi-arch (amd64+arm64), built by CI in https://github.com/rayfish/rayfish-umbrel from the pinned upstream commit. It wraps the upstream `ray` binary with a browser dashboard (upstream's `ray gui`), since upstream is otherwise CLI-first.

**Host access justification** (the three linter warnings): Rayfish is a mesh VPN in the same mold as the existing Tailscale app, and uses the identical access pattern: `network_mode: host` plus `NET_ADMIN`/`NET_RAW` and `/dev/net/tun` so the daemon can create the host TUN interface and routes, making the whole Umbrel (and its apps) reachable over the mesh. Because of host networking there is no app_proxy; port 8480 is served by the container. The dashboard is consequently reachable on the LAN without umbrelOS auth (same trade-off as Tailscale's web UI); this is disclosed in the app description.

**Credentials/setup**: no accounts or credentials. First run opens a dashboard where the user creates a network or joins with an invite code; the device defaults to hostname `umbrel` on the mesh. Data (identity, network config, logs) persists under `${APP_DATA_DIR}/data/`.

**Testing**: linted with `npm run lint:apps -- rayfish --check-images` (0 errors). Installed through umbrelOS on x86_64: image pulls anonymously by digest, app starts, dashboard loads on 8480, created/joined a network, peers connect direct, data survives app restart and reinstall.

Screenshots and logo assets incoming in a follow-up comment.