### PR TITLE
yuvomi: update to v1.87.0

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:1.77.0@sha256:726ae06111ac05503162e0c4ffb48402c8039062ee99e0ba5dec6112ac87b15e
+    image: ghcr.io/ulsklyc/yuvomi:1.87.0@sha256:f83e7b8b01ecea8c8ca42d8924a67491b7c8fae4113accf8f830982764fff5a7
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -50,7 +50,40 @@ description: >-
 
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
-releaseNotes: "Shopping items can now be reordered by hand within their category, by dragging the handle in the row or with the arrow keys once it has focus. The list groups by aisle and that order was already yours to arrange in the category manager, but inside an aisle the items stayed in the order they were typed, which is not the order a shop is walked in. New items keep landing at the end of their category, including the ones that arrive from the meal plan, a recipe, the pantry or a synced reminder list - the position is assigned by the database itself, so no path can forget it. Moving an item to another category, and the items that move along when a category is deleted, join the end of their new group rather than wedging themselves between what is already sorted there. Checked-off items stay at the bottom of their aisle and are exempt: they are done, and a drag on them would have sprung back on the next load. Existing lists keep the order they show today (#678)"
+releaseNotes: >-
+  Shopping lists can now follow the route you take through the store. Drag
+  unchecked items into any order within their category, or move them with the
+  keyboard arrow keys.
+
+
+  Credit-card accounts can now store the issuing bank and credit limit and show
+  the remaining available credit. Recurring budget entries also support custom
+  weekly, monthly, and yearly schedules, plus an option to confirm each entry
+  before it affects your totals.
+
+
+  Health tracking now includes sleep, mood, height, and head circumference.
+  Family admins can also allow another household member to record health data
+  for a child or other person.
+
+
+  Archived tasks now keep their completed status and reward points. Recurring
+  tasks can calculate their next due date from the day they are completed, and
+  floating add buttons now behave more reliably on iOS.
+
+
+  New events can default to a connected calendar. CalDAV reminder subtasks now
+  sync correctly, can be completed from the task details, and task filters can
+  include multiple priorities, statuses, or people. The reminder-sync page also
+  explains why current Apple Reminders lists are unavailable over iCloud CalDAV.
+
+
+  The dashboard now includes an optional clock widget and update notifications.
+  This update also adds Filipino, 25 currencies, and 34 regional presets.
+
+
+  Full release notes are available at
+  https://github.com/ulsklyc/yuvomi/compare/v1.77.0...v1.87.0
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "1.77.0"
+version: "1.87.0"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -50,26 +50,7 @@ description: >-
 
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
-releaseNotes: >-
-  Loans can now track whether your household borrowed or lent money, optionally
-  assign installments to an account, and book borrowed-money repayments as
-  expenses so mortgage-style payments no longer inflate the monthly balance.
-
-  CalDAV reminder sync now handles task-only collections correctly: reminder
-  lists are discovered on their own, task collections are no longer offered as
-  event calendars, and existing accounts clean up those task lists on the next
-  sync.
-
-  New Zealand dollar support is available in household, subscription, and
-  split-expense settings, and housekeeping task/report actions now show their
-  icons immediately after list updates.
-
-  The installer now keeps the full start log visible before offering retry when
-  setup fails.
-
-  Full release notes are available at
-  https://github.com/ulsklyc/yuvomi/compare/v1.75.6...v1.77.0
-
+releaseNotes: "Shopping items can now be reordered by hand within their category, by dragging the handle in the row or with the arrow keys once it has focus. The list groups by aisle and that order was already yours to arrange in the category manager, but inside an aisle the items stayed in the order they were typed, which is not the order a shop is walked in. New items keep landing at the end of their category, including the ones that arrive from the meal plan, a recipe, the pantry or a synced reminder list - the position is assigned by the database itself, so no path can forget it. Moving an item to another category, and the items that move along when a category is deleted, join the end of their new group rather than wedging themselves between what is already sorted there. Checked-off items stay at the bottom of their aisle and are exempt: they are done, and a drag on them would have sprung back on the next load. Existing lists keep the order they show today (#678)"
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db


### PR DESCRIPTION
Updates Yuvomi from 1.77.0 to 1.79.0, covering three upstream releases (1.78.0, 1.78.1, 1.79.0).

Two files change:

- `yuvomi/umbrel-app.yml` — `version` and `releaseNotes`
- `yuvomi/docker-compose.yml` — image tag and digest

The image is pinned to the multi-arch index digest of the published release:

```
ghcr.io/ulsklyc/yuvomi:1.79.0@sha256:bf447f4dab7cbaa72d227125357b66cf56827b76d769f2800a9525d375560624
```

Nothing else in the manifest is touched, so the port, gallery and category set during review are preserved.

**What's new for users**

- A default calendar for new events, chosen per household member, so a family calendar no longer has to be picked by hand on every event.
- Filipino as the 24th interface language; 25 more currencies (the Americas plus the Philippine peso, 54 in total) and 64 region presets, each with its own date and time format.
- CalDAV reminder lists now keep their subtask relationships instead of importing subtasks as unrelated top-level tasks, and the task filter accepts several priorities, states or people at once.

Full notes: https://github.com/ulsklyc/yuvomi/compare/v1.77.0...v1.79.0