### PR TITLE
update: New Electrs GUI

### DIFF
--- a/electrs/umbrel-app.yml
+++ b/electrs/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: electrs
 category: bitcoin
 name: Electrs
-version: "0.11.1-patch.1"
+version: "0.11.1-patch.2"
 tagline: A simple and efficient Electrum Server
 description: >
   Run your personal Electrum server and connect your Electrum-compatible wallet,
@@ -29,14 +29,8 @@ gallery:
   - 4.jpg
 path: ""
 defaultPassword: ""
-releaseNotes: >
-  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
-
-
-  This update bumps the underlying electrs version to 0.11.1. It improves Electrum API compliance for transaction lookups, adds more flexible network magic configuration, and updates core dependencies.
-
-
-  Full electrs release notes are available at https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#0111-feb-22-2026
+releaseNotes: >-
+  Modernizes the Electrs dashboard with clearer provider-owned indexing progress, synchronized status, and wallet connection details.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/242
 backupIgnore:


### PR DESCRIPTION
## Type

Existing app update

## App

App ID: `electrs`
Current package: `0.11.1-patch.1`
Proposed package: `0.11.1-patch.2`

## Summary

Prepares the official Electrs package metadata for the modernized Bitcoin GUI: clearer Electrs-owned initial-index progress, synchronized state, and wallet connection details.

## Upstream GUI dependency and image publication blocker

Matching upstream GUI pull request: https://github.com/getumbrel/umbrel-electrs/pull/14

The source PR is open and mergeable. Its fork-originated workflow is awaiting upstream maintainer approval before it can run.

**This draft must not merge yet.** The upstream GUI PR must be opened and merged, and its multi-architecture image build/publication must complete. After publication, this package PR must replace the currently retained `getumbrel/umbrel-electrs:v1.0.4` image reference with the new immutable tag and OCI index digest before merge.

The current image reference is intentionally unchanged so this draft cannot claim to deliver unpublished runtime code.

## Proposed New Icon
Matches the orange for bitcoin's apps.
<img width="256" height="256" alt="electrs" src="https://github.com/user-attachments/assets/e8e79d57-28f4-437a-b8e7-8f71609ef0f8" />


## Preview of GUI Changes
<img width="1440" height="1000" alt="marketplace-complete" src="https://github.com/user-attachments/assets/720d6f83-654f-466f-91d5-a825100568b6" />
<img width="1440" height="1000" alt="marketplace-local-connect" src="https://github.com/user-attachments/assets/8c8a428e-e331-4169-a3c7-57f216bf2d14" />
<img width="1440" height="1000" alt="marketplace-syncing" src="https://github.com/user-attachments/assets/cb9d5da3-2584-44fd-8592-d114d1dad909" />

https://github.com/user-attachments/assets/54e36e7c-ce4b-42ff-9875-2b3f6b63e13c

## Follow-up source hardening (2026-08-21)

The linked Electrs source PR now also pins Fastify 5.12.1 to patch CVE-2026-18504 and CVE-2026-16732, and fixes the mobile Connect-dialog border crossing its scrolling content. The package remains draft and still retains the currently published image until maintainers merge and publish the upstream source candidate.


## Core-IBD status follow-up (2026-09-07)

- Electrs now consults its listener and trustworthy provider metrics during Bitcoin Core IBD, while retaining startup/waiting sentinels when provider progress is unavailable or stale.
- The signed follow-up commit `63d9e027fba0031c190255d561f7d9d72f80b273` is pushed to the existing upstream source PR: https://github.com/getumbrel/umbrel-electrs/pull/14
- This official package PR intentionally retains its currently published GUI image. The corrected candidate cannot be pinned here until upstream maintainers merge the source PR and publish a public multi-architecture image with a verified immutable index digest.
- Consequently this PR remains draft and must not be merged yet; no manifest or Compose claim has been added for unavailable runtime code.
