### PR TITLE
hermitstash: update to 1.14.2

### DIFF
--- a/hermitstash/docker-compose.yml
+++ b/hermitstash/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/dotcoocoo/hermitstash:1.13.21@sha256:03d5183b3242616aca540e914377b713779c65c1a7ddc54f319b9c95e12fd74a
+    image: ghcr.io/dotcoocoo/hermitstash:1.14.2@sha256:46f5c4ba6ed9ddeff93963cf60084c4c9b531918dec9f7b9eea56193786cf9f8
     user: "1000:1000"
     init: true
     restart: on-failure

--- a/hermitstash/umbrel-app.yml
+++ b/hermitstash/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: hermitstash
 category: files
 name: HermitStash
-version: "1.13.21"
+version: "1.14.2"
 tagline: Post-quantum encrypted self-hosted file sharing
 description: >-
   HermitStash is a self-hosted file upload server with post-quantum encryption. Every file and database field is sealed with an ML-KEM-1024 + ECDH P-384 hybrid envelope and XChaCha20-Poly1305 before touching disk; passwords use Argon2id. Nothing is stored in plaintext, including database fields the operator never thinks of as sensitive.
@@ -11,7 +11,7 @@ description: >-
   Generate shareable download links with optional expiry, download limits, and per-bundle passwords. Sign in with WebAuthn passkeys, mTLS browser certificates issued by the built-in CA, or password + TOTP. A separately-installable desktop sync client watches a local folder and mirrors changes back to the server over a post-quantum WebSocket channel.
 
 
-  The admin panel covers users, uploads, webhooks, API keys, branding, and storage backends — local disk by default, or any S3-compatible bucket (MinIO, Cloudflare R2, Backblaze B2) for off-device archives. Retry-safe writes via the standard Idempotency-Key header. RFC 9457 problem-details on every API error response.
+  The admin panel covers users, uploads with per-user and per-stash size limits, webhooks, API keys, branding, a tamper-evident audit log (CSV/JSON/CADF export, plus syslog or webhook forwarding to a SIEM), mutual-TLS certificate-authority management, and storage backends — local disk by default, or any S3-compatible bucket (MinIO, Cloudflare R2, Backblaze B2) for off-device archives. Retry-safe writes via the standard Idempotency-Key header. RFC 9457 problem-details on every API error response.
 
 
   Files and database fields are sealed with post-quantum encryption at rest no matter how you reach the app. When it is served over HTTPS — a custom domain, or remote access over Tor or Tailscale — the TLS handshake also negotiates a post-quantum key exchange (X25519MLKEM768 or SecP384r1MLKEM1024), so the connection itself is quantum-resistant; over a plain local-network address the at-rest protection still applies.
@@ -31,12 +31,16 @@ defaultPassword: ""
 submitter: dotCooCoo
 submission: https://github.com/getumbrel/umbrel-apps/pull/5378
 releaseNotes: >-
-  This security-focused release keeps plaintext upload data off disk and hardens authentication, backup/restore, and path cleanup behavior.
+  This release moves the mutual-TLS certificate authority for sync clients to post-quantum ML-DSA-87 (FIPS 204), migrates existing installs to it automatically, and lands a broad round of security hardening across the upload, authentication, admin, and audit surfaces.
 
-  - Uploads and chunked-upload fragments are now processed in memory or encrypted while staged, so plaintext file content is not written to disk before sealing.
-  - Backup restores, sealed-column queries, sealed-array updates, and backup operation locks are now more robust.
-  - Google sign-in now binds returning accounts to their stable Google identity, uses PKCE, and has stronger request handling and rate limiting.
-  - Certificate, encrypted-blob, path-containment, directory-cleanup, and startup HTTPS-warning checks now fail closed more consistently.
+  - The sync certificate authority now signs with post-quantum ML-DSA-87 (FIPS 204) by default. An existing classical authority migrates itself automatically at startup on a capable runtime; the migration is crash-safe and keeps existing sync certificates verifying through a 30-day grace window while their owners re-enroll.
+  - The certificates people import into a browser or OS keystore stay on a separate classical ECDSA P-384 authority so they remain universally importable, while machine sync certificates go post-quantum. The certificate engine moves to the zero-dependency @blamejs/pki toolkit.
+  - In the admin panel, the mutual-TLS certificate-authority view reflects the split between the post-quantum sync authority and the classical browser authority, shows each authority's algorithm and generation, and surfaces the auto-migration grace window on the Danger Zone card.
+  - File and bundle changes now enforce the API key's certificate binding and its stash and bundle confinement, so a bearer token presented without its client certificate can no longer reach another key's resources.
+  - Chunked-upload reassembly memory is bounded even under a no-limit policy, and the shared bundle behind a public sync stash can no longer be overwritten by an unauthenticated request.
+  - The tamper-evident audit chain no longer interleaves retention cleanup with encrypted archival, outbound webhooks are signed under the Standard Webhooks scheme for replay protection, and account-enumeration timing is closed on password-reset, email-verification, and access-code requests.
+  - Authentication is tightened: the soft mTLS gate validates a presented bearer token, passkey verification runs before any account-status check, repeated second-factor failures count against the pending sign-in, and operator-supplied legal-policy text is HTML-sanitized before rendering.
+  - Reliability fixes: an oversized request on an encrypted session returns a Payload Too Large response instead of resetting the connection, a negative numeric setting falls back to its default, access-code attempts are counted atomically, and a storage error mid-download no longer crashes the process. The container base image is also refreshed to clear a high-severity npm advisory (CVE-2026-14257).
 
-  Full release notes can be found at https://github.com/dotCooCoo/hermitstash/releases/tag/v1.13.21
+  Full release notes can be found at https://github.com/dotCooCoo/hermitstash/releases/tag/v1.14.2
 dependencies: []


### PR DESCRIPTION
Updates HermitStash from 1.13.21 to 1.14.2.

Highlights of this release:

- The sync client's mutual-TLS certificate authority moves to post-quantum ML-DSA-87 (FIPS 204), with a crash-safe automatic migration on upgrade and a 30-day grace window so existing sync certificates keep verifying while their owners re-enroll. Browser-imported certificates stay on a separate classical ECDSA P-384 authority so they remain universally importable.
- Broad security hardening across the upload, authentication, admin, and audit surfaces: certificate binding + stash confinement on file/bundle changes, bounded chunked-upload reassembly memory, protection of the shared sync bundle from anonymous overwrite, replay-protected (Standard Webhooks) outbound webhooks, and closed account-enumeration timing on password-reset / email-verification / access-code requests.
- The container base image is refreshed to clear a high-severity npm advisory (CVE-2026-14257).

The app description now also surfaces admin-panel capabilities that were already present but previously unlisted: a tamper-evident audit log with CSV/JSON/CADF export and syslog/webhook SIEM forwarding, per-user and per-stash upload limits, and mutual-TLS certificate-authority management.

Image is pinned to the multi-arch digest for 1.14.2:

```
ghcr.io/dotcoocoo/hermitstash:1.14.2@sha256:46f5c4ba6ed9ddeff93963cf60084c4c9b531918dec9f7b9eea56193786cf9f8
```

Full release notes: https://github.com/dotCooCoo/hermitstash/releases/tag/v1.14.2
