### PR TITLE
Update Nostr VPN to v4.1.7

### DIFF
--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -34,6 +34,12 @@ services:
     stop_grace_period: 1m
     depends_on:
       - daemon
+    command:
+      - --listen
+      - 0.0.0.0:38080
+      - --behind-trusted-proxy
+      - --config
+      - /data/config/nvpn/config.toml
     environment:
       HOME: /data/home
       XDG_CONFIG_HOME: /data/config

--- a/nostr-vpn/docker-compose.yml
+++ b/nostr-vpn/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 38080
 
   daemon:
-    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.67@sha256:b01f4a62f6b093bed74db7f9feaa77325668bb64bd36147ff6a40f97a542db91
+    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.1.7@sha256:8e2df108b88970c5c28ee7fd5b82b9695ef26b0241054794956098e71242c101
     restart: on-failure
     stop_grace_period: 1m
     network_mode: "host"
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   web:
-    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.0.67@sha256:b01f4a62f6b093bed74db7f9feaa77325668bb64bd36147ff6a40f97a542db91
+    image: ghcr.io/mmalmi/nostr-vpn-umbrel:v4.1.7@sha256:8e2df108b88970c5c28ee7fd5b82b9695ef26b0241054794956098e71242c101
     restart: on-failure
     stop_grace_period: 1m
     depends_on:

--- a/nostr-vpn/umbrel-app.yml
+++ b/nostr-vpn/umbrel-app.yml
@@ -2,19 +2,19 @@ manifestVersion: 1
 id: nostr-vpn
 category: networking
 name: Nostr VPN
-version: "v4.0.67"
-tagline: Invite-only mesh VPN over Nostr
+version: "v4.1.7"
+tagline: Admin-approved mesh VPN over Nostr
 description: >-
   Nostr VPN turns your Umbrel into a private mesh VPN node for your own devices
-  and trusted groups. Create invite-only networks, approve join requests, share
-  QR invites, manage peers, and route traffic through trusted exit nodes without
-  relying on a hosted VPN provider or a central control server.
+  and trusted groups. Approve signed join-request QRs, manage peers, and route
+  traffic through trusted exit nodes without relying on a hosted VPN provider
+  or a central control server.
 
 
-  To connect a device, open Nostr VPN on your Umbrel and create an invite. Then import that
-  invite in the Nostr VPN app or CLI on the device you want to connect. Once you
-  accept the join request on your Umbrel, your devices can reach each other
-  using their private Nostr VPN IPs.
+  To connect a device, choose Join on the device you want to add so it displays
+  its signed QR code or link. On your Umbrel, scan or paste that request, review
+  it, and accept it. The joining device then receives the signed network roster
+  and your devices can reach each other using their private Nostr VPN IPs.
 developer: mmalmi and contributors
 website: https://github.com/mmalmi/nostr-vpn
 repo: https://github.com/mmalmi/nostr-vpn
@@ -31,10 +31,9 @@ gallery:
   - 2.webp
   - 3.webp
 releaseNotes: >-
-  Changes since v4.0.58:
-    - Keeps VPN traffic flowing over mesh fallback when direct UDP is marked link-dead, while direct probing continues and can recover.
-    - Fixes stale or freshly reconnected UDP paths suppressing better fallback routes after hotspot/NAT changes.
-    - Prevents fallback transit loops after direct-path loss.
-    - Warms established sessions after fresh fallback discovery, reducing stalls after liveness timeouts.
+  Changes since v4.0.67:
+    - Updates Umbrel to the signed join-request flow used by current clients: the joining device displays a QR code or link and the Umbrel admin scans or pastes it.
+    - Improves VPN reliability, fallback recovery, and performance across platforms.
+    - Fixes paid-exit discovery, provider links, connection status, pricing, and settlement.
 submitter: mmalmi
 submission: https://github.com/getumbrel/umbrel-apps/pull/5678


### PR DESCRIPTION
## Summary

- Update the Nostr VPN package from v4.0.67 to v4.1.7.
- Pin both services to the anonymously verified multi-arch release image `ghcr.io/mmalmi/nostr-vpn-umbrel:v4.1.7@sha256:8e2df108b88970c5c28ee7fd5b82b9695ef26b0241054794956098e71242c101`.
- Correct the connection instructions for the current signed join flow: the joining device displays its QR code or link, then the Umbrel admin scans or pastes and accepts it.

## Testing

- The release gate exercised the authenticated Umbrel proxy and full requester join: requester displayed a signed QR/link, admin scanned/pasted and approved it, requester received the signed roster and left the QR screen.
- Anonymous registry readback verified the immutable OCI index contains both `linux/amd64` and `linux/arm64` plus only their attestations.
- Tested the real update path on an ARM64 umbrelOS device from installed v4.0.87 to v4.1.7 through `umbreld`; the app returned `ready`.
- Restarted through Umbrel; it returned `ready`, the web UI/API started behind `app_proxy`, and the persisted mesh returned with 26 connections.
- `npm run lint:apps -- nostr-vpn --check-images`: 0 errors.
- `git diff --check`: passed.

## Existing permissions

The three linter warnings are unchanged and required for the VPN daemon: host networking, `/dev/net/tun`, and `NET_ADMIN`. This update changes no ports, persistence paths, dependencies, credentials, hooks, or permissions.
