### PR TITLE
yuvomi: update to v2.7.1

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:2.6.0@sha256:28c134190158c5933c36162aa95ec53a63a44f29fdda2abcdd97d6a630df2f73
+    image: ghcr.io/ulsklyc/yuvomi:2.7.1@sha256:ccbb3685e333bb5568ce16b4de9d8398f257bb360b2fe672be5b4175bc8aac8b
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "2.6.0"
+version: "2.7.1"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -51,26 +51,14 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  Yuvomi now includes Wall Mode for hallway tablets, Immich photo screensavers,
-  Tandoor recipe syncing, income subcategories, and API tokens that can act as a
-  selected family member.
-
-
-  The dashboard has clearer module colours, an improved day programme, more
-  responsive widgets, background refreshes, and better layouts for notes,
-  birthdays, budgets, and family tasks.
-
-
-  This update also fixes excessive GPU use while idle, app installation behind
-  authenticated reverse proxies, and several accessibility and interaction issues.
-
-
-  Recipe providers on private or LAN addresses now require the
-  `RECIPE_PROVIDER_ALLOW_PRIVATE_NETWORK=true` environment setting to sync.
+  There is nothing new to see in this update and nothing to do after it. It only
+  adds documentation for people who write their own Yuvomi modules, describing
+  how such a module talks to Yuvomi safely and keeps working across updates. The
+  app itself, your data and your settings are unchanged.
 
 
   Full release notes are available at
-  https://github.com/ulsklyc/yuvomi/releases
+  https://github.com/ulsklyc/yuvomi/releases/tag/v2.7.1
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db


### PR DESCRIPTION
Automated update of Yuvomi, prepared by the release workflow in `ulsklyc/yuvomi` and following this repo's `AGENTS.md`.

| | |
|---|---|
| Old version | `2.6.0` |
| New version | `2.7.1` |
| Upstream release | https://github.com/ulsklyc/yuvomi/releases/tag/v2.7.1 |
| Image | `ghcr.io/ulsklyc/yuvomi:2.7.1@sha256:ccbb3685e333bb5568ce16b4de9d8398f257bb360b2fe672be5b4175bc8aac8b` |
| Architectures | linux/amd64, linux/arm64 |
| Linter | passed (`node .tools/lint-apps.mjs yuvomi --check-images`) |

**Package changes**

- `yuvomi/docker-compose.yml`
- `yuvomi/umbrel-app.yml`

Manifest `version`, `releaseNotes` and the pinned image digest. No changes to compose wiring, env vars, volumes, ports, `app_proxy`, hooks, exports or permissions, so there is nothing for existing installs to migrate.

**Breaking changes**

None. This is a patch/minor upstream release; see the upstream notes above for the user-visible list.

**Testing performed**

- Upstream CI (`npm test`) green on the release commit.
- Image pulled from the public registry and pinned by the multi-arch index digest; `linux/amd64` and `linux/arm64` verified to be present in the manifest list.
- Manifest and compose parsed as YAML after editing.
- Repo linter: passed (`node .tools/lint-apps.mjs yuvomi --check-images`)

**Not tested**: the update path was not exercised through umbrelOS itself - this workflow has no Umbrel instance. The package change is limited to the manifest version, the release notes and the image digest.
