### PR TITLE
Add DMARC Analyzer

### DIFF
--- a/dmarc-analyzer/docker-compose.yml
+++ b/dmarc-analyzer/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: dmarc-analyzer_server_1
+      APP_PORT: 8080
+
+  server:
+    image: ghcr.io/dmarc-analyzer-net/dmarc-analyzer:0.2.2@sha256:aa0ef8f1a366933f986b1362c98d56848b75bdb8e0d2d6e0693227e48a8620cb
+    restart: on-failure
+    stop_grace_period: 1m
+    environment:
+      # Console and report ingestion in one process; the loop takes a Postgres
+      # advisory lock, so only ever run one of these against the database.
+      APP_MODE: all
+      ConnectionStrings__Default: Host=dmarc-analyzer_db_1;Port=5432;Database=dmarc_analyzer;Username=dmarc;Password=${APP_DMARC_ANALYZER_DB_PASSWORD}
+      Database__MigrateOnStartup: "true"
+      # Encrypts stored mailbox passwords at rest. Derived in exports.sh rather
+      # than taken from APP_SEED directly, because the app requires base64 that
+      # decodes to exactly 32 bytes and refuses to start otherwise.
+      Security__CredentialEncryptionKey: ${APP_DMARC_ANALYZER_ENCRYPTION_KEY}
+    depends_on:
+      db:
+        # The app migrates on boot; waiting for Postgres to accept connections
+        # avoids a first-run failure and restart.
+        condition: service_healthy
+
+  db:
+    image: postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193
+    restart: on-failure
+    stop_grace_period: 1m
+    environment:
+      POSTGRES_DB: dmarc_analyzer
+      POSTGRES_USER: dmarc
+      POSTGRES_PASSWORD: ${APP_DMARC_ANALYZER_DB_PASSWORD}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dmarc -d dmarc_analyzer"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+    volumes:
+      - ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data

--- a/dmarc-analyzer/exports.sh
+++ b/dmarc-analyzer/exports.sh
@@ -1,0 +1,12 @@
+# Derived per-install secrets.
+#
+# The encryption key cannot be APP_SEED directly: the app requires valid base64
+# that decodes to exactly 32 bytes (AES-256) and throws at startup otherwise, so
+# a raw derive_entropy value would make the app fail to boot on install. Take 32
+# characters and base64 them.
+#
+# Both values are derived, so they are stable across restarts and reinstalls —
+# which matters for the encryption key in particular: change it and every stored
+# mailbox password becomes undecryptable.
+export APP_DMARC_ANALYZER_ENCRYPTION_KEY="$(derive_entropy "app-dmarc-analyzer-encryption-key" | head -c 32 | base64 | tr -d '\n')"
+export APP_DMARC_ANALYZER_DB_PASSWORD="$(derive_entropy "app-dmarc-analyzer-db-password" | head -c 32)"

--- a/dmarc-analyzer/umbrel-app.yml
+++ b/dmarc-analyzer/umbrel-app.yml
@@ -1,0 +1,54 @@
+manifestVersion: 1
+id: dmarc-analyzer
+category: networking
+name: DMARC Analyzer
+version: "0.2.2"
+tagline: Collect and chart the DMARC reports for your domains
+description: >-
+  DMARC Analyzer reads the aggregate reports that Gmail, Outlook and other
+  receivers send back about mail claiming to be from your domains, and turns them
+  into something you can act on: who is sending as you, how much of it passes
+  SPF and DKIM, and what is still blocking a stricter policy.
+
+
+  🛠️ **SET-UP REQUIRED**
+
+
+  You need a mailbox that receives DMARC reports. Publish a DMARC record for your
+  domain with a `rua=` address pointing at it, for example
+  `v=DMARC1; p=none; rua=mailto:dmarc@yourdomain.com`, then add that mailbox
+  under Mailbox sources. Reports arrive roughly once a day per receiver, so the
+  first charts appear within about 24 hours.
+
+
+  The first account you create becomes the administrator; registration closes
+  after that.
+
+
+  **Good to know**
+
+
+  - Nothing is sent anywhere. The app connects out to your mailbox over IMAP and
+    keeps every report in its own PostgreSQL database on your Umbrel.
+
+  - Aggregate (RUA) reports only. Forensic (RUF) reports are not parsed.
+
+  - Reports are statistics, not mail. They contain sending IPs and pass/fail
+    counts, never message content.
+releaseNotes: ""
+
+developer: dmarc-analyzer.net
+website: https://dmarc-analyzer.net
+dependencies: []
+repo: https://github.com/dmarc-analyzer-net/DmarcAnalyzerApp
+support: https://github.com/dmarc-analyzer-net/DmarcAnalyzerApp/issues
+
+port: 8189
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+submitter: dmarc-analyzer-net
+submission: ""

--- a/dmarc-analyzer/umbrel-app.yml
+++ b/dmarc-analyzer/umbrel-app.yml
@@ -51,4 +51,4 @@ defaultUsername: ""
 defaultPassword: ""
 
 submitter: dmarc-analyzer-net
-submission: ""
+submission: https://github.com/getumbrel/umbrel-apps/pull/5929


### PR DESCRIPTION
Self-hosted DMARC aggregate-report monitoring. It reads the reports Gmail, Outlook and other receivers send back about mail claiming to be from your domains, and turns them into who is sending as you, how much passes SPF and DKIM, and what is still blocking a stricter policy.

**Disclosure:** I maintain this app.

## Against the App Store gates

- **Opens to a useful page.** First run is a browser setup page that creates the administrator account — no SSH, no CLI, no log scraping.
- **Both architectures.** `linux/amd64` and `linux/arm64` for the app image and `postgres:17-alpine`, both pinned by digest.
- **All state under `${APP_DATA_DIR}`.**
- **No host access.** No Docker socket, no privileged mode, no host networking, no device mounts, no extra capabilities.

## Notes on the package

**`exports.sh` derives the encryption key rather than passing `APP_SEED` directly.** The app requires base64 decoding to exactly 32 bytes and throws at startup otherwise, so the obvious wiring would fail every install. Both derived secrets are stable across reinstalls, which matters here: changing the encryption key makes stored mailbox passwords undecryptable.

**`depends_on: condition: service_healthy`** on Postgres. The app migrates as it boots, so plain ordering produced a first-run failure and restart.

**Port 8189** checked free across all 390 packages in the store.

`gallery: []` and no `icon`, per the packaging guidance for new official packages. `submission:` is empty and I'll set it to this PR's URL — happy to push that as a follow-up commit here.

## How it was validated

Ran the compose with Umbrel's container-name injection emulated (`dmarc-analyzer_server_1`, `dmarc-analyzer_db_1`) and `${APP_DATA_DIR}` pointed at a scratch directory:

- console returns 200, setup endpoint reports `requiresBootstrap: true`
- 19 database migrations applied
- ingestion loop running in-process
- **zero restarts**
- created an account, restarted the stack, and the account survived from the bind mount

Setup needs a mailbox that receives DMARC reports — publish `v=DMARC1; p=none; rua=mailto:...` and add that mailbox in the UI. Reports arrive about daily per receiver, so charts populate within roughly 24 hours. That's called out at the top of the description.