### PR TITLE
Update EE Gateway to 0.10.7

### DIFF
--- a/ee-gateway/docker-compose.yml
+++ b/ee-gateway/docker-compose.yml
@@ -34,7 +34,7 @@ services:
   # extra download, and it is the only place root is used. This is NOT privileged
   # mode; the app containers themselves stay non-root.
   init_perms:
-    image: encryptedenergy/ee-gateway-worker:0.7.7@sha256:678688523b9357b87308aae532b8f57a0a5769eb43ad33911ad0c345220eb17b
+    image: encryptedenergy/ee-gateway-worker:0.8.0@sha256:816e236ff47052e5d081cc4a99f56c40434df33aba1b0efd0badc4d30902ae04
     user: "0:0"
     entrypoint: ["sh", "-c", "chown -R 1000:1000 /data"]
     restart: on-failure
@@ -58,7 +58,7 @@ services:
     environment:
       EE_DATA_DIR: /data
       EE_UI_PORT: 8080
-      EE_GATEWAY_VERSION: "0.10.6"
+      EE_GATEWAY_VERSION: "0.10.7"
 
   # BLE scan + GPS-stamped cloud ingest worker. It reaches the host's
   # Bluetooth radio through bluetoothd over the D-Bus system bus, talks to
@@ -67,7 +67,7 @@ services:
   # Python process runs as uid 1000; gpsd starts as root only to open the
   # serial device, then drops to user nobody.
   worker:
-    image: encryptedenergy/ee-gateway-worker:0.7.7@sha256:678688523b9357b87308aae532b8f57a0a5769eb43ad33911ad0c345220eb17b
+    image: encryptedenergy/ee-gateway-worker:0.8.0@sha256:816e236ff47052e5d081cc4a99f56c40434df33aba1b0efd0badc4d30902ae04
     init: true
     restart: on-failure
     depends_on:

--- a/ee-gateway/umbrel-app.yml
+++ b/ee-gateway/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ee-gateway
 category: networking
 name: EE Gateway
-version: "0.10.6"
+version: "0.10.7"
 tagline: Self-hosted Bluetooth gateway for open BLE networks
 description: >-
   EE Gateway turns your Umbrel into a self-hosted Bluetooth gateway for
@@ -27,23 +27,23 @@ description: >-
   encryptedenergy.com. It is an independent community project and is not
   affiliated with any specific BLE network.
 releaseNotes: >-
-  Setup gets much easier. You can now type a street address or
-  landmark and the gateway looks up the coordinates for you, on both
-  the setup wizard and the location settings page. Coordinate entry
-  also accepts what people actually paste: the full "lat, lon" pair
-  copied from Google Maps dropped into either field, degree symbols,
-  N/S/E/W letters, and European decimal commas all work now.
+  Big efficiency release. The worker now uploads queued packets in one
+  batch instead of one request per packet. On a busy gateway that cuts
+  network requests and SD card writes by up to 500 times, and uploads
+  clear much faster after the gateway comes back online.
 
 
-  Setup is also one field shorter: the organization ID is gone. Your
-  API token alone connects the gateway; existing installs are
-  unaffected and need no changes.
+  Location reporting is more trustworthy too. Each packet now carries
+  the exact time its GPS coordinate was captured and how precise the
+  fix was, straight from your dongle. That lets the upstream network
+  verify your gateway's coverage is real, which protects your payout
+  eligibility as anti-fraud checks tighten.
 
 
-  Reliability fix for busy gateways: when the EE cloud answers a
-  packet upload with HTTP 408 (request timeout) or 429 (rate limited),
-  the worker now keeps that packet queued and retries it on the next
-  pass instead of dropping it permanently. Worker 0.7.7, UI 0.6.4.
+  Housekeeping: the last unused leftovers of the organization ID are
+  gone from the worker. Your API token alone connects the gateway, and
+  existing installs keep working with no changes. Worker 0.8.0, UI
+  0.6.4.
 developer: encryptedenergy.com
 website: https://encryptedenergy.com
 dependencies: []


### PR DESCRIPTION
Big efficiency and data-integrity release. The worker now uploads queued packets in one batched request per drain instead of one request per packet, cutting network requests and SD-card writes on busy gateways by up to 500x. Each packet also now reports when its GPS coordinate was captured and its horizontal accuracy, so the upstream network can verify location freshness. Rounding it out, the last unused org-ID leftovers are removed from the worker config (API token alone connects the gateway; existing installs unaffected).

No permission or manifest-structure changes — worker image digest bump + release notes only. UI unchanged at 0.6.4 (existing digest kept). Description copy edits from the 0.10.6 review are preserved.

Full changelog: https://github.com/Encrypted-Energy/gateway/releases/tag/v0.10.7