### PR TITLE
Fix Arcane proxy authentication

### DIFF
--- a/arcane/docker-compose.yml
+++ b/arcane/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
       APP_HOST: arcane_arcane_1
       APP_PORT: 3552
+      PROXY_AUTH_ADD: "false"
 
   docker:
     image: docker:27.2.0-dind@sha256:f9f72ad901a78f27be922b2d320bbc263174f12919c1b37e6a01f828fa904565

--- a/arcane/umbrel-app.yml
+++ b/arcane/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: arcane
 category: developer
 name: Arcane
-version: "2.8.1"
+version: "2.8.1-1"
 tagline: An easy and modern Docker management platform
 description: >-
   ⚠️ Make sure to only use named Docker volumes for your containers and projects. Data in bind-mounted volumes will be lost when the Arcane app is restarted or updated.
@@ -55,6 +55,8 @@ releaseNotes: >-
   Additional fixes improve localization, HTTP/2 connection handling, and filesystem error checks.
 
   If you're updating from a pre-2.0 version, back up your Arcane data first and review the v2 migration guide if you use OIDC, API keys/automation, Edge mTLS remote environments, Apprise notifications, or deprecated prune/GitOps settings.
+
+  This Umbrel package revision also disables proxy authentication so the Arcane mobile app can connect.
 
   Full release notes can be found at https://github.com/getarcaneapp/arcane/releases/tag/v2.8.1
 permissions:


### PR DESCRIPTION
<!--
Title format:
- Add <app name>
- Update <app name> to <version>
- Fix <app name> <issue>
-->

## Type

App update

## App

App ID: arcane
Upstream project: https://github.com/getarcaneapp/arcane
Version: 2.8.1-1

## Summary

Rebased onto current master (Arcane 2.8.1). Disable Umbrel `app_proxy` authentication (`PROXY_AUTH_ADD: "false"`) so the Arcane mobile app ([testflight](https://testflight.apple.com/join/Y9KUft8F)) can connect.

The image is the master 2.8.1 pin; this is a package revision (`2.8.1` → `2.8.1-1`). Official 2.8.1 release notes are kept, with a note that proxy auth is disabled. Arcane still has its own login (`arcane` / `arcane-admin`).

## Verification

Umbrel testing performed:

Environment tested:
- [x] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64

Known lint warnings or caveats:
Pre-existing warnings only: DinD digest drift, `privileged: true`, and host networking. Unchanged by this PR.

Runtime retest of 2.8.1 + mobile connect was not repeated after this rebase. Proxy-auth behavior was previously verified on 2.6.0 on an Umbrel device (amd64).

## Notes

- Intentional security tradeoff: Umbrel login is no longer required before Arcane; access is protected by Arcane's own auth.
- No permission, dependency, migration, or credential changes.