### PR TITLE
Update Robosats to v0.8.6-alpha

### DIFF
--- a/robosats/docker-compose.yml
+++ b/robosats/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 12596
 
   web:
-    image: recksato/robosats-client:v0.8.4-alpha@sha256:85bf9ace2eafbcd7c5c61f62d81423aea63ddf08375f5cbe1090392bb49e92f8
+    image: recksato/robosats-client:v0.8.6-alpha@sha256:071634c1a73aa5eecdb4e7f84419319888fa10d238ae3ad2433a984301727fbe
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -34,6 +34,9 @@ description: >-
   You can join other cool Robots and get community support at https://t.me/robosats telegram group.
   
 releaseNotes: >-
+  After updating, hard-refresh RoboSats once (Ctrl/Cmd + Shift + R) to load the new client.
+
+
   Highlights:
 
     - Visual warning for orders with bonds below the default 3%

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: robosats
 category: bitcoin
 name: RoboSats
-version: "v0.8.4-alpha"
+version: "v0.8.6-alpha"
 tagline: Simple and Private Bitcoin P2P Exchange
 description: >-
   RoboSats is a simple and private app to exchange bitcoin for national currencies. 
@@ -39,29 +39,27 @@ releaseNotes: >-
 
   Highlights:
 
-    - Multiple UI improvements and bug fixes.
-    - Payment methods input clears when switching to Swap.
-    - API errors are now displayed globally in toast messages.
-    - Orders are automatically sorted by premium when filtering by SELL / BUY type.
-    - Bond amount in sats is now estimated before order creation.
-    - Also includes v0.8.3-alpha additions such as new coordinators, Tor Browser configuration warning, and better order-form errors.
-
+    - Visual warning for orders with bonds below the default 3%
+    - Libraries security updates
+    - Removed 3 coordinators
 
   New payment methods:
 
-    - Binance Pay
-    - DANA
+    - Doordash USA giftcard
+    - Wero
 
 
   Bugs:
 
-    - Fixed typo in federation table.
-    - Fixed swap and range-order "You receive..." calculations.
-    - Fixed coordinator node app and Nostr values for WhiteEyeSats and Alice.
-    - Pin colors are now static in map view.
+    - Infinite loading when reloading/renewing orders now properly catch up
+    - When loading any specific path different from root the app failed.
+    - Crash on mobile devices when switching between Fiat/Swap modes with a payment method selected
+    - Coordinator ratings showed different counts in the list view vs. the detail dialog
+    - UI overlap issue where the bond percentage was displayed simultaneously in both the Bond column and the Premium column on certain screen sizes
+    - Return OK on successful order cancel
 
 
-  Full release notes are available at https://github.com/RoboSats/robosats/releases/tag/v0.8.4-alpha
+  Full release notes are available at https://github.com/RoboSats/robosats/releases/tag/v0.8.6-alpha
 developer: RoboSats
 website: https://learn.robosats.org
 dependencies: []

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -34,9 +34,6 @@ description: >-
   You can join other cool Robots and get community support at https://t.me/robosats telegram group.
   
 releaseNotes: >-
-  Note for users who already updated to v0.8.5-alpha: v0.8.5-alpha was a pre-release, so this update returns RoboSats to v0.8.4-alpha, the latest regular release. It is safe to click update. This only changes the RoboSats app version that opens on Umbrel and does not reset your RoboSats data or require you to set up RoboSats again.
-
-
   Highlights:
 
     - Visual warning for orders with bonds below the default 3%


### PR DESCRIPTION
## Type

App update

## App

App ID: robosats
Upstream project: Robosats
Version: v0.8.6-alpha

## Summary

Full changelog here: https://github.com/RoboSats/robosats/releases/tag/v0.8.6-alpha

## Verification

Umbrel testing performed:

Environment tested:
- [ ] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [ ] amd64
- [ ] arm64

Known lint warnings or caveats:

## Notes

Permissions, dependencies, migrations, default credentials, or caveats:

For new apps, include screenshots and a logo reference. Umbrel will create the final App Store gallery assets.
