### PR TITLE
Add PPQ Private Mode 0.4.0

### DIFF
--- a/ppq-private-mode/docker-compose.yml
+++ b/ppq-private-mode/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: ppq-private-mode_web_1
+      APP_PORT: 8787
+      # API endpoints are used by OpenAI/Anthropic SDK clients that cannot send
+      # Umbrel auth cookies. The status/setup page (/) and the key-saving
+      # endpoint (/setup/*) stay behind Umbrel auth.
+      PROXY_AUTH_WHITELIST: "/v1,/v1/*,/health"
+
+  web:
+    # Image runs as the bundled `node` user (uid/gid 1000), matching Umbrel's
+    # app-data ownership.
+    image: ghcr.io/payperq/ppq-private-mode:0.4.0@sha256:5c675673e0e2cd1e73fa9b0a09d2792b2b59399fc49852511da3b5de09273d38
+    environment:
+      HOST: "0.0.0.0"
+      PORT: "8787"
+      PPQ_DATA_DIR: "/data"
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+    restart: on-failure

--- a/ppq-private-mode/umbrel-app.yml
+++ b/ppq-private-mode/umbrel-app.yml
@@ -1,0 +1,45 @@
+manifestVersion: 1
+id: ppq-private-mode
+category: ai
+name: PPQ Private Mode
+version: "0.4.0"
+tagline: Use powerful cloud AI models with end-to-end encrypted queries
+description: >-
+  PPQ Private Mode lets you use large AI models — without anyone being able to
+  read your queries. Every request is encrypted on your Umbrel before it leaves,
+  and is only decrypted inside a hardware-secured enclave (TEE) whose code
+  fingerprint is cryptographically verified before any data is sent. Not even
+  PPQ.AI, the service operator, can see your prompts or responses.
+
+
+  To get started, open the app and paste a PPQ.AI API key (create one at
+  ppq.ai under Settings → API Keys and top up the account — usage is billed
+  per query, with no subscription).
+
+
+  The app exposes an OpenAI-compatible API and a native Anthropic endpoint on
+  your local network, so you can point almost any AI client, IDE integration,
+  or agent (including Claude Code) at it:
+
+  - OpenAI format: POST /v1/chat/completions
+
+  - Anthropic format: POST /v1/messages
+
+  - Model list: GET /v1/models
+
+
+  Available models include Kimi K2, GLM, GPT-OSS 120B, Llama 3.3 70B, Qwen3
+  VL, and Gemma — all running in attested secure enclaves.
+releaseNotes: ""
+developer: PPQ.AI
+website: https://ppq.ai
+dependencies: []
+repo: https://github.com/PayPerQ/ppq-private-mode-proxy
+support: https://github.com/PayPerQ/ppq-private-mode-proxy/issues
+port: 8687
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: PayPerQ
+submission: https://github.com/getumbrel/umbrel-apps/pull/TBD

--- a/ppq-private-mode/umbrel-app.yml
+++ b/ppq-private-mode/umbrel-app.yml
@@ -42,4 +42,4 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: PayPerQ
-submission: https://github.com/getumbrel/umbrel-apps/pull/TBD
+submission: https://github.com/getumbrel/umbrel-apps/pull/5931


### PR DESCRIPTION
## App submission: PPQ Private Mode

**App / version:** PPQ Private Mode 0.4.0
**Upstream project:** https://github.com/PayPerQ/ppq-private-mode-proxy (MIT)
**Image source:** `ghcr.io/payperq/ppq-private-mode:0.4.0` — multi-arch (linux/amd64 + linux/arm64), built by [GitHub Actions](https://github.com/PayPerQ/ppq-private-mode-proxy/blob/main/.github/workflows/docker-publish.yml) from the upstream repo, pinned by manifest-list digest.

### What it is

An end-to-end encryption proxy for PPQ.AI's private (TEE) AI models. Queries are encrypted on the user's Umbrel and only decrypted inside a hardware-secured enclave whose code fingerprint is cryptographically attested before any data is sent — the service operator (PPQ.AI) cannot read prompts or responses. The app exposes an OpenAI-compatible API plus a native Anthropic endpoint, so users can point any AI client (including Claude Code) at their Umbrel.

To be upfront: this is a client for a paid remote API (pay-per-query via a PPQ.AI API key, no subscription), not a self-hosted model server. The first-run page walks the user through pasting their key.

### Auth model

- `/` (status/setup page) and `/setup/*` (key saving) stay behind Umbrel auth.
- `PROXY_AUTH_WHITELIST: "/v1,/v1/*,/health"` — the API endpoints must be reachable by OpenAI/Anthropic SDK clients that cannot send Umbrel auth cookies. The status page and key management remain protected.

### Persistence

Single bind mount `${APP_DATA_DIR}/data:/data` holding `config.json` (the saved API key, written 0600). Container runs as the bundled `node` user (uid/gid 1000).

### Testing performed

- `npm run lint:apps -- ppq-private-mode --check-images` — no issues
- Containerized umbrelOS 1.7.4 (arm64, Docker on macOS): install through the app store flow, first-run key setup, restart persistence, uninstall/reinstall
- Verified through app_proxy from outside the device: `/health`, `/v1/models`, a live streaming-capable chat completion (`/v1/chat/completions`) end-to-end through the attested enclave, and that `/` + `/setup/*` correctly redirect to Umbrel auth
- Image multi-arch verified with `docker buildx imagetools inspect`

### Assets

- Icon (256px flame logo): https://raw.githubusercontent.com/PayPerQ/umbrel-app-store/main/assets/icon.png
- Screenshots (1440×900):
  - https://raw.githubusercontent.com/PayPerQ/umbrel-app-store/main/assets/1-setup.png
  - https://raw.githubusercontent.com/PayPerQ/umbrel-app-store/main/assets/2-configured.png
  - https://raw.githubusercontent.com/PayPerQ/umbrel-app-store/main/assets/3-full.png

🤖 Generated with [Claude Code](https://claude.com/claude-code)