### PR TITLE
peartune: add PearTune 1.0.0

### DIFF
--- a/peartune/docker-compose.yml
+++ b/peartune/docker-compose.yml
@@ -1,0 +1,58 @@
+version: "3.7"
+
+services:
+  # NO app_proxy, and that is not an oversight.
+  #
+  # PearTune's host MUST run with network_mode: host. Measured on a real Umbrel,
+  # twice, with the real image: under Docker's default bridge the firewall admits
+  # the phone (gate:allow-for-pairing) and the connection then dies before the pair
+  # channel opens. Bridge NAT is a second layer of NAT and holepunching does not
+  # survive it.
+  #
+  # app_proxy is a container on a bridge network, so it cannot front a
+  # host-networked service - which is why Umbrel's own host-networked apps (Plex,
+  # Home Assistant) do not use it either. The proxy WAS the only thing standing in
+  # for our missing auth, so the dashboard now has its own: PEARTUNE_PASSWORD, which
+  # umbrelOS fills with the app password shown next to PearTune in the app list.
+  # The host refuses to start on a non-loopback bind without it.
+  app:
+    image: ghcr.io/peerloomllc/peartune-host:0.2.41@sha256:47ab391cc042382a1b5c2eee8dddbba936153b1b3b6695ae41765055e3504032
+    restart: on-failure
+    stop_grace_period: 1m
+    network_mode: host
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      PEARTUNE_HTTP_HOST: 0.0.0.0
+      PEARTUNE_HTTP_PORT: "8741"
+      PEARTUNE_PASSWORD: ${APP_PASSWORD}
+      PEARTUNE_NAME: My Library
+      PEARTUNE_DATA: /data
+      # Point PearTune at the Navidrome you already run on this box. Leave the URL
+      # empty to serve a plain folder instead (mounted at /music below).
+      PEARTUNE_NAVIDROME_URL: ${APP_PEARTUNE_NAVIDROME_URL:-}
+      PEARTUNE_NAVIDROME_USER: ${APP_PEARTUNE_NAVIDROME_USER:-}
+      PEARTUNE_NAVIDROME_PASS: ${APP_PEARTUNE_NAVIDROME_PASS:-}
+      # The DEFAULT library, for a folder install with no dashboard choice. This is
+      # the path INSIDE the container, and it points at the music subfolder of the
+      # mount below. The operator can pick a different folder in the dashboard
+      # (music vs podcasts vs audiobooks) - it browses what the container can see.
+      PEARTUNE_MUSIC: /library/music
+    volumes:
+      # The host identity seed and the grant store. Losing this means every device
+      # must re-pair; leaking it means someone can impersonate your library.
+      - ${APP_DATA_DIR}/data:/data
+      # WHERE AN UMBREL USER'S MUSIC ACTUALLY LIVES.
+      #
+      # This mounted ${UMBREL_ROOT}/data/storage/downloads before, and that path was
+      # simply WRONG: on a real Umbrel it is a different, empty directory, so a folder
+      # install landed on an empty library and looked broken. Navidrome's own Umbrel
+      # app - the established music app on the box, the one PearTune reads alongside -
+      # mounts ${UMBREL_ROOT}/home/Downloads/music, and that is where the files are
+      # (verified on hardware: 1357 tracks there, 0 in the old path).
+      #
+      # We mount the whole Downloads directory, not just music/, so the dashboard's
+      # folder picker can also reach podcasts/ and audiobooks/ if that is where a
+      # given user keeps things. Read-only, always: PearTune serves music, it has no
+      # business writing to it.
+      - ${UMBREL_ROOT}/home/Downloads:/library:ro

--- a/peartune/umbrel-app.yml
+++ b/peartune/umbrel-app.yml
@@ -38,10 +38,7 @@ description: >-
 
 
   Pair a phone by scanning the QR code on this dashboard with the PearTune app.
-releaseNotes: >-
-  First release of the PearTune host for Umbrel. Serves your Navidrome library (or a
-  plain folder) to the PearTune phone app over a peer-to-peer connection, with a
-  dashboard for pairing devices, naming who holds them, and revoking access mid-song.
+releaseNotes: ""
 
 developer: PeerLoom
 website: https://peerloomllc.com/peartune/
@@ -59,4 +56,4 @@ defaultUsername: ""
 deterministicPassword: true
 
 submitter: PeerLoom
-submission: https://github.com/peerloomllc/peartune
+submission: https://github.com/getumbrel/umbrel-apps/pull/5943

--- a/peartune/umbrel-app.yml
+++ b/peartune/umbrel-app.yml
@@ -1,0 +1,62 @@
+manifestVersion: 1
+id: peartune
+category: media
+name: PearTune
+version: "1.0.0"
+tagline: Your music, playable anywhere - and shareable with friends
+description: >-
+  Play the music on your Umbrel from anywhere, without exposing your server to the
+  internet.
+
+
+  PearTune connects your phone straight to this machine over an encrypted
+  peer-to-peer connection (the Hypercore Protocol). No port forwarding, no VPN, no
+  dynamic DNS, no account, and no copy of your library in anyone's cloud. The music
+  never leaves your hardware: it streams through the live connection while it plays.
+
+
+  It reads your existing library. Point it at the Navidrome or Jellyfin you already
+  run and it uses that - your tags, your artwork, your album art, and the server's
+  transcoding. Or point it at a plain folder of files: PearTune reads the tags itself
+  (artist, album, track number, year and embedded cover art), so a folder is a real
+  library, not a list of filenames. You choose the source in the dashboard - no
+  compose file to edit.
+
+
+  YOU decide who gets in. Every phone that pairs is a device on this dashboard, with
+  a name it chose and a person it belongs to. Revoke a device and the music stops
+  within a second, mid-song - not "on next login". Revoke a person and every device
+  they hold dies at once. There are no shared passwords or bearer tokens anywhere in
+  the design: every connection is authenticated by the phone's own key.
+
+
+  That is what makes SHARING safe. Your library is not only for your own phones: let a
+  friend or a family member in and they get their own place here, with their own
+  devices, their own favourites and their own resume points - and no login to pass
+  around. Hand out a guest pass that expires by itself, or cut someone off the moment
+  you want to. They never get a copy of a single file.
+
+
+  Pair a phone by scanning the QR code on this dashboard with the PearTune app.
+releaseNotes: >-
+  First release of the PearTune host for Umbrel. Serves your Navidrome library (or a
+  plain folder) to the PearTune phone app over a peer-to-peer connection, with a
+  dashboard for pairing devices, naming who holds them, and revoking access mid-song.
+
+developer: PeerLoom
+website: https://peerloomllc.com/peartune/
+dependencies: []
+repo: https://github.com/peerloomllc/peartune
+support: https://github.com/peerloomllc/peartune/issues
+
+port: 8741
+permissions:
+  - STORAGE_DOWNLOADS
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: $APP_PASSWORD
+
+submitter: PeerLoom
+submission: https://github.com/peerloomllc/peartune

--- a/peartune/umbrel-app.yml
+++ b/peartune/umbrel-app.yml
@@ -56,7 +56,7 @@ gallery: []
 path: ""
 
 defaultUsername: ""
-defaultPassword: $APP_PASSWORD
+deterministicPassword: true
 
 submitter: PeerLoom
 submission: https://github.com/peerloomllc/peartune


### PR DESCRIPTION
## App

**PearTune 1.0.0** — plays the music already on your Umbrel from a phone anywhere, over a direct encrypted peer-to-peer connection. No port forwarding, no VPN, no dynamic DNS, no account, and no copy of the library in anyone's cloud.

- **Upstream project:** https://github.com/peerloomllc/peartune (MIT)
- **Website:** https://peerloomllc.com/peartune/
- **Image:** `ghcr.io/peerloomllc/peartune-host:0.2.41`, pinned by digest, built from [`host/Dockerfile`](https://github.com/peerloomllc/peartune/blob/master/host/Dockerfile) in that repo. Multi-arch manifest list, `linux/amd64` + `linux/arm64`.

It reads the library that is already on the box: point it at an existing Navidrome or Jellyfin and it uses that server's tags, artwork and transcoding, or point it at a plain folder and it reads the tags itself (ID3, Vorbis, MP4, FLAC, including embedded cover art). The source is chosen in the dashboard — no compose edits.

The phone app is the client. It is on the App Store now and in closed testing on Google Play.

## Screenshots

The dashboard is the whole browser surface: first run, choosing the music source, and managing who has access.

![First run](https://raw.githubusercontent.com/peerloomllc/peartune/master/docs/img/dashboard-first-run.png)
![Music source](https://raw.githubusercontent.com/peerloomllc/peartune/master/docs/img/dashboard-music-source.png)
![People and devices](https://raw.githubusercontent.com/peerloomllc/peartune/master/docs/img/dashboard-people.png)
![Pairing QR](https://raw.githubusercontent.com/peerloomllc/peartune/master/docs/img/dashboard-pair-qr.png)

Logo: https://raw.githubusercontent.com/peerloomllc/peartune/master/umbrel/icon.svg

## App Store Standard

Opens straight to a web dashboard on port 8741 with a three-step first-run flow: name the library, point it at your music, pair a phone. No SSH, no CLI, no log scraping, no file edits for normal use.

## Host access and permissions — the two lint warnings

**`network_mode: host` — required, and measured.** PearTune reaches phones by outbound UDP holepunching over the Hypercore DHT, which is what removes the need for port forwarding. Docker's default bridge adds a second layer of NAT that kills it: the connection is admitted and then no media flows. That was measured on a real Umbrel twice before host networking was adopted, and the reasoning is recorded in the compose file itself. The manifest `port: 8741` matches the host listener the dashboard binds.

**`security_opt: no-new-privileges:true` — hardening, not a privilege request.** It only prevents the container from gaining privileges it was not started with. Happy to drop it if you would rather packages not set `security_opt` at all.

**`permissions: [STORAGE_DOWNLOADS]`** — the compose mounts `${UMBREL_ROOT}/home/Downloads` **read-only** at `/library`. That is where an Umbrel user's music actually lives (it is what Navidrome's own package mounts). The whole Downloads directory rather than `music/` alone, so the dashboard's folder picker can also reach `podcasts/` or `audiobooks/`. PearTune never writes to it — it serves music and has no import or edit path.

No Docker socket, no privileged mode, no device mounts, no extra capabilities.

## Persistence

`${APP_DATA_DIR}/data` holds the host identity seed and the grant store (which devices are allowed in). Losing it means every phone must re-pair, so it is deliberately the only writable volume, and `peartune/data` is committed for fresh installs.

## Default credentials

`defaultUsername: ""` with `deterministicPassword: true`, so umbrelOS shows the password it derives. There is no user account — the dashboard is password-gated with Umbrel's generated app password, and the phone side has no password at all: each connection is authenticated by the device's own key, so there are no bearer tokens or connection strings anywhere in the design.

## Testing

- `npm run lint:apps -- peartune --check-images` → 0 errors, 2 warnings (the two justified above).
- The image has been running as the author's daily host on an Umbrel Home (N100) against a 1358-track Navidrome library, plus a plain-folder library, with phones streaming on the LAN and over cellular.
- Pair, browse, play, seek, and revoke-mid-song verified on real hardware; revocation cuts new requests within about a second.
