### PR TITLE
Add ROMarr

### DIFF
--- a/romarr/docker-compose.yml
+++ b/romarr/docker-compose.yml
@@ -4,10 +4,10 @@ services:
   app_proxy:
     environment:
       APP_HOST: romarr_web_1
-      APP_PORT: 7878
+      APP_PORT: 6868
 
   web:
-    image: ghcr.io/blizzhacker/romarr:0.6.1@sha256:ce961117539fa985ee6d9c92a7ee8781ec3a154d2bb6c482d9eae27fed3e961c
+    image: ghcr.io/blizzhacker/romarr:0.7.0@sha256:106b336bf174813e1f2a6f610b567f9b384efba2ac2563ccc415015703786cbe
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/romarr/docker-compose.yml
+++ b/romarr/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: romarr_web_1
+      APP_PORT: 7878
+
+  web:
+    image: ghcr.io/blizzhacker/romarr:0.6.1@sha256:ce961117539fa985ee6d9c92a7ee8781ec3a154d2bb6c482d9eae27fed3e961c
+    restart: on-failure
+    stop_grace_period: 1m
+    volumes:
+      # Settings, history and indexer configuration.
+      - ${APP_DATA_DIR}/data/config:/config
+      # Where finished ROMs are filed.
+      - ${UMBREL_ROOT}/data/storage/downloads:/downloads
+      - ${APP_DATA_DIR}/data/roms:/roms
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: ${TZ}
+      LIBRARY_KIND: romm
+      LIBRARY_PATH: /roms

--- a/romarr/umbrel-app.yml
+++ b/romarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: romarr
 category: media
 name: ROMarr
-version: "0.6.1"
+version: "0.7.0"
 tagline: The *arr for games
 description: >-
   Request a title and ROMarr searches your indexers through Prowlarr, hands the
@@ -43,7 +43,7 @@ website: https://foundation.moveweight.com
 dependencies: []
 repo: https://github.com/BlizzHacker/romarr
 support: https://github.com/BlizzHacker/romarr/issues
-port: 7878
+port: 6868
 gallery:
   - 1.jpg
   - 2.jpg

--- a/romarr/umbrel-app.yml
+++ b/romarr/umbrel-app.yml
@@ -1,0 +1,57 @@
+manifestVersion: 1.1
+id: romarr
+category: media
+name: ROMarr
+version: "0.6.1"
+tagline: The *arr for games
+description: >-
+  Request a title and ROMarr searches your indexers through Prowlarr, hands the
+  winner to your download client, and files the ROM into your game library where
+  it can actually be played. If you run Radarr for films and Sonarr for TV, this
+  is the missing one.
+
+
+  ROMarr is not tied to one library. RomM, Gaseous and Retrom are all supported
+  and chosen with a single setting. There is also a folder mode that writes a
+  plain directory tree laid out by platform, which is what Batocera, RetroPie,
+  EmulationStation, ES-DE, EmuDeck, Pegasus, Lakka, muOS and LaunchBox all read
+  — no URL and no account needed.
+
+
+  Releases are scored and the reasoning is shown, so a wrong pick is a click to
+  correct rather than a bug report. Interactive search lists every candidate
+  with its score and a Grab button.
+
+
+  🛠️ SETUP INSTRUCTIONS
+
+
+  ROMarr needs three things: a Prowlarr instance, at least one download client
+  (qBittorrent, SABnzbd or NZBGet), and somewhere to put the ROMs. Install
+  Prowlarr and a download client from the Umbrel App Store first, then open
+  ROMarr and fill in the Settings page.
+
+
+  A download client is genuinely required rather than merely recommended: a
+  release found with no client that speaks its protocol is ranked and then
+  refused.
+
+
+  ⚠️ Unofficial. ROMarr is not affiliated with RomM, Gaseous or Retrom.
+developer: Move Weight Foundation
+website: https://foundation.moveweight.com
+dependencies: []
+repo: https://github.com/BlizzHacker/romarr
+support: https://github.com/BlizzHacker/romarr/issues
+port: 7878
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+path: ""
+releaseNotes: >-
+  Interactive search — every release scored with its reasoning shown, then a
+  Grab button — and a folder library backend for setups that are just a
+  directory tree laid out by platform.
+submitter: BlizzHacker
+submission: https://github.com/getumbrel/umbrel-apps/pull/PR_NUMBER

--- a/romarr/umbrel-app.yml
+++ b/romarr/umbrel-app.yml
@@ -54,4 +54,4 @@ releaseNotes: >-
   Grab button — and a folder library backend for setups that are just a
   directory tree laid out by platform.
 submitter: BlizzHacker
-submission: https://github.com/getumbrel/umbrel-apps/pull/PR_NUMBER
+submission: https://github.com/getumbrel/umbrel-apps/pull/5947


### PR DESCRIPTION
## Type

New app

## App

App ID: `romarr`
Upstream project: https://github.com/BlizzHacker/romarr
Version: 0.6.1

## Summary

Adds **ROMarr**, the \*arr for games. It takes a request, searches indexers
through Prowlarr, hands the winner to a download client, and files the ROM into
a game library — the same shape as Radarr and Sonarr, for the one media type
that did not have it.

It is not tied to a single library: RomM, Gaseous and Retrom are supported via
`LIBRARY_KIND`, and a `folder` mode writes a plain directory tree laid out by
platform, which is what Batocera, RetroPie, ES-DE, EmuDeck, Pegasus, Lakka and
LaunchBox already read.

Image is pinned by digest and is genuinely multi-arch:
`ghcr.io/blizzhacker/romarr:0.6.1@sha256:ce961117539fa985ee6d9c92a7ee8781ec3a154d2bb6c482d9eae27fed3e961c`
(~75 MB, `python:3.13-alpine` base).

## Verification

Umbrel testing performed:

I have verified the image, not the Umbrel integration. The manifest follows the
`app_proxy` + `${APP_DATA_DIR}` pattern from existing media apps, but I do not
have an umbrelOS environment to install it on, so I have marked that honestly
below rather than guess.

Verified directly:
- The pinned digest resolves on GHCR, and its manifest list advertises
  `linux/amd64`, `linux/arm64` and `linux/arm/v7`.
- The image declares a `HEALTHCHECK` against `/api/health` on `$ROMARR_PORT`,
  and `EXPOSE 7878`.

Not verified by me: I have not run this image as part of preparing the PR, on
any architecture. Upstream CI builds all three arches and gates the image job
behind its pytest suite, and the project runs in production on amd64, but I
would rather state the boundary than imply testing I did not do.

Environment tested:
- [ ] Umbrel device
- [ ] Local umbrelOS test environment
- [x] Not runtime tested

Architecture tested:
- [ ] amd64
- [ ] arm64

Known lint warnings or caveats:

None known. Happy to correct anything the CI flags.

## Notes

**No default credentials.** ROMarr ships with no account and no auth of its
own; it is reached through `app_proxy` like the other media apps here.

**Dependencies:** none declared, deliberately. ROMarr needs a Prowlarr instance
and at least one download client, but both are commonly already running and
users may point it at instances outside Umbrel, so forcing an install felt
wrong. Happy to add `dependencies: [prowlarr]` if you would rather it be
explicit — say the word and I will push it.

**One behaviour worth knowing when reviewing:** ROMarr reads its environment
variables once, on first start, and copies them into its own settings; the
stored settings win afterwards. That is deliberate upstream behaviour so the
Settings page can hold a decision, but it means editing env vars post-install
has no effect. Setup is meant to happen in ROMarr's own UI.

**Screenshots** for the gallery:

- https://raw.githubusercontent.com/BlizzHacker/romarr/main/docs/img/status.png
- https://raw.githubusercontent.com/BlizzHacker/romarr/main/docs/img/interactive-search.png
- https://raw.githubusercontent.com/BlizzHacker/romarr/main/docs/img/library.png

**Logo:** https://raw.githubusercontent.com/BlizzHacker/cartridge-unraid/main/icon/romarr.png
(original mark, MIT, SVG source available in the same directory)

MIT licensed. **Unofficial — not affiliated with RomM, Gaseous or Retrom.**
