### PR TITLE
Update Bitcoin Knots to v29.4.knots20260508

### DIFF
--- a/bitcoin-knots/docker-compose.yml
+++ b/bitcoin-knots/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
   
   app:
-    image: ghcr.io/retropex/umbrel-bitcoin-knots:1.2.12@sha256:498a54d5e65acce0ccc5c1881534033bb0f10939e8a371ef17dcf4409a56e891
+    image: ghcr.io/retropex/umbrel-bitcoin-knots:1.2.13@sha256:65978ca7980fd2cb171fd142602b841dadd169b3862c27991cddff3bc3a7fcf2
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 15m30s

--- a/bitcoin-knots/umbrel-app.yml
+++ b/bitcoin-knots/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - bitcoin
 category: bitcoin
 name: Bitcoin Knots
-version: "1.2.12-patch.1"
+version: "1.2.13"
 tagline: Run your personal node powered by Bitcoin Knots
 description: >-
   Take control of your digital sovereignty by choosing Bitcoin Knots to run your node! By using Knots, you’re supporting a version of Bitcoin that prioritizes efficiency, security, and flexibility. With Bitcoin Knots’ enhanced configuration options, you can fine-tune your node to help keep the network clean and resilient, actively reducing unnecessary load from spam or parasitic transactions.
@@ -36,7 +36,7 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
+  Update to Bitcoin Knots v29.4.knots20260508
 
 
   🚨 This version adds BIP 110 code directly into the Bitcoin Knots codebase 🚨


### PR DESCRIPTION
## Type

App update

## App

App ID: `bitcoin-knots`
Upstream project: Bitcoin Knots
Version: `v29.4.knots20260508`

## Summary

Update to the latest upstream version

## Verification

Umbrel testing performed:

Environment tested:
- [x] Umbrel device
- [x] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64
