### PR TITLE
App Submission: ElectrumX (LTC)

### DIFF
--- a/litecoin-electrumx/docker-compose.yml
+++ b/litecoin-electrumx/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       APP_PORT: 3008
 
   app:
-    image: ghcr.io/ryleastark/umbrel-litecoin-electrumx-gui:v1.0.8@sha256:15124b0d35881037eed538b6cedf8122ace8de22e0bd5b525ab83947ede6e389
+    image: ghcr.io/ryleastark/umbrel-litecoin-electrumx-gui:v1.0.10@sha256:8c33c731a7e29cf075195a3e4cc9aea2da0b1ef67477acf5e28a5a5d4168b6ba
     depends_on:
       - electrumx
     restart: on-failure

--- a/litecoin-electrumx/docker-compose.yml
+++ b/litecoin-electrumx/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       APP_PORT: 3008
 
   app:
-    image: ghcr.io/ryleastark/umbrel-litecoin-electrumx-gui:v1.0.10@sha256:8c33c731a7e29cf075195a3e4cc9aea2da0b1ef67477acf5e28a5a5d4168b6ba
+    image: ghcr.io/ryleastark/umbrel-litecoin-electrumx-gui:v1.0.11@sha256:27fd13e4e89276d951bf7cbcefa17dab9a891dbdfa419445fc714d52f8bc8a74
     depends_on:
       - electrumx
     restart: on-failure

--- a/litecoin-electrumx/docker-compose.yml
+++ b/litecoin-electrumx/docker-compose.yml
@@ -1,0 +1,62 @@
+services:
+  app_proxy:
+    environment:
+      APP_HOST: $APP_LITECOIN_ELECTRUMX_IP
+      APP_PORT: 3008
+
+  app:
+    image: ghcr.io/ryleastark/umbrel-litecoin-electrumx-gui:v1.0.8@sha256:15124b0d35881037eed538b6cedf8122ace8de22e0bd5b525ab83947ede6e389
+    depends_on:
+      - electrumx
+    restart: on-failure
+    environment:
+      PORT: "3008"
+      ELECTRUM_HIDDEN_SERVICE: "${APP_LITECOIN_ELECTRUMX_RPC_HIDDEN_SERVICE}"
+      ELECTRUM_LOCAL_SERVICE: "${DEVICE_DOMAIN_NAME}"
+      ELECTRUM_HOST: "${APP_LITECOIN_ELECTRUMX_NODE_IP}"
+      ELECTRUM_PUBLIC_CONNECTION_PORT: "${APP_LITECOIN_ELECTRUMX_NODE_PORT}"
+      ELECTRUM_RPC_PORT: "${APP_LITECOIN_ELECTRUMX_RPC_PORT}"
+      LITECOIN_HOST: "${APP_LITECOIN_NODE_IP}"
+      RPC_USER: "${APP_LITECOIN_RPC_USER}"
+      RPC_PASSWORD: "${APP_LITECOIN_RPC_PASS}"
+      RPC_PORT: "${APP_LITECOIN_RPC_PORT}"
+    networks:
+      default:
+        ipv4_address: $APP_LITECOIN_ELECTRUMX_IP
+
+  electrumx:
+    image: ghcr.io/ryleastark/umbrel-litecoin-electrumx:v2.0.0-umbrel.5@sha256:24eaca92ab9a2ad85e2266de6ffaee5773f69e6c0a21734c836d2f6d15e81385
+    user: "1000:1000"
+    init: true
+    restart: on-failure
+    stop_grace_period: 5m
+    environment:
+      DAEMON_URL: "http://${APP_LITECOIN_RPC_USER}:${APP_LITECOIN_RPC_PASS}@${APP_LITECOIN_NODE_IP}:${APP_LITECOIN_RPC_PORT}"
+      COIN: "Litecoin"
+      NET: "${APP_LITECOIN_ELECTRUMX_NETWORK}"
+      DB_DIRECTORY: "/data"
+      DB_ENGINE: "rocksdb"
+      SERVICES: "tcp://0.0.0.0:${APP_LITECOIN_ELECTRUMX_NODE_PORT},rpc://0.0.0.0:${APP_LITECOIN_ELECTRUMX_RPC_PORT}"
+      PEER_DISCOVERY: "off"
+      PEER_ANNOUNCE: ""
+      CACHE_MB: "512"
+    volumes:
+      - "${APP_DATA_DIR}/data/electrumx:/data"
+    ports:
+      - "${APP_LITECOIN_ELECTRUMX_NODE_PORT}:${APP_LITECOIN_ELECTRUMX_NODE_PORT}"
+    networks:
+      default:
+        ipv4_address: $APP_LITECOIN_ELECTRUMX_NODE_IP
+
+  tor:
+    image: ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a
+    user: "1000:1000"
+    restart: on-failure
+    volumes:
+      - ${APP_DATA_DIR}/torrc:/etc/tor/torrc:ro
+      - ${TOR_DATA_DIR}:/data
+    environment:
+      HOME: "/tmp"
+    networks:
+      default:
+        ipv4_address: $APP_LITECOIN_ELECTRUMX_TOR_IP

--- a/litecoin-electrumx/exports.sh
+++ b/litecoin-electrumx/exports.sh
@@ -1,0 +1,29 @@
+export APP_LITECOIN_ELECTRUMX_IP="10.21.24.220"
+export APP_LITECOIN_ELECTRUMX_NODE_IP="10.21.25.220"
+export APP_LITECOIN_ELECTRUMX_TOR_IP="10.21.24.221"
+
+export APP_LITECOIN_ELECTRUMX_NODE_PORT="51003"
+export APP_LITECOIN_ELECTRUMX_RPC_PORT="8000"
+
+export APP_LITECOIN_ELECTRUMX_NETWORK="${APP_LITECOIN_NETWORK:-mainnet}"
+if [[ "${APP_LITECOIN_ELECTRUMX_NETWORK}" == "testnet3" ]]; then
+  export APP_LITECOIN_ELECTRUMX_NETWORK="testnet"
+fi
+
+# ElectrumX (LTC) implements the canonical Electrs (LTC) capability.
+for var in \
+  IP \
+  NODE_IP \
+  NODE_PORT
+do
+  electrs_var="APP_LITECOIN_ELECTRS_${var}"
+  electrumx_var="APP_LITECOIN_ELECTRUMX_${var}"
+  if [[ -n "${!electrumx_var-}" ]]; then
+    export "${electrs_var}"="${!electrs_var:=${!electrumx_var}}"
+  else
+    echo "Warning: ${electrumx_var} is unset or empty"
+  fi
+done
+
+rpc_hidden_service_file="${EXPORTS_TOR_DATA_DIR}/app-${EXPORTS_APP_ID}-rpc/hostname"
+export APP_LITECOIN_ELECTRUMX_RPC_HIDDEN_SERVICE="$(cat "${rpc_hidden_service_file}" 2>/dev/null || echo "notyetset.onion")"

--- a/litecoin-electrumx/hooks/pre-start
+++ b/litecoin-electrumx/hooks/pre-start
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ELECTRUMX_DATA_DIR="${APP_DATA_DIR}/data/electrumx"
+mkdir -p "${ELECTRUMX_DATA_DIR}"
+chown -R 1000:1000 "${ELECTRUMX_DATA_DIR}"
+find "${ELECTRUMX_DATA_DIR}" -type d -exec chmod u+rwx {} +
+find "${ELECTRUMX_DATA_DIR}" -type f -exec chmod u+rw {} +
+
+HIDDEN_SERVICE_FILE="${TOR_DATA_DIR}/app-${APP_ID}-rpc/hostname"
+if [[ ! -f "${HIDDEN_SERVICE_FILE}" ]]; then
+  "${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" up --detach electrumx
+  "${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" up --detach tor
+  echo "App: ${APP_ID} - Generating Tor hidden service..."
+  for _ in $(seq 1 100); do
+    [[ -f "${HIDDEN_SERVICE_FILE}" ]] && break
+    sleep 0.1
+  done
+fi

--- a/litecoin-electrumx/torrc.template
+++ b/litecoin-electrumx/torrc.template
@@ -1,0 +1,3 @@
+# ElectrumX (LTC) hidden service
+HiddenServiceDir /data/app-$APP_ID-rpc
+HiddenServicePort $APP_LITECOIN_ELECTRUMX_NODE_PORT $APP_LITECOIN_ELECTRUMX_NODE_IP:$APP_LITECOIN_ELECTRUMX_NODE_PORT

--- a/litecoin-electrumx/umbrel-app.yml
+++ b/litecoin-electrumx/umbrel-app.yml
@@ -30,3 +30,4 @@ submission: https://github.com/getumbrel/umbrel-apps/pull/5979
 backupIgnore:
   - data/electrumx/meta
   - data/electrumx/hist
+  - data/electrumx/utxo

--- a/litecoin-electrumx/umbrel-app.yml
+++ b/litecoin-electrumx/umbrel-app.yml
@@ -4,14 +4,16 @@ implements:
   - litecoin-electrs
 category: bitcoin
 name: "ElectrumX (LTC)"
-version: "2.0.0-umbrel.11"
+version: "2.0.0-umbrel.12"
 tagline: "A lightweight Litecoin Electrum server"
 description: >-
   Run a personal Litecoin Electrum server powered by ElectrumX 2.0 and Litecoin Core.
   Connect Electrum-compatible Litecoin wallets directly to your own indexed node over
   your local network or Tor. ElectrumX (LTC) is an independent indexer and can satisfy
   the same Electrs (LTC) capability used by compatible applications.
-releaseNotes: ""
+releaseNotes: >-
+  Updates the GUI to Fastify 5.12.1 to resolve CVE-2026-18504 and CVE-2026-16732,
+  and fixes the Connect dialog's decorative border while scrolling on mobile.
 developer: Electrum developers and RyleaStark
 website: https://electrumx-spesmilo.readthedocs.io/
 dependencies:

--- a/litecoin-electrumx/umbrel-app.yml
+++ b/litecoin-electrumx/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - litecoin-electrs
 category: bitcoin
 name: "ElectrumX (LTC)"
-version: "2.0.0-umbrel.12"
+version: "2.0.0-umbrel.13"
 tagline: "A lightweight Litecoin Electrum server"
 description: >-
   Run a personal Litecoin Electrum server powered by ElectrumX 2.0 and Litecoin Core.
@@ -12,8 +12,8 @@ description: >-
   your local network or Tor. ElectrumX (LTC) is an independent indexer and can satisfy
   the same Electrs (LTC) capability used by compatible applications.
 releaseNotes: >-
-  Updates the GUI to Fastify 5.12.1 to resolve CVE-2026-18504 and CVE-2026-16732,
-  and fixes the Connect dialog's decorative border while scrolling on mobile.
+  Shows ElectrumX's live indexing progress while Litecoin Core completes initial sync,
+  instead of incorrectly remaining on "Waiting for Litecoin Core."
 developer: Electrum developers and RyleaStark
 website: https://electrumx-spesmilo.readthedocs.io/
 dependencies:

--- a/litecoin-electrumx/umbrel-app.yml
+++ b/litecoin-electrumx/umbrel-app.yml
@@ -24,7 +24,7 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: Rylea Stark
-submission: ""
+submission: https://github.com/getumbrel/umbrel-apps/pull/5979
 backupIgnore:
   - data/electrumx/meta
   - data/electrumx/hist

--- a/litecoin-electrumx/umbrel-app.yml
+++ b/litecoin-electrumx/umbrel-app.yml
@@ -1,0 +1,30 @@
+manifestVersion: 1.1
+id: litecoin-electrumx
+implements:
+  - litecoin-electrs
+category: bitcoin
+name: "ElectrumX (LTC)"
+version: "2.0.0-umbrel.11"
+tagline: "A lightweight Litecoin Electrum server"
+description: >-
+  Run a personal Litecoin Electrum server powered by ElectrumX 2.0 and Litecoin Core.
+  Connect Electrum-compatible Litecoin wallets directly to your own indexed node over
+  your local network or Tor. ElectrumX (LTC) is an independent indexer and can satisfy
+  the same Electrs (LTC) capability used by compatible applications.
+releaseNotes: ""
+developer: Electrum developers and RyleaStark
+website: https://electrumx-spesmilo.readthedocs.io/
+dependencies:
+  - litecoin-core
+repo: https://github.com/RyleaStark/umbrel-litecoin-electrumx
+support: https://github.com/RyleaStark/umbrel-litecoin-electrumx/issues
+port: 12108
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: Rylea Stark
+submission: ""
+backupIgnore:
+  - data/electrumx/meta
+  - data/electrumx/hist


### PR DESCRIPTION
## Type

New app

## App

App ID: `litecoin-electrumx`
Version: `2.0.0-umbrel.13`
Upstream projects:
- https://github.com/RyleaStark/umbrel-litecoin-electrumx
- https://github.com/RyleaStark/umbrel-litecoin-electrumx-gui
Image: `ghcr.io/ryleastark/umbrel-litecoin-electrumx-gui:v1.0.11@sha256:27fd13e4e89276d951bf7cbcefa17dab9a891dbdfa419445fc714d52f8bc8a74`

## Summary

Adds a Litecoin Electrum server powered by ElectrumX 2.0. The browser UI uses ElectrumX admin database/daemon heights for progress and requires the public listener for authoritative readiness.

## Dependencies and provider contract

Depends on the official `litecoin-core` submission in https://github.com/getumbrel/umbrel-apps/pull/5970 and implements the `litecoin-electrs` contract introduced by the companion Electrs submission. This PR cannot pass dependency/provider validation or merge before those app IDs land on `master`.

### Environment tested:

- [x] Umbrel device
- [x] Local umbrelOS test environment
- [ ] Not runtime tested

### Architecture tested:

- [x] amd64
- [x] arm64

### App Icon:
<img width="256" height="256" alt="electrumx" src="https://github.com/user-attachments/assets/7eea92d0-cc14-40a6-8255-c19c41d5a211" />

### App Screenshots: 
<img width="1440" height="1000" alt="marketplace-complete" src="https://github.com/user-attachments/assets/3ddc8bf5-0a7f-47ad-841c-f84986a941d4" />
<img width="1440" height="1000" alt="marketplace-local-connect" src="https://github.com/user-attachments/assets/e37ba8c7-b34d-4bbf-afce-8920a39e7987" />
<img width="1440" height="1000" alt="marketplace-syncing" src="https://github.com/user-attachments/assets/fc139a91-957d-4eb2-bdf7-dee8b28baeca" />

### App Video:

https://github.com/user-attachments/assets/f93aa309-ed5b-4380-b662-e44cf80764a6



## Verification

- The same immutable package/image release was previously linted with zero errors/warnings and tested on the Extended Umbrella store.
- Official-store adaptation passed `npm run lint:apps -- litecoin-electrumx --check-images` with no issues when validated together with the pending `litecoin-core` package from PR #5970 and pending `litecoin-electrs` package from PR #5977.
- `git diff --check` and shell syntax checks passed.
- The committed manifest links this submission PR.
- GitHub CI will continue to report unresolved dependency/provider IDs until those prerequisite PRs merge into `master`.
- No fresh install or runtime test of this official-store ID was performed.

## Follow-up hardening and mobile verification (2026-08-21)

- Updated the immutable GUI image to `ghcr.io/ryleastark/umbrel-litecoin-electrumx-gui:v1.0.10@sha256:8c33c731a7e29cf075195a3e4cc9aea2da0b1ef67477acf5e28a5a5d4168b6ba`.
- The image contains Fastify 5.12.1, patching CVE-2026-18504 and CVE-2026-16732.
- The mobile Connect-dialog border now remains fixed at the outer modal edge instead of scrolling across the connection note.
- Anonymous OCI inspection verified `linux/amd64` and `linux/arm64`; the exact published ARM64 image passed non-root/read-only startup, security-header checks, and a 390 × 700 Chromium scroll-boundary regression.
- Official-store lint passes with no issues when the pending prerequisite app directories are supplied as unstaged validation fixtures. GitHub CI is expected to retain only the unresolved prerequisite-ID diagnostics until those PRs merge.


## Core-IBD status correction (2026-09-07)

- Updated to package version `2.0.0-umbrel.13` and immutable GUI image `v1.0.11@sha256:27fd13e4e89276d951bf7cbcefa17dab9a891dbdfa419445fc714d52f8bc8a74`.
- ElectrumX now reports provider-authoritative indexing progress while Litecoin Core remains in IBD, and still waits safely when ElectrumX itself is unavailable.
- Source PR: https://github.com/RyleaStark/umbrel-litecoin-electrumx-gui/pull/1
- Signed source tag targets merge commit `64d344981414a1bb6a80d24629c799e123028f2e`; release workflow 34080848666 passed.
- Public OCI inspection verified `linux/amd64` and `linux/arm64` at the pinned index digest.
- Integrated official-store lint passed with pending prerequisite packages from PRs #5970 and #5977 supplied as fixtures. Hosted CI is expected to retain prerequisite-ID failures until those submissions merge.
- This update changes only the manifest version/release notes and GUI image pin; daemon, storage, exports, ports, dependencies, and backup exclusions are unchanged. No fresh device deployment was performed for this package commit.
