### PR TITLE
yuvomi: update to v2.16.1

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:2.7.1@sha256:ccbb3685e333bb5568ce16b4de9d8398f257bb360b2fe672be5b4175bc8aac8b
+    image: ghcr.io/ulsklyc/yuvomi:2.16.1@sha256:ef038c3eab85c29c39f216f21086a64083f47e710ca1f78a2bc55f80b280600d
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "2.7.1"
+version: "2.16.1"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -51,14 +51,19 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  There is nothing new to see in this update and nothing to do after it. It only
-  adds documentation for people who write their own Yuvomi modules, describing
-  how such a module talks to Yuvomi safely and keeps working across updates. The
-  app itself, your data and your settings are unchanged.
+  Editing a reward no longer replaces its icon with the word "null". Any reward
+  you had created without an icon lost it the first time you changed anything
+  else about it - the price, the name - and showed a stray piece of text in its
+  place. Clearing the description of a reward did the same to the description.
+
+
+  Rewards that already carry that text are cleaned up while the app starts,
+  including the copy kept in the redemption history, so there is nothing for you
+  to correct by hand.
 
 
   Full release notes are available at
-  https://github.com/ulsklyc/yuvomi/releases/tag/v2.7.1
+  https://github.com/ulsklyc/yuvomi/releases/tag/v2.16.1
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db


### PR DESCRIPTION
Automated update of Yuvomi, prepared by the release workflow in `ulsklyc/yuvomi` and following this repo's `AGENTS.md`.

| | |
|---|---|
| Old version | `2.7.1` |
| New version | `2.16.1` |
| Upstream release | https://github.com/ulsklyc/yuvomi/releases/tag/v2.16.1 |
| Image | `ghcr.io/ulsklyc/yuvomi:2.16.1@sha256:ef038c3eab85c29c39f216f21086a64083f47e710ca1f78a2bc55f80b280600d` |
| Architectures | linux/amd64, linux/arm64 |
| Linter | passed (`node .tools/lint-apps.mjs yuvomi --check-images`) |

**Package changes**

- `yuvomi/docker-compose.yml`
- `yuvomi/umbrel-app.yml`

Manifest `version`, `releaseNotes` and the pinned image digest. No changes to compose wiring, env vars, volumes, ports, `app_proxy`, hooks, exports or permissions, so there is nothing for existing installs to migrate.

**Breaking changes**

None. This is a patch/minor upstream release; see the upstream notes above for the user-visible list.

**Testing performed**

- Upstream CI (`npm test`) green on the release commit.
- Image pulled from the public registry and pinned by the multi-arch index digest; `linux/amd64` and `linux/arm64` verified to be present in the manifest list.
- Manifest and compose parsed as YAML after editing.
- Repo linter: passed (`node .tools/lint-apps.mjs yuvomi --check-images`)

**Not tested**: the update path was not exercised through umbrelOS itself - this workflow has no Umbrel instance. The package change is limited to the manifest version, the release notes and the image digest.
