### PR TITLE
Update BOLT12 Pay to v0.3.0.7

### DIFF
--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.3.0.2@sha256:f598805126059a410f3c9bfc46c538d82ce12112d1e2bfda5936eb213b3144d7
+    image: alex71btc/bolt12-pay:0.3.0.7@sha256:8b24d40b6a45e9abee202dbbc528780084b9f07d720b5c5bfbcea6628be32e5b
     restart: on-failure
     depends_on:
       - lndk

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.3.0.2
+version: 0.3.0.7
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
@@ -154,31 +154,22 @@ releaseNotes: |
 
   Highlights:
 
-  - Introduces Transaction History for incoming and outgoing Lightning payments
-  - Automatically synchronizes payment history from LND
-  - Preserves payment metadata including BOLT12, Lightning Address, LNURL, NWC, Zaps and Keysend
-  - Live synchronization keeps transaction history up to date
-  - Improved NWC wallet integration and payment handling
-  - Numerous UI improvements and bug fixes
+  - Fixes BIP353 resolution on recent StartOS releases
+  - Restores Lightning Address payments on StartOS 0.4.x
+  - Improves Lightning Address fallback behaviour during temporary DNS transport failures
+  - Uses the system DNS resolver for improved compatibility across platforms
 
-  Native Onion Messaging:
+  Compatibility:
 
-  - Automatic detection of native Onion Messaging support in LND v0.21+
-  - Native Onion Messaging status is displayed during setup
-  - Legacy custom-message configuration is automatically hidden when no longer required
-  - Full compatibility with both LND v0.20.x and LND v0.21.x
+  - Verified on Docker deployments
+  - Verified on Umbrel
+  - Verified on StartOS 0.4.x
+  - Preserves existing DNSSEC behaviour and interoperability
 
-  Payment Compatibility:
+  Notes:
 
-  - Automatic fallback between LND v0.20 and v0.21 payment APIs
-  - Automatically switches to RouterRPC on LND v0.21 when required
-  - Improved Lightning Address, LNURL, BOLT11, BOLT12 and NWC payment compatibility
-  - Added default routing fee limits for better interoperability with wallets and Lightning Address providers
-
-  Upgrade Notes:
-
-  - LND v0.20.x users should keep their existing custom protocol configuration.
-  - LND v0.21.x users should remove legacy custom protocol settings from lnd.conf after upgrading to native Onion Messaging support.
+  - No configuration changes are required.
+  - Existing Lightning Addresses, BIP353 addresses and BOLT12 Offers continue to work as before.
 
 dependencies:
   - lightning


### PR DESCRIPTION
## Summary

Updates BOLT12 Pay to v0.3.0.7.

### Highlights

- Fixes BIP353 resolution by using the system DNS resolver where appropriate
- Restores Lightning Address payments on StartOS 0.4.x
- Improves Lightning Address fallback handling during temporary DNS transport failures
- Preserves existing DNSSEC behaviour and interoperability

### Tested

Successfully verified on:

- ✅ Local Docker deployment
- ✅ Umbrel Community App
- ✅ StartOS 0.4.x

Verified:

- BIP353 payments
- Lightning Address payments
- LNURL fallback
- BOLT12 Offer payments