### PR TITLE
Update Cloudflare Tunnel to 2026.7.3

### DIFF
--- a/cloudflared/docker-compose.yml
+++ b/cloudflared/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       CLOUDFLARED_TOKEN_FILE: "/app/data/token"
 
   connector:
-    image: ghcr.io/radiokot/umbrel-cloudflared-connector:1.0.1-cf.2026.6.1@sha256:a72d52f15f8c9ad7a766140dc574775d2276381e1f4df9495fda038c4d2d2091
+    image: ghcr.io/radiokot/umbrel-cloudflared-connector:1.0.1-cf.2026.7.3@sha256:843bf75f58000c352180697e349e939c9e2d1910f05f03b1b033459b7acff3f4
     restart: on-failure
     stop_grace_period: 3s
     volumes:

--- a/cloudflared/umbrel-app.yml
+++ b/cloudflared/umbrel-app.yml
@@ -3,7 +3,7 @@ id: cloudflared
 name: Cloudflare Tunnel
 tagline: Access your Umbrel apps from the Internet using Cloudflare network
 category: networking
-version: "2026.6.1"
+version: "2026.7.3"
 port: 4499
 description: >-
   Start a secure tunnel to access your Umbrel apps from the Internet using the Cloudflare network. 
@@ -34,7 +34,7 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  The tunneling daemon (cloudflared) has been updated to 2026.6.1
+  The tunneling daemon (cloudflared) has been updated to 2026.7.3
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
## Type

App update

## App

App ID: cloudflared
Upstream project: https://github.com/cloudflare/cloudflared
Version: 2026.7.3

## Summary

The tunneling daemon (cloudflared) has been updated to 2026.7.3

## Verification

Umbrel testing performed:

Environment tested:
- [ ] Umbrel device
- [x] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64