### PR TITLE
Update BFFless to v0.4.15

### DIFF
--- a/bffless/docker-compose.yml
+++ b/bffless/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   # Nginx reverse proxy - serves frontend, routes API calls
   # Uses custom umbrel image with baked-in config template and setup page
   nginx:
-    image: ghcr.io/bffless/ce-nginx:umbrel@sha256:e3bbe4fc349af155e60c4768042b1794c615843845c697f375816f72a786a35f
+    image: ghcr.io/bffless/ce-nginx:umbrel@sha256:e76ceda29c799638ac88eb40ebec0ed2763a0f8750a263d03a27b5c00522b0db
     restart: on-failure
     stop_grace_period: 30s
     environment:
@@ -86,7 +86,7 @@ services:
   # NestJS backend API
   # Uses custom umbrel image with baked-in entrypoint that derives keys from APP_SEED
   backend:
-    image: ghcr.io/bffless/ce-backend:umbrel@sha256:055a7bee1e63b403d51019b97e81d716078c98f58e2153d43b43b601ccbf440e
+    image: ghcr.io/bffless/ce-backend:umbrel@sha256:329c19087c022d4b0085d790ed3b5eca83a86d21ffa96f01ce9547d674f5a1d7
     restart: on-failure
     stop_grace_period: 30s
     depends_on:
@@ -143,7 +143,7 @@ services:
 
   # React frontend (serves static files)
   frontend:
-    image: ghcr.io/bffless/ce-frontend:umbrel@sha256:99b8b5f15827588eab86b03b0ef0ca04afd27ed408a12ca89ff9b6aeef2e1abc
+    image: ghcr.io/bffless/ce-frontend:umbrel@sha256:d961857db9765406311cd6e2934c3a146a10501f45faa8e8c83b9658c8376077
     restart: on-failure
     stop_grace_period: 30s
     volumes:

--- a/bffless/umbrel-app.yml
+++ b/bffless/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: bffless
 category: developer
 name: BFFless
-version: '0.2.10'
+version: '0.4.15'
 tagline: Self-hosted static site hosting platform
 description: >-
   BFFless is a self-hosted platform for hosting static websites and build artifacts from CI/CD pipelines.
@@ -33,44 +33,55 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  Updates BFFless CE from v0.1.90 to v0.2.10.
+  Updates BFFless CE from v0.2.10 to v0.4.15.
 
 
-  Proxy rules as code:
-    - New bffless CLI: manage proxy rule sets as TypeScript files in your repo — compile, decompile, publish, and live sync
-    - Rule set revisions with rollback (accepts the short revision ids shown in the CLI table)
-    - Write pipeline handlers in TypeScript with a local rules dev workflow
+  App catalog — 1-click app install:
+    - Browse and install self-hosted apps directly from the admin dashboard
+    - Installs deploy under the real upstream source commit
+    - Registry store metadata and per-app setup notes render on the app cards
+    - Reachability gates only install apps that can actually be served over HTTPS
 
 
-  Traffic monitoring & blocklists:
-    - Live traffic tail in the admin UI, with unmatched-request history and per-IP rollups
-    - IP blocklists: reusable blocklist library, per-domain attachment, and inline add-to-blocklist
-    - Enforcement at both the application and nginx edge
-
-
-  Pipelines:
-    - Pipeline schedules (cron) with a full admin UI
-    - New handlers: xml_feed_parse and data_upsert_many (with optional update-on-conflict)
-    - ai_handler attachments (multi-part image/file content)
-    - New "in" (array-membership) filter operator; data_delete supports the full filter operator set
-    - file_serve_handler cacheability supports expressions; verbatim keyStrategy for presigned uploads
+  Onboarding & setup:
+    - New welcome walkthrough (with video) and an app-install callout as the primary first-login path
+    - Onboarding and day-2 settings now link out to the docs site
+    - Claim-token links go straight to the setup wizard and prefill the claim form
+    - Replay the onboarding modal any time with ?onboarding=1
 
 
   Storage:
-    - Edit provider credentials in place without migrating
-    - Presigned download URLs can sign Content-Disposition for friendly filenames
+    - Presigned uploads now work on local filesystem storage
+    - Same-SHA republish serves fresh bytes instead of stale cached content
+    - Served content types resolve from storage, with the correct charset
 
 
-  Fixes:
-    - Users with the "user" global role can create projects again
-    - Copying a proxy rule set re-encrypts header secrets
-    - Auth-proxy rules work through the visibility gate on private deployments
-    - Large JSON pipeline responses are sent verbatim to avoid out-of-memory
-    - data_query consistently returns arrays unless single/recordId is set
-    - Custom content types allowed in the response_handler UI
+  Pipelines & groups:
+    - Pipelines can read user.groups, plus a member-accessible group directory
+    - New now_ms() helper; data-write values are coerced to schema field types
+    - Null-safe "ne" filter operator (IS DISTINCT FROM)
 
 
-  Full release notes can be found at https://github.com/bffless/ce/releases/tag/v0.2.10
+  CLI:
+    - New bffless login credential store and auth commands
+    - rules init --schema scaffold command
+
+
+  Frontend & polish:
+    - Per-route document titles and a real favicon
+    - Fixed mobile viewport overflow and crashes across admin pages
+    - Traffic-splitting tools (weights + routing rules) added to the MCP server
+
+
+  Fixes (including for proxied setups like Cloudflare Tunnel):
+    - Auth and presigned uploads are excepted from the subdomain-alias rewrite
+    - Presigned local uploads serve correctly on externally-proxied vhosts
+    - App-serving vhosts share a consistent request-body ceiling
+    - Blocklists never enforce a half-loaded or stale rule set
+    - Alias visibility / required-role overrides persist and read back correctly
+
+
+  Full release notes can be found at https://github.com/bffless/ce/releases/tag/v0.4.15
 path: ''
 defaultUsername: ''
 deterministicPassword: false


### PR DESCRIPTION
### App Submission / Update

- **App:** BFFless
- **Old version:** 0.2.10
- **New version:** 0.4.15
- **Upstream release:** https://github.com/bffless/ce/releases/tag/v0.4.15

### What changed

Bumps BFFless CE from v0.2.10 to v0.4.15. Updated the three custom Umbrel images (`ce-nginx`, `ce-backend`, `ce-frontend`, all `:umbrel` tag) to new digests, bumped the manifest `version`, and rewrote `releaseNotes` for users upgrading an existing install.

Highlights across this range:

- **1-click app catalog** — browse and install self-hosted apps from the admin dashboard, with reachability gates and per-app setup notes.
- **Browser onboarding/setup overhaul** — welcome walkthrough, claim-token links that go straight to the wizard, docs links.
- **Local-filesystem presigned uploads** and fresh-bytes serving on same-SHA republish.
- **Pipelines & groups** — `user.groups`, member-accessible group directory, `now_ms()`, schema-typed data writes.
- **CLI** — `bffless login` credential store, `rules init --schema` scaffold.
- **Proxy fixes relevant to the Cloudflare Tunnel setup Umbrel uses** — auth + presigned uploads excepted from the subdomain-alias rewrite; presigned local uploads serve correctly on externally-proxied vhosts.

### Packaging notes

- Only `bffless/` changed: `umbrel-app.yml` (version + releaseNotes) and `docker-compose.yml` (three image digests).
- No compose structure, env, port, proxy, hook, permission, or persistence changes — drop-in image bump, no migration required.
- Images are public multi-arch (`linux/amd64` + `linux/arm64`), pinned by digest.
- `npm run lint:apps -- bffless --check-images`: 0 errors. The one warning is on the **unchanged** `supertokens/supertokens-postgresql` image (upstream moved its tag) and is intentionally left pinned to its existing digest.

### Testing

Tested on an **Umbrel Home** device (x86 / `linux/amd64`) via the real update path:

- ✅ Updated an existing **v0.2.10** install to **v0.4.15** (upgrade path, not a fresh install)
- ✅ Existing data preserved across the update (deployments / settings / credentials intact)
- ✅ App opens and core functionality works after the update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
