### PR TITLE
Update Hashrate Autopilot to 1.17.6

### DIFF
--- a/hashrate-autopilot/docker-compose.yml
+++ b/hashrate-autopilot/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3010
 
   web:
-    image: ghcr.io/rdouma/hashrate-autopilot:1.17.5@sha256:5ec82e060f8e2f61ef503f9ba2063f712aac46dc400420d30b2bea8c5d1aca71
+    image: ghcr.io/rdouma/hashrate-autopilot:1.17.6@sha256:5636d3560c995d7bed4ee6d2bc855999b19bc77bdb316e6485b941a546a99444
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/hashrate-autopilot/umbrel-app.yml
+++ b/hashrate-autopilot/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: hashrate-autopilot
 category: bitcoin
 name: Hashrate Autopilot
-version: "1.17.5"
+version: "1.17.6"
 tagline: Autopilot for renting hashrate to mine on Ocean Mining
 
 description: >-
@@ -73,13 +73,16 @@ defaultPassword: ""
 submitter: Remco Douma
 submission: https://github.com/getumbrel/umbrel-apps/pull/5685
 releaseNotes: >-
-  v1.17.5 - security maintenance: eight dependency advisories closed.
+  v1.17.6 - phantom Lightning payouts removed from Profit & Loss, and the dashboard API is locked to the dashboard itself.
 
 
-  Security: Eight published security advisories are closed across the libraries the app is built on, covering the web server's static-file handling and request routing, the dashboard's router, and several supporting parsers. None of these were known to be reachable through the autopilot itself, but they are cleared now rather than left to age.
+  Fixed: Profit & Loss no longer invents Lightning payouts you never received. A brief glitch in Ocean's reported unpaid balance could be read as a payout, inflating your "collected" total and understating your loss rate - and because the entry was recalculated from your history on every scan, even the Profit & Loss hard reset could not remove it. Impossible readings are now discarded rather than stored, and a drop only counts as a payout if the balance stays down: if it climbs back near its previous level within half an hour, it is treated as a reporting glitch. Existing false entries are deleted on upgrade and cannot come back. Genuine payouts, and any personal notes you attached to them, are left untouched.
 
 
-  Nothing in the dashboard or the daemon behaves differently in this release, and there are no new migrations. Safe to upgrade from any 1.17.x release.
+  Fixed: The dashboard API now only answers browser requests coming from the dashboard itself. It previously told browsers that any website could make requests to it using your saved login, so a page in another tab could have acted on your behalf while you had the dashboard open. Nothing changes about how you reach the dashboard - a local address, a .local name, dynamic DNS, a VPN or a reverse proxy all keep working - and scripts or monitoring that call the API directly are unaffected.
+
+
+  Also includes routine dependency maintenance. No new settings. Safe to upgrade from any 1.17.x release.
 
 
   Migrating from the community-store version (rdouma-hashrate-autopilot)? One-time five-minute guide: https://github.com/rdouma/hashrate-autopilot/blob/main/docs/migrating-from-community-store.md


### PR DESCRIPTION
### Type

App update: Hashrate Autopilot 1.17.5 → 1.17.6

### App

`hashrate-autopilot`

### Summary

Two bug fixes.

**Profit & Loss no longer invents Lightning payouts.** A brief glitch in the mining pool's reported unpaid balance could be read as a payout, inflating the user's "collected" total. Because the entry was recalculated from stored history on every scan, the app's own hard-reset control could not clear it. Impossible readings are now discarded rather than stored, and a balance drop only counts as a payout if the balance stays down. Existing false entries are removed by a migration on upgrade; genuine payouts and user-attached notes are preserved.

**The app's API is now restricted to same-origin browser requests.** It previously advertised that any website could make credentialed cross-origin calls and read the replies. Every endpoint still required the user's password, but browsers attach saved credentials automatically, so another tab could have driven authenticated endpoints during an active session. This does not affect how users reach the app (local address, `.local` name, dynamic DNS, VPN or reverse proxy all remain same-origin), nor non-browser API clients, since CORS is browser-enforced.

Also includes routine dependency maintenance. No new settings or environment variables.

### Changes

- `hashrate-autopilot/umbrel-app.yml`: `version` bumped to `1.17.6`, `releaseNotes` replaced with the 1.17.6 entry.
- `hashrate-autopilot/docker-compose.yml`: image pinned to `ghcr.io/rdouma/hashrate-autopilot:1.17.6@sha256:5636d3560c995d7bed4ee6d2bc855999b19bc77bdb316e6485b941a546a99444`.

No other files touched; no changes to ports, dependencies, or environment.

### Verification

- Image published to GHCR by the upstream repo's tag-triggered workflow, confirmed present as a multi-arch index covering `linux/amd64` and `linux/arm64`.
- The digest above is the multi-arch index digest read back from the GHCR manifest endpoint.
- Upstream CI green on the release commit: full test suite (761 tests), typecheck, and production build.
- The database migration included in this release is covered by tests for the repair itself, for preservation of legitimate records and their ids, and for idempotency on re-run.
- Not tested on a physical Umbrel device by the submitter for this update.

### Notes

The app is also distributed through the submitter's community store under the id `rdouma-hashrate-autopilot`. Users moving from that install to this one keep their history via the one-time migration linked from the app description.
