### PR TITLE
Add Kapowarr

### DIFF
--- a/kapowarr/docker-compose.yml
+++ b/kapowarr/docker-compose.yml
@@ -7,7 +7,7 @@ services:
             APP_PORT: 5656
 
     server:
-        image: mrcas/kapowarr:v1.3.1@sha256:d455797e4f2c5b1a8ccc5ce05c427f1af2179451bb1af195ca3fa8c3e928623b
+        image: mrcas/kapowarr:v1.3.1@sha256:sha256:d455797e4f2c5b1a8ccc5ce05c427f1af2179451bb1af195ca3fa8c3e928623b
         volumes:
             - ${APP_DATA_DIR}/data/db:/app/db
             - ${UMBREL_ROOT}/data/storage/downloads:/app/temp_downloads

--- a/kapowarr/docker-compose.yml
+++ b/kapowarr/docker-compose.yml
@@ -7,7 +7,7 @@ services:
             APP_PORT: 5656
 
     server:
-        image: mrcas/kapowarr:v1.3.1@sha256:sha256:d455797e4f2c5b1a8ccc5ce05c427f1af2179451bb1af195ca3fa8c3e928623b
+        image: mrcas/kapowarr:v1.3.1@sha256:d455797e4f2c5b1a8ccc5ce05c427f1af2179451bb1af195ca3fa8c3e928623b
         volumes:
             - ${APP_DATA_DIR}/data/db:/app/db
             - ${UMBREL_ROOT}/data/storage/downloads:/app/temp_downloads

--- a/kapowarr/docker-compose.yml
+++ b/kapowarr/docker-compose.yml
@@ -6,7 +6,7 @@ services:
             APP_HOST: kapowarr_kapowarr_1
             APP_PORT: 5656
 
-    server:
+    kapowarr:
         image: mrcas/kapowarr:v1.3.1@sha256:d455797e4f2c5b1a8ccc5ce05c427f1af2179451bb1af195ca3fa8c3e928623b
         volumes:
             - ${APP_DATA_DIR}/data/db:/app/db

--- a/kapowarr/docker-compose.yml
+++ b/kapowarr/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.7"
+
+services:
+    app_proxy:
+        environment:
+            APP_HOST: kapowarr_kapowarr_1
+            APP_PORT: 5656
+
+    server:
+        image: mrcas/kapowarr:v1.3.1@sha256:d455797e4f2c5b1a8ccc5ce05c427f1af2179451bb1af195ca3fa8c3e928623b
+        volumes:
+            - ${APP_DATA_DIR}/data/db:/app/db
+            - ${UMBREL_ROOT}/data/storage/downloads:/app/temp_downloads
+        restart: on-failure

--- a/kapowarr/umbrel-app.yml
+++ b/kapowarr/umbrel-app.yml
@@ -1,0 +1,25 @@
+manifestVersion: 1.1
+id: kapowarr
+category: media
+name: Kapowarr
+version: "1.3.1"
+tagline: The *arr suite, rebuilt for comics and manga
+description: >-
+    Kapowarr is a self-hosted manager that finds, downloads, renames, and organizes your comic and manga issues automatically — the *arr-style workflow, built for comics.
+developer: Casvt
+website: https://casvt.github.io/Kapowarr/
+dependencies:
+    - transmission
+repo: https://github.com/Casvt/Kapowarr
+support: https://github.com/Casvt/Kapowarr/issues
+port: 5656
+gallery: []
+path: ""
+releaseNotes: ""
+defaultUsername: ""
+defaultPassword: ""
+torOnly: false
+permissions:
+    - STORAGE_DOWNLOADS
+submitter: Harriet Landa
+submission: https://github.com/getumbrel/umbrel-hello-world-app

--- a/kapowarr/umbrel-app.yml
+++ b/kapowarr/umbrel-app.yml
@@ -22,4 +22,4 @@ torOnly: false
 permissions:
     - STORAGE_DOWNLOADS
 submitter: Harriet Landa
-submission: https://github.com/getumbrel/umbrel-hello-world-app
+submission: https://github.com/getumbrel/umbrel-apps/pull/5987


### PR DESCRIPTION
<!--
Title format: 
- Add <app name>
- Update <app name> to <version>
- Fix <app name> <issue>
-->

## Type

New app

## App

App ID: kapowarr
Upstream project: https://github.com/Casvt/Kapowarr
Version: 1.3.1

## Summary

Adds Kapowarr, a software to build and manage a comic book library, fitting in the *arr suite of software.

## Verification

Umbrel testing performed: Installed and ran the app on an Umbrel device, added a comic and download it correctly.

Environment tested:
- [x] Umbrel device
- [x] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64

Known lint warnings or caveats:

## Notes

- Dependencies:
    - Transmission (Optional)
- No default credentials: Kapowarr as all the *arr softwares has a parameter where the user sets the admin password.
- Persists `/config/db` (database + app config)
- Permissions to `/downloads` folder as temp download path.
- Image pinned by tag + digest (`mrcas/kapowarr:v1.3.1`), multi-arch (amd64/arm64).

Screenshots and a 256x256 SVG icon are attached below.

<img width="256" height="256" alt="kapowarr-icon-256" src="https://github.com/user-attachments/assets/2c947d30-3677-46a3-9a51-53e2bff47925" />

<img width="1586" height="992" alt="kapowarr-image-1" src="https://github.com/user-attachments/assets/9972a638-3fdb-4f82-981e-3f8a7eaf3dfc" />

<img width="1586" height="992" alt="kapowarr-image-2" src="https://github.com/user-attachments/assets/fcaec9f4-c956-49d3-9aa8-31bb449d0b9d" />
