### PR TITLE
joinstr: update to 0.1.2

### DIFF
--- a/joinstr/docker-compose.yml
+++ b/joinstr/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   web:
     # Multi-arch (amd64+arm64) image pinned by digest — required by umbrel-apps.
-    image: ghcr.io/1440000bytes/joinstr-web:0.1.1@sha256:3a3d513c758fb5a5346dc1e26c430c3e35f72062a3fe5dcc064cf75b6fd83d7c
+    image: ghcr.io/1440000bytes/joinstr-web:0.1.2@sha256:33a83abd3935b69bf44274c5ebce3be5115c5e7a81f6bb05127cc83b2133f91e
     restart: on-failure
     stop_grace_period: 1m
     environment:

--- a/joinstr/umbrel-app.yml
+++ b/joinstr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: joinstr
 category: bitcoin
 name: Joinstr
-version: "0.1.0"
+version: "0.1.2"
 tagline: Decentralized coinjoin over Nostr
 description: >-
   Joinstr is a coordinator-less coinjoin that uses Nostr relays to find peers
@@ -11,7 +11,18 @@ description: >-
 
   The app runs the Joinstr web UI against your Umbrel's Bitcoin node, which it
   connects to automatically.
-releaseNotes: ""
+releaseNotes: >-
+  Fixes a bug where joining a pool showed a blank page and the join never
+  completed. The credentials page had a malformed title tag, which made the
+  browser render the page empty, and the pool creator stopped answering join
+  requests after the first attempt, so retrying never worked.
+
+
+  Also a security release. A joiner now bounds what a coinjoin can cost it and
+  will not sign a registration transaction that could be broadcast on its own,
+  pool credentials are accepted only from the pool that was actually joined,
+  pool announcements must be signed by the key they name, and nostr events are
+  verified before use rather than trusted from the relay.
 developer: Invincible Privacy
 website: https://joinstr.xyz
 dependencies:


### PR DESCRIPTION
Updates Joinstr to 0.1.2.

## Bug fix

A user reported that joining a pool showed a blank page and the join never completed, however many times it was retried. Two causes:

- `wait_credentials_template.html` had `<title>Credentials/title>`, missing the `</`. The browser then treats the rest of the document as title text, so the page renders empty. `my_pools_template.html` had the same defect.
- The pool creator's credential monitor stopped after the first join request, so a joiner that hit the blank page and retried found nobody answering. Resuming a pool also never restarted the monitor.

## Security

Also carries a set of security fixes. A joiner now bounds what a coinjoin may cost it and refuses to sign a registration PSBT that could be broadcast on its own; pool credentials are accepted only when they carry the private key of the pool that was chosen; pool announcements must be signed by the key they name; and nostr events are verified before use rather than trusted from the relay.

## Image

`ghcr.io/1440000bytes/joinstr-web:0.1.2@sha256:33a83abd3935b69bf44274c5ebce3be5115c5e7a81f6bb05127cc83b2133f91e`

Multi-arch (linux/amd64 + linux/arm64), built from joinstr `ed106f5a39e22ab4095c93552911c31577236a40` with the build definition now in the repo at `contrib/docker`. Verified by pulling the digest:

```
python 3.12.13 | nostrj 0.1.1 | events verified: True
```