### PR TITLE
Update Stratum V2 UI to v0.6.0

### DIFF
--- a/sv2-ui/docker-compose.yml
+++ b/sv2-ui/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - ${APP_DATA_DIR}/data/config:/app/data/config
 
   sv2-ui:
-    image: stratumv2/sv2-ui:v0.5.0@sha256:e02bb0ec9588dda71817ef70bad9ff6c41f800d5d2c770ca4e39227d7d48381d
+    image: stratumv2/sv2-ui:v0.6.0@sha256:e9fc51df9c0fc02d367b4fe1a72f8216d7aaa5ce8a502982965610b95f244305
     stop_grace_period: 1m
     restart: on-failure
     # required: sv2-ui expects docker DNS to resolve container names in production.

--- a/sv2-ui/umbrel-app.yml
+++ b/sv2-ui/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: sv2-ui
 category: bitcoin
 name: Stratum V2 UI
-version: "0.5.0"
+version: "0.6.0"
 tagline: Setup and monitor Stratum V2 mining
 description: >-
   Stratum V2 UI is a setup wizard and monitoring dashboard for running a
@@ -27,7 +27,7 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Added new Sv2 SOLO pools, together with new features like fallback pools, payout verification and minor bug fixes. More details in the release notes at https://github.com/stratum-mining/sv2-ui/releases/tag/v0.5.0.
+  Added NexusPool and CK Pool (solo mining), simplified node setup, unified pool configuration flows, and a streamlined dashboard with per-worker best difficulty and more accurate hashrate reporting based on new miner telemetry data. Coinbase verification and minimum individual worker hashrate can now be configured from the UI, custom pools in Job Declaration mode can specify a JDS port, and logs feature smart color coding for easier reading. More details in the release notes at https://github.com/stratum-mining/sv2-ui/releases/tag/v0.6.0.
 dependencies:
   - bitcoin
 developer: "The Stratum V2 Developers"

--- a/sv2-ui/umbrel-app.yml
+++ b/sv2-ui/umbrel-app.yml
@@ -26,8 +26,14 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
-releaseNotes: >-
-  Added NexusPool and CK Pool (solo mining), simplified node setup, unified pool configuration flows, and a streamlined dashboard with per-worker best difficulty and more accurate hashrate reporting based on new miner telemetry data. Coinbase verification and minimum individual worker hashrate can now be configured from the UI, custom pools in Job Declaration mode can specify a JDS port, and logs feature smart color coding for easier reading. More details in the release notes at https://github.com/stratum-mining/sv2-ui/releases/tag/v0.6.0.
+releaseNotes: |-
+  - Added NexusPool and CK Pool for solo mining.
+  - Simplified Bitcoin Core connection setup for Job Declaration mode and unified pool configuration.
+  - Streamlined the dashboard with per-worker best difficulty and more accurate hashrate reporting.
+  - Added UI settings for coinbase verification, minimum worker hashrate, and custom JDS ports.
+  - Improved log readability with smart color coding.
+
+  Full release notes: https://github.com/stratum-mining/sv2-ui/releases/tag/v0.6.0
 dependencies:
   - bitcoin
 developer: "The Stratum V2 Developers"


### PR DESCRIPTION
<!--
Title format:
- Add <app name>
- Update <app name> to <version>
- Fix <app name> <issue>
-->

## Type
App update

## App

App ID: sv2-ui
Upstream project: https://github.com/stratum-mining/sv2-ui
Version: 0.6.0

## Summary

In `sv2-ui` v0.6.0 we added NexusPool and CK Pool (solo mining), simplified node setup, unified pool configuration flows, and a streamlined dashboard with per-worker best difficulty and more accurate hashrate reporting based on new miner telemetry data. Now coinbase verification and minimum individual worker hashrate can be configured from the UI, custom pools in Job Declaration mode can specify a JDS port, and logs feature smart color coding for easier reading. More details in the release notes at https://github.com/stratum-mining/sv2-ui/releases/tag/v0.6.0.

## Verification

Umbrel testing performed:
Tested on my Umbrel VM and everything works properly.

Environment tested:
- [ ] Umbrel device
- [x] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64