### PR TITLE
Update lnSwitchboard to 0.3.1

### DIFF
--- a/lnswitchboard/docker-compose.yml
+++ b/lnswitchboard/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/.well-known/*"
 
   app:
-    image: ghcr.io/ryleastark/lnswitchboard:0.2.3@sha256:16a031d84746100c5c8ceefc06ac40570c759b546c978d07d951e85cfc771401
+    image: ghcr.io/ryleastark/lnswitchboard:0.3.1@sha256:4e17638594ca50f6f868aef2db50e09479e3d90247d5dd75e2b3ac07a827198d
     user: "1000:1000"
     restart: on-failure
     environment:
@@ -20,6 +20,8 @@ services:
       LND_TLS_PATH: "/lnd/tls.cert"
       LND_MACAROON_PATH: "/lnd/invoice.macaroon"
       LND_READONLY_MACAROON_PATH: "/lnd/readonly.macaroon"
+      TRUSTED_PROXY_CIDRS: "${NETWORK_IP}/16"
+      TRUSTED_HOSTS: "*"
       DEP_ENV: "UMBREL"
     volumes:
       - ${APP_LIGHTNING_NODE_DATA_DIR}/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/invoice.macaroon:/lnd/invoice.macaroon:ro

--- a/lnswitchboard/umbrel-app.yml
+++ b/lnswitchboard/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lnswitchboard
 category: bitcoin
 name: "lnSwitchboard"
-version: "0.2.3"
+version: "0.3.1"
 tagline: "Self-Hosted Lightning Addresses for Your Domain"
 description: >-
   Host your own Lightning Addresses directly from your node. lnSwitchboard exposes only the public LNURL-pay endpoint while keeping its dashboard and admin routes local on port 22121.
@@ -15,6 +15,8 @@ description: >-
 
 
   You will need your own domain and a reverse proxy to use this application. Click “Help” within the app to open the wiki and follow the getting-started guides.
+releaseNotes: >-
+  Hardens reverse-proxy, Host, CORS, webhook, and Nostr relay security; improves LND connectivity, Nostr acknowledgement handling, database reliability, and multi-architecture releases; and refreshes the application runtime. Existing data is preserved and no manual migration is required.
 developer: RyleaStark
 website: https://github.com/RyleaStark/lnSwitchboard
 gallery:


### PR DESCRIPTION
## Type

App update

## App

App ID: `lnswitchboard`  
Upstream project: https://github.com/RyleaStark/lnSwitchboard  
Release source: https://github.com/RyleaStark/lnSwitchboard/pull/12  
Version: `0.3.1`

## Summary

Updates lnSwitchboard from `0.2.3` to `0.3.1`.

- Pins the public multi-architecture image `ghcr.io/ryleastark/lnswitchboard:0.3.1` to verified index digest `sha256:4e17638594ca50f6f868aef2db50e09479e3d90247d5dd75e2b3ac07a827198d`.
- Adds concise user-facing release notes covering the security and reliability improvements.
- Trusts forwarding headers only from Umbrel's `${NETWORK_IP}/16` app network.
- Allows arbitrary Host values because lnSwitchboard serves user-owned Lightning Address domains; the app container remains behind Umbrel's authenticated `app_proxy`, and only `/.well-known/*` remains publicly whitelisted.

## Verification

Umbrel testing performed:

- `npm run lint:apps -- lnswitchboard --check-images` — no issues found.
- Verified the exact image digest, OCI source revision, and `linux/amd64` plus `linux/arm64` manifests across GHCR and Docker Hub.
- `git diff --check` passed.
- An Umbrel update-path runtime test was not performed.

Environment tested:
- [ ] Umbrel device
- [ ] Local umbrelOS test environment
- [x] Not runtime tested

Architecture tested:
- [ ] amd64
- [ ] arm64

Image availability was statically verified for both architectures; neither architecture was runtime-tested through Umbrel.

Known lint warnings or caveats: None.

## Notes

- The `lightning` dependency, application port, app-proxy whitelist, runtime user, and persisted `${APP_DATA_DIR}/data` path are unchanged.
- Existing databases and generated Nostr signer material remain on the same bind mount.
- No manual migration or configuration action is required for existing installs.
