### PR TITLE
update: New ElectrumX GUI

### DIFF
--- a/electrumx/umbrel-app.yml
+++ b/electrumx/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - electrs
 category: bitcoin
 name: ElectrumX
-version: "1.16.0-patch.3"
+version: "1.16.0-patch.4"
 tagline: A lightweight Electrum server
 description: >
   Run your personal Electrum server and connect your Electrum-compatible wallet,
@@ -30,11 +30,8 @@ gallery:
   - 3.jpg
 path: ""
 defaultPassword: ""
-releaseNotes: >
-  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
-
-
-  This update adds support for Backups in umbrelOS 1.5.
+releaseNotes: >-
+  Modernizes the ElectrumX dashboard with authoritative database and daemon indexing progress, synchronized status, and wallet connection details.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/1813
 backupIgnore:

--- a/electrumx/umbrel-app.yml
+++ b/electrumx/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - electrs
 category: bitcoin
 name: ElectrumX
-version: "1.16.0-patch.4"
+version: "1.16.0-patch.5"
 tagline: A lightweight Electrum server
 description: >
   Run your personal Electrum server and connect your Electrum-compatible wallet,
@@ -30,8 +30,8 @@ gallery:
   - 3.jpg
 path: ""
 defaultPassword: ""
-releaseNotes: >
-  This update excludes the ElectrumX UTXO database from umbrelOS backups. The database is rebuilt from your Bitcoin node when ElectrumX resyncs and doesn't need to be backed up. Because it is rewritten frequently, including it caused backups to grow rapidly and fill up backup drives.
+releaseNotes: >-
+  Modernizes the ElectrumX dashboard with authoritative database and daemon indexing progress, synchronized status, and wallet connection details. It also excludes the rebuildable ElectrumX UTXO database from umbrelOS backups to prevent rapid backup growth.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/1813
 backupIgnore:


### PR DESCRIPTION
## Type

Existing app update

## App

App ID: `electrumx`
Current package: `1.16.0-patch.3`
Proposed package: `1.16.0-patch.4`

## Summary

Prepares the official ElectrumX package metadata for the modernized Bitcoin GUI: authoritative database/daemon progress, synchronized state, and wallet connection details.

## Upstream GUI dependency and image publication blocker

Matching upstream GUI pull request: https://github.com/getumbrel/umbrel-electrumx/pull/4

The source PR is open and mergeable. Its fork-originated workflow is awaiting upstream maintainer approval before it can run.

**This draft must not merge yet.** The upstream GUI PR must be opened and merged, and its multi-architecture image build/publication must complete. After publication, this package PR must replace the currently retained `ghcr.io/getumbrel/umbrel-electrumx:1.0.0` image reference with the new immutable tag and OCI index digest before merge.

The current image reference is intentionally unchanged so this draft cannot claim to deliver unpublished runtime code.

## Proposed New Icon
Matches the orange for bitcoin's apps.
<img width="256" height="256" alt="electrumx" src="https://github.com/user-attachments/assets/4d56d746-a405-4417-904e-e7551731b918" />


## Preview of GUI Changes
<img width="1440" height="1000" alt="marketplace-complete" src="https://github.com/user-attachments/assets/6471c0ec-7682-4df2-953e-2437ba5f1ce2" />
<img width="1440" height="1000" alt="marketplace-local-connect" src="https://github.com/user-attachments/assets/bc1e9b51-575f-4a42-9050-8bad04fe3a82" />
<img width="1440" height="1000" alt="marketplace-syncing" src="https://github.com/user-attachments/assets/f211a2d7-af96-4e82-b07d-8e11d1718025" />

https://github.com/user-attachments/assets/e5c27b73-4c6c-41b6-b68d-83bbca7cafc9

## Follow-up source hardening (2026-08-21)

The linked ElectrumX source PR now also pins Fastify 5.12.1 to patch CVE-2026-18504 and CVE-2026-16732, and fixes the mobile Connect-dialog border crossing its scrolling content. The package remains draft and still retains the currently published image until maintainers merge and publish the upstream source candidate.


## Core-IBD status follow-up (2026-09-07)

- ElectrumX now treats synchronized txindex and txospenderindex—not IBD alone—as its Core prerequisites, then reports provider-authoritative progress/readiness.
- The signed follow-up commit `033f31b0a431e61f48e3ee96647db7e467ee8c6d` is pushed to the existing upstream source PR: https://github.com/getumbrel/umbrel-electrumx/pull/4
- This official package PR intentionally retains its currently published GUI image. The corrected candidate cannot be pinned here until upstream maintainers merge the source PR and publish a public multi-architecture image with a verified immutable index digest.
- Consequently this PR remains draft and must not be merged yet; no manifest or Compose claim has been added for unavailable runtime code.
