### PR TITLE
Add Sportarr

### DIFF
--- a/sportarr/docker-compose.yml
+++ b/sportarr/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: sportarr_server_1
+      APP_PORT: 1867
+      PROXY_AUTH_WHITELIST: "/api/*"
+
+  server:
+    image: sportarr/sportarr:4.1.0.1110@sha256:5ab15cfdbac71aad8e5a4a6a97e0513f21e4e8315f247fcdff34d85654d3f6ef
+    environment:
+      - PUID=1000
+      - PGID=1000
+    volumes:
+      - ${APP_DATA_DIR}/data/config:/config
+      - ${UMBREL_ROOT}/data/storage/downloads:/downloads
+    restart: on-failure

--- a/sportarr/umbrel-app.yml
+++ b/sportarr/umbrel-app.yml
@@ -1,0 +1,44 @@
+manifestVersion: 1.1
+id: sportarr
+category: media
+name: Sportarr
+version: "4.1.0.1110"
+releaseNotes: ""
+tagline: Sports event manager for Usenet and BitTorrent
+description: >-
+  Sportarr is an event manager for sports fans. It monitors the leagues and
+  events you follow, grabs broadcasts through your Usenet and BitTorrent
+  download clients, then sorts and renames them into a clean season/episode
+  layout that Plex, Emby, Jellyfin and Kodi understand. Quality profiles,
+  a calendar of upcoming events, automatic upgrades and DVR-style IPTV
+  recording are built in.
+
+
+  🛠️ SETUP INSTRUCTIONS
+
+  Install your preferred download client from the Umbrel App Store
+  (Transmission, qBittorrent, or SABnzbd) and connect it under Settings >
+  Download Clients inside Sportarr.
+
+
+  Then add an indexer so Sportarr can search for events. You can add
+  indexers directly within Sportarr, or install Prowlarr from the Umbrel
+  App Store for easier management of indexers across multiple apps.
+developer: Sportarr
+website: https://sportarr.net
+dependencies: []
+repo: https://github.com/Sportarr/Sportarr
+support: https://github.com/Sportarr/Sportarr/issues
+port: 1867
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+torOnly: false
+permissions:
+  - STORAGE_DOWNLOADS
+submitter: Sportarr
+submission: https://github.com/getumbrel/umbrel-apps/pull/5957


### PR DESCRIPTION
## Type

New app

## App

App ID: sportarr
Upstream project: https://github.com/Sportarr/Sportarr
Version: 4.1.7.1117

## Summary

App submission for Sportarr, a sports event manager in the arr family. It monitors leagues and events, grabs broadcasts through Usenet and BitTorrent download clients, and renames them into a season and episode layout for Plex, Emby, Jellyfin and Kodi.

- Official multi-architecture image for amd64 and arm64, pinned by digest
- Entry modeled on the Bazarr app
- Downloads storage mounted at `/downloads`
- Configuration persisted in app data
- `/api/*` allowed through the app proxy so companion tools can authenticate with Sportarr's API key

## Verification

- The repository image-aware linter passed with no issues.
- The `4.1.7.1117` tag resolves to `sha256:2264bc46951b5056d7900864ab7339e01c5a4c280286d72b6ef9e5473aca0390`.
- The registry manifest contains linux/amd64 and linux/arm64 images.
- The original 4.1.0 submission was boot-tested on amd64.
- A fresh 4.1.7 startup test could not be repeated because Docker Hub returned its anonymous pull limit before creating a container.

Environment tested:

- [ ] Umbrel device
- [ ] Local umbrelOS test environment
- [x] Not runtime tested on 4.1.7

Known lint warnings or caveats: none.

## Notes

No dependencies, package migrations, port changes, mount changes, or default credentials were added.