### PR TITLE
pearcircle-seeder: update to 1.1.0

### DIFF
--- a/pearcircle-seeder/docker-compose.yml
+++ b/pearcircle-seeder/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8730
 
   app:
-    image: ghcr.io/peerloomllc/pearcircle-seeder:1.0.24@sha256:3b3e0cf6068b154a7a12205da5969e4fc8151ec4e054a7dfeea0cd375f1af690
+    image: ghcr.io/peerloomllc/pearcircle-seeder:1.1.0@sha256:da0a9f7b86a54f1ea277e70eadc719381e6ebaf2d1b1fcdfebe10482696a9067
     restart: on-failure
     stop_grace_period: 1m
     security_opt:

--- a/pearcircle-seeder/umbrel-app.yml
+++ b/pearcircle-seeder/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: pearcircle-seeder
 category: networking
 name: PearCircle Seeder
-version: "1.0.24"
+version: "1.1.0"
 tagline: Keep your PearCircle circles online 24/7
 description: >-
   Run a blind seeder for your PearCircle circles on your Umbrel so their

--- a/pearcircle-seeder/umbrel-app.yml
+++ b/pearcircle-seeder/umbrel-app.yml
@@ -29,17 +29,21 @@ description: >-
   To enroll a circle: open the seeder dashboard, then in the PearCircle phone
   app mint a seed invite for the circle and paste it in.
 releaseNotes: >-
-  This update brings the seeder in line with PearCircle 1.0.24. PearCircle now
-  offers an optional, direct-first connection relay for phones on networks that
-  block peer-to-peer traffic. The relay forwards encrypted data without storing
-  it, can be disabled in the PearCircle phone app, and does not change how this
-  seeder stores or serves circle data.
+  This update upgrades PearCircle Seeder to 1.1.0. The dashboard now shows live
+  progress while a phone is pairing instead of appearing to stall. In
+  PearCircle 1.1.0, the phone app's Seeders screen can also distinguish seeders
+  that have actually checked in for a circle from those that were only
+  approved, and shows when each was last heard from.
 
 
-  No manual action is required after updating.
+  The seeder now warns if a circle member publishes a last-known location
+  without encryption. PearCircle fixed the affected phone-side behavior in
+  1.0.25, so circle members using older versions should update their phone apps
+  too; updating the seeder alone does not fix an affected phone. No seeder data
+  migration or reconfiguration is required.
 
 
-  Full upstream release notes: https://github.com/peerloomllc/pearcircle/releases/tag/v1.0.24
+  Full upstream release notes: https://github.com/peerloomllc/pearcircle/releases/tag/v1.1.0
 developer: PeerLoom
 website: https://peerloomllc.com
 dependencies: []


### PR DESCRIPTION
Bump PearCircle Seeder to 1.1.0 (image pinned to the multi-arch manifest-list digest).