### PR TITLE
Release Bisq 2 Node 2.1.11.2

### DIFF
--- a/bisq2-node/docker-compose.yml
+++ b/bisq2-node/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       APP_PORT: 8091
 
   server:
-    image: ghcr.io/bisq-network/bisq2-api@sha256:3dd9152da26fa6d409707e16b4e0a5725ed95e59383de02a1f5778ec75d69306
+    image: ghcr.io/bisq-network/bisq2-api:2.1.11.2@sha256:3dd9152da26fa6d409707e16b4e0a5725ed95e59383de02a1f5778ec75d69306
     restart: on-failure
     stop_grace_period: 1m
     mem_limit: 2g
@@ -24,7 +24,7 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   web:
-    image: ghcr.io/bisq-network/bisq2-api-web-ui@sha256:86b93c3b99661bed88011842b2e02504147546687af62b86fdd0a4a5e937add4
+    image: ghcr.io/bisq-network/bisq2-api-web-ui:2.1.11.2@sha256:86b93c3b99661bed88011842b2e02504147546687af62b86fdd0a4a5e937add4
     restart: on-failure
     network_mode: "service:server"
     volumes:

--- a/bisq2-node/docker-compose.yml
+++ b/bisq2-node/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       APP_PORT: 8091
 
   server:
-    image: ghcr.io/bisq-network/bisq2-api:2.1.11.1@sha256:af77443abc90114b0282d44a1fa5b5f3beeb608b6df76d8674f4366236856154
+    image: ghcr.io/bisq-network/bisq2-api@sha256:3dd9152da26fa6d409707e16b4e0a5725ed95e59383de02a1f5778ec75d69306
     restart: on-failure
     stop_grace_period: 1m
     mem_limit: 2g
@@ -24,7 +24,7 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   web:
-    image: ghcr.io/bisq-network/bisq2-api-web-ui:2.1.11.1@sha256:0295d45b6dafb3d9bf0d2e6ba74caeb42222e00eb30d9fa847a136a0f358aa23
+    image: ghcr.io/bisq-network/bisq2-api-web-ui@sha256:86b93c3b99661bed88011842b2e02504147546687af62b86fdd0a4a5e937add4
     restart: on-failure
     network_mode: "service:server"
     volumes:

--- a/bisq2-node/umbrel-app.yml
+++ b/bisq2-node/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bisq2-node
 category: bitcoin
 name: Bisq 2 Node
-version: "2.1.11.1"
+version: "2.1.11.2"
 tagline: Run your own Bisq 2 node for private Bitcoin trading
 description: >-
   Bisq Connect lets you buy and sell Bitcoin peer-to-peer from your phone. This
@@ -34,4 +34,4 @@ defaultUsername: ""
 defaultPassword: ""
 submitter: rodvar
 submission: https://github.com/getumbrel/umbrel-apps/pull/5850
-releaseNotes: ""
+releaseNotes: "Bisq 2 Node 2.1.11.2 — tracks Bisq 2 API 2.1.11 (bisq2 @ 9322011). Changelog: https://github.com/bisq-network/bisq2/releases"

--- a/bisq2-node/umbrel-app.yml
+++ b/bisq2-node/umbrel-app.yml
@@ -34,4 +34,4 @@ defaultUsername: ""
 defaultPassword: ""
 submitter: rodvar
 submission: https://github.com/getumbrel/umbrel-apps/pull/5850
-releaseNotes: "Bisq 2 Node 2.1.11.2 — tracks Bisq 2 API 2.1.11 (bisq2 @ 9322011). Changelog: https://github.com/bisq-network/bisq2/releases"
+releaseNotes: "Bisq 2 Node 2.1.11.2 — Bisq 2 API 2.1.11 (bisq2 @ 9322011). Changes since 2.1.11.1: https://github.com/bisq-network/bisq2/compare/285cf42b5259c34f50a586620a75c6a8b1a158ab...932201100b181e1ecf6fd5f0fb3f0943c8ddd453"


### PR DESCRIPTION
Automated by the Release Umbrel images workflow (channel: official), opened from fork `rodvar/umbrel-apps` (we have pull-only access to `getumbrel/umbrel-apps`). Digest-pins the freshly-built images and bumps the manifest version to `2.1.11.2`. Merge to publish.