### PR TITLE
Update lnSwitchboard to 0.3.2

### DIFF
--- a/lnswitchboard/docker-compose.yml
+++ b/lnswitchboard/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/.well-known/*"
 
   app:
-    image: ghcr.io/ryleastark/lnswitchboard:0.2.3@sha256:16a031d84746100c5c8ceefc06ac40570c759b546c978d07d951e85cfc771401
+    image: ghcr.io/ryleastark/lnswitchboard:0.3.2@sha256:7a91c256a69b218adcaa30b4f52315577e6966cde7ffe702bb95c4e26a07fc83
     user: "1000:1000"
     restart: on-failure
     environment:
@@ -20,6 +20,8 @@ services:
       LND_TLS_PATH: "/lnd/tls.cert"
       LND_MACAROON_PATH: "/lnd/invoice.macaroon"
       LND_READONLY_MACAROON_PATH: "/lnd/readonly.macaroon"
+      TRUSTED_PROXY_CIDRS: "${NETWORK_IP}/16"
+      TRUSTED_HOSTS: "*"
       DEP_ENV: "UMBREL"
     volumes:
       - ${APP_LIGHTNING_NODE_DATA_DIR}/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/invoice.macaroon:/lnd/invoice.macaroon:ro

--- a/lnswitchboard/umbrel-app.yml
+++ b/lnswitchboard/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lnswitchboard
 category: bitcoin
 name: "lnSwitchboard"
-version: "0.2.3"
+version: "0.3.2"
 tagline: "Self-Hosted Lightning Addresses for Your Domain"
 description: >-
   Host your own Lightning Addresses directly from your node. lnSwitchboard exposes only the public LNURL-pay endpoint while keeping its dashboard and admin routes local on port 22121.
@@ -15,6 +15,20 @@ description: >-
 
 
   You will need your own domain and a reverse proxy to use this application. Click “Help” within the app to open the wiki and follow the getting-started guides.
+releaseNotes: >-
+  **0.3.2**
+
+
+  Replaces the dashboard invoice activity visualization with Dither Kit and adds selectable 14-day Sats routed, Invoices paid, and Invoices created metrics. The chart now supports keyboard and screen-reader access while preserving timezone-aware daily buckets.
+
+
+  **0.3.1**
+
+
+  Hardens reverse-proxy, Host, CORS, webhook, and Nostr relay security; improves LND connectivity, Nostr acknowledgement handling, database reliability, and multi-architecture releases; and refreshes the application runtime.
+
+
+  Existing data is preserved and no manual migration is required.
 developer: RyleaStark
 website: https://github.com/RyleaStark/lnSwitchboard
 gallery:


### PR DESCRIPTION
## Type

App update

## App

App ID: `lnswitchboard`  
Upstream project: https://github.com/RyleaStark/lnSwitchboard  
Release source: https://github.com/RyleaStark/lnSwitchboard/pull/13  
Release workflow: https://github.com/RyleaStark/lnSwitchboard/actions/runs/30876776963  
Version: `0.2.3` → `0.3.2`

## Summary

Updates lnSwitchboard from `0.2.3` to `0.3.2`, carrying both skipped `0.3.1` changes and the new `0.3.2` dashboard release.

- Adds clearly separated `0.3.1` and `0.3.2` sections to `umbrel-app.yml` release notes so users upgrading from the current official `0.2.3` package see both releases.
- Pins `ghcr.io/ryleastark/lnswitchboard:0.3.2` to verified multi-architecture index digest `sha256:7a91c256a69b218adcaa30b4f52315577e6966cde7ffe702bb95c4e26a07fc83`.
- `0.3.2` replaces the invoice activity visualization with Dither Kit and adds selectable 14-day Sats routed, Invoices paid, and Invoices created metrics, including keyboard and screen-reader access.
- Carries forward the `0.3.1` security and reliability update, including trusted-proxy configuration for Umbrel's app network.
- Allows arbitrary Host values because lnSwitchboard serves user-owned Lightning Address domains; the app container remains behind Umbrel's authenticated `app_proxy`, and only `/.well-known/*` remains publicly whitelisted.

## Verification

Umbrel testing performed:

- The maintainer completed an on-device review of `0.3.2` before authorizing this official submission.
- `npm ci` — completed with zero reported vulnerabilities.
- `npm run lint:apps -- lnswitchboard --check-images` — no issues found.
- Independently verified that GHCR and Docker Hub resolve `0.3.2` to the same index digest and expected source revision `44aed258dc8ad2b1fb1d77ed1190305ed170d950`.
- Verified `linux/amd64` and `linux/arm64` runtime manifests; additional `unknown/unknown` entries are BuildKit attestations.
- Parsed the final YAML and asserted separate `0.3.1`/`0.3.2` release-note headings, exact image pin, proxy/Host settings, public whitelist, runtime user, and persistence mount.
- `git diff --check` passed.

Environment tested:
- [x] Umbrel device
- [x] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [x] arm64

The device architecture was not recorded by this PR automation. Multi-architecture availability was independently verified but is not presented as runtime coverage for both architectures.

Known lint warnings or caveats: None.

## Notes

- The `lightning` dependency, application port, app-proxy whitelist, runtime user, and persisted `${APP_DATA_DIR}/data` path are unchanged.
- Existing databases and generated Nostr signer material remain on the same bind mount.
- The database index needed by the new created-invoice activity query is created automatically.
- No manual migration or configuration action is required for existing installs.
