### PR TITLE
update: New Fulcrum GUI

### DIFF
--- a/fulcrum/umbrel-app.yml
+++ b/fulcrum/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - electrs
 category: bitcoin
 name: Fulcrum
-version: "2.1.2"
+version: "2.1.2-patch.1"
 tagline: A fast and nimble Electrum Server
 description: >-
   Run your personal Electrum server and connect your Electrum-compatible wallet,
@@ -30,15 +30,13 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  Fulcrum 2.1.2 is a minor maintenance update with internal fixes and dependency refreshes.
+  Updates the Fulcrum dashboard with provider-owned indexing progress, synchronized status,
+  and clearer wallet connection details. The refreshed GUI uses Fastify 5.12.1 to resolve
+  CVE-2026-18504 and CVE-2026-16732 and fixes a decorative border crossing the Connect dialog
+  while scrolling on mobile.
 
 
-  Key improvements:
-    - Refreshed the internal hash map library used by Fulcrum
-    - Improved mempool, block processing, and address handling internals
-    - Includes assorted typo fixes, cleanup, and small code correctness improvements
-
-
-  Full release notes are available at https://github.com/cculianu/Fulcrum/releases/tag/v2.1.2
+  Fulcrum 2.1.2 includes internal fixes and dependency refreshes. Full daemon release notes are
+  available at https://github.com/cculianu/Fulcrum/releases/tag/v2.1.2
 backupIgnore:
   - data/fulcrum/fulc2_db


### PR DESCRIPTION
## Type

Existing app update

## App

App ID: `fulcrum`
Current package: `2.1.2`
Proposed package: `2.1.2-patch.1`

## Summary

Prepares the official Fulcrum package metadata for the modernized Bitcoin GUI: clear separation of Bitcoin Core prerequisites from Fulcrum-owned initial-index progress, synchronized state, and wallet connection details.

## Upstream GUI dependency and image publication blocker

Matching upstream GUI pull request: https://github.com/nmfretz/umbrel-fulcrum/pull/1

The source PR is open and mergeable. Its fork-originated workflow is awaiting upstream maintainer approval before it can run.

**This draft must not merge yet.** The upstream GUI PR must be opened and merged, and its multi-architecture image build/publication must complete. After publication, this package PR must replace the currently retained `nmfretz/umbrel-fulcrum:1.0.1` image reference with the new immutable tag and OCI index digest before merge.

The current image reference is intentionally unchanged so this draft cannot claim to deliver unpublished runtime code.

## Proposed New Icon
Matches the orange for bitcoin's apps.
<img width="256" height="256" alt="fulcrum" src="https://github.com/user-attachments/assets/28b13eaa-b1bc-4a87-a658-2e9dc5506b97" />


## Preview of GUI Changes
<img width="1440" height="1000" alt="marketplace-complete" src="https://github.com/user-attachments/assets/0aca7b08-373f-4870-be9f-ac994b1675ac" />
<img width="1440" height="1000" alt="marketplace-local-connect" src="https://github.com/user-attachments/assets/3baef435-6e69-4e21-9ebf-5de4585532c3" />
<img width="1440" height="1000" alt="marketplace-syncing" src="https://github.com/user-attachments/assets/8a3946d0-557f-4f1e-8c08-7b1b82449114" />

https://github.com/user-attachments/assets/f5481d34-2a58-4ebe-8ab6-272066d779b9

## Follow-up source hardening (2026-08-21)

The linked Fulcrum source PR now also pins Fastify 5.12.1 to patch CVE-2026-18504 and CVE-2026-16732, and fixes the mobile Connect-dialog border crossing its scrolling content. The package remains draft and still retains the currently published image until maintainers merge and publish the upstream source candidate.

## Base refresh (2026-08-21)

Rebased onto current `getumbrel/umbrel-apps` `master` after Fulcrum 2.1.2 landed. The PR is now a one-file, conflict-free metadata patch over 2.1.2; its current GUI image remains intentionally unchanged pending merge and publication of the linked source PR.


## Core-IBD status follow-up (2026-09-07)

- Fulcrum now treats synchronized txindex—not IBD alone—as the Core prerequisite, then reports provider-authoritative progress/readiness.
- The signed follow-up commit `7370aaa43e80b0546cd9238495fbf34a269dd771` is pushed to the existing upstream source PR: https://github.com/nmfretz/umbrel-fulcrum/pull/1
- This official package PR intentionally retains its currently published GUI image. The corrected candidate cannot be pinned here until upstream maintainers merge the source PR and publish a public multi-architecture image with a verified immutable index digest.
- Consequently this PR remains draft and must not be merged yet; no manifest or Compose claim has been added for unavailable runtime code.
