### PR TITLE
Add Popcorn Vote

### DIFF
--- a/popcorn-vote/docker-compose.yml
+++ b/popcorn-vote/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   main:
-    image: ghcr.io/stadicus/popcorn-vote:1.2.0@sha256:03e8f36ca31419f656a1d4286d851945b0c890c97b9aa5b4b32fcd66f35295b6
+    image: ghcr.io/stadicus/popcorn-vote:1.3.0@sha256:115369d57f8fefd2aa952fe269c9fb7a0719319e86ac64f68bd6842631be404d
     # The image already runs as node, which is uid/gid 1000, matching the
     # ownership Umbrel gives app data. Stated explicitly so a future base-image
     # change cannot silently move it and leave the data directory unwritable.

--- a/popcorn-vote/docker-compose.yml
+++ b/popcorn-vote/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: popcorn-vote_main_1
+      APP_PORT: 3000
+      # Umbrel auth is off for this app on purpose, and the reasoning is the
+      # opposite of the usual one: it is not that the app's own login would
+      # break, it is who the app is for. Popcorn Vote is used by the whole
+      # family from their own phones and tablets, while the Umbrel login belongs
+      # to whoever runs the server. Leaving Umbrel auth in front would mean
+      # handing the server password to the children in order to let them vote on
+      # a film, which is a far worse trade than the four-digit family PIN the
+      # app asks for and rate-limits per address.
+      PROXY_AUTH_ADD: "false"
+
+  main:
+    image: ghcr.io/stadicus/popcorn-vote:1.2.0@sha256:03e8f36ca31419f656a1d4286d851945b0c890c97b9aa5b4b32fcd66f35295b6
+    # The image already runs as node, which is uid/gid 1000, matching the
+    # ownership Umbrel gives app data. Stated explicitly so a future base-image
+    # change cannot silently move it and leave the data directory unwritable.
+    user: "1000:1000"
+    restart: on-failure
+    stop_grace_period: 1m
+    volumes:
+      # Everything worth keeping: the SQLite database, downloaded posters and
+      # the nightly backups. Nothing else in the container survives an update.
+      - ${APP_DATA_DIR}/data:/data

--- a/popcorn-vote/docker-compose.yml
+++ b/popcorn-vote/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   main:
-    image: ghcr.io/stadicus/popcorn-vote:1.3.0@sha256:115369d57f8fefd2aa952fe269c9fb7a0719319e86ac64f68bd6842631be404d
+    image: ghcr.io/stadicus/popcorn-vote:1.4.0@sha256:eb9e21d87780a45900bebaff5ea887d6d585bcb91e52aff96b79be3bb7d2b7c6
     # The image already runs as node, which is uid/gid 1000, matching the
     # ownership Umbrel gives app data. Stated explicitly so a future base-image
     # change cannot silently move it and leave the data directory unwritable.

--- a/popcorn-vote/umbrel-app.yml
+++ b/popcorn-vote/umbrel-app.yml
@@ -1,0 +1,57 @@
+manifestVersion: 1
+id: popcorn-vote
+category: media
+name: Popcorn Vote
+version: "1.2.0"
+tagline: Settle movie night fairly, with a vote instead of an argument
+description: >-
+  No more arguing about who gets to pick the film. Everyone suggests films,
+  everyone gets one vote a week, and votes can be saved up — so the film only
+  one person is longing for eventually gets its turn too.
+
+
+  Before movie night somebody presses Evaluate: the most votes win, a wheel of
+  fortune settles a tie, and the winner is announced with a burst of popcorn.
+  Watched films go into the archive with star ratings, a shared family film
+  diary.
+
+
+  Everything is set up in the browser on first start: the family PIN, who is in
+  the family, the film database keys and the languages. Nothing to edit, no
+  console needed.
+
+
+  - Mobile-first and installable as an app on Android and iOS
+
+
+  - One four-digit PIN for the whole family, with a brute-force brake, rather
+    than an account per person
+
+
+  - Posters, descriptions, runtimes, genres, IMDb ratings and trailers from TMDB
+    and OMDb; both are free for private use and each needs its own key, which
+    the setup asks for
+
+
+  - Nine interface languages: English, German, Spanish, French, Brazilian
+    Portuguese, Italian, Polish, Turkish and Japanese
+
+
+  This app is reached without an Umbrel login on purpose, so that everyone in
+  the family can use it from their own phone without the password to your
+  server. The four-digit PIN it asks for is a house key, not a safe: whoever
+  knows it can also spend other people's votes. Inside one family that is the
+  point.
+releaseNotes: ""
+developer: Stadicus
+website: https://popcornvote.org
+dependencies: []
+repo: https://github.com/Stadicus/popcorn-vote
+support: https://github.com/Stadicus/popcorn-vote/issues
+port: 3019
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: Stadicus
+submission: ""

--- a/popcorn-vote/umbrel-app.yml
+++ b/popcorn-vote/umbrel-app.yml
@@ -42,7 +42,7 @@ description: >-
   server. The four-digit PIN it asks for is a house key, not a safe: whoever
   knows it can also spend other people's votes. Inside one family that is the
   point.
-releaseNotes: "Updates Popcorn Vote to version 1.3.0. See the full release notes at https://github.com/Stadicus/popcorn-vote/releases/tag/v1.3.0."
+releaseNotes: ""
 developer: Stadicus
 website: https://popcornvote.org
 dependencies: []

--- a/popcorn-vote/umbrel-app.yml
+++ b/popcorn-vote/umbrel-app.yml
@@ -54,4 +54,4 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: Stadicus
-submission: ""
+submission: https://github.com/getumbrel/umbrel-apps/pull/5994

--- a/popcorn-vote/umbrel-app.yml
+++ b/popcorn-vote/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: popcorn-vote
 category: media
 name: Popcorn Vote
-version: "1.2.0"
+version: "1.3.0"
 tagline: Settle movie night fairly, with a vote instead of an argument
 description: >-
   No more arguing about who gets to pick the film. Everyone suggests films,
@@ -42,7 +42,7 @@ description: >-
   server. The four-digit PIN it asks for is a house key, not a safe: whoever
   knows it can also spend other people's votes. Inside one family that is the
   point.
-releaseNotes: ""
+releaseNotes: "Updates Popcorn Vote to version 1.3.0. See the full release notes at https://github.com/Stadicus/popcorn-vote/releases/tag/v1.3.0."
 developer: Stadicus
 website: https://popcornvote.org
 dependencies: []

--- a/popcorn-vote/umbrel-app.yml
+++ b/popcorn-vote/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: popcorn-vote
 category: media
 name: Popcorn Vote
-version: "1.3.0"
+version: "1.4.0"
 tagline: Settle movie night fairly, with a vote instead of an argument
 description: >-
   No more arguing about who gets to pick the film. Everyone suggests films,


### PR DESCRIPTION
## Type

New app

## App

App ID: `popcorn-vote`
Upstream project: https://github.com/Stadicus/popcorn-vote
Version: 1.3.0

## Summary

Popcorn Vote settles family movie night with a vote instead of an argument.
Everyone suggests films, everyone gets one vote a week, and unspent votes carry
over, so the film only one person is longing for eventually gets its turn.
Before movie night somebody presses Evaluate, the most votes win, a wheel of
fortune settles a tie, and watched films go into an archive with star ratings.

It is self-hosted, MIT-licensed, has no accounts and no cloud component, and
stores everything in a single SQLite file under the app's data directory.

## Verification

Umbrel testing performed:

Tested on a real, isolated umbrelOS 1.7.4 VM (amd64, KVM/UEFI, 4 GiB RAM; ISO
SHA-256 verified), with this package served through Umbrel's App Store source
at the exact digest pinned below:

- Fresh install through Umbrel's app lifecycle API reached state `ready`; the
  main container was healthy and `app_proxy` routed to the first-run setup.
- Completed the browser setup (family PIN, several members). Configuration and
  SQLite data landed under Umbrel-managed app data, owned by `umbrel:umbrel`,
  config file mode `0600`.
- `apps.restart`: back to `ready`, persisted configuration reloaded, an
  unauthenticated request is routed by the proxy to the app's PIN page.
- Full graceful VM reboot: app back to `ready`, proxy path reachable with
  `PROXY_AUTH_ADD: "false"`, the app's own PIN gate active.
- Settled proxy and app logs contain no actionable error. No external film API
  keys were used.

In addition, the container was exercised the way the store runs it (data owned
`1000:1000`, `--user 1000:1000`) by `packaging/test-install.sh` in the app's
repository: first start, `/healthz`, setup wizard, completing setup, no longer
offering it afterwards, container replacement (update), restart, another host
port, and restoring a copied data directory. CI runs this natively on amd64 and
arm64.

`.tools/lint-apps.mjs popcorn-vote --check-images` reports no errors and no
warnings besides the `submission` field, which this pull request fills in.

Environment tested:
- [ ] Umbrel device
- [x] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [x] arm64

The umbrelOS VM run covers amd64; arm64 was run under QEMU emulation against
the same multi-arch index, not on physical ARM hardware.

Known lint warnings or caveats: none.

## Notes

**`PROXY_AUTH_ADD: "false"` is deliberate, and the reason is who the app is
for.** It is not that the app's own login would break behind the Umbrel proxy.
Popcorn Vote is used by the whole family from their own phones, while the Umbrel
login belongs to whoever runs the server. Leaving Umbrel auth in front would
mean handing the server password to the children in order to let them vote on a
film. The app asks for a four-digit family PIN instead, rate-limited per
address, which is the right size of lock for the job: a house key, not a safe.

**No default credentials.** Nothing is configured up front. The first visit
opens a setup wizard in the browser that asks for the family PIN, who is in the
family, the film database keys and the languages. No shell, no file editing.

**API keys.** Posters, descriptions, runtimes, genres, ratings and trailers come
from TMDB and OMDb. Both are free for private use and each needs its own key,
which the setup asks for. The app installs and starts without them.

**Dependencies and migrations:** none. Single container, single SQLite file
under `${APP_DATA_DIR}/data`, which is everything worth backing up.

**Port:** 3019. 3009 was the first choice and is free across the manifests, but
`.tools/lint-apps.mjs` correctly points out that samourai-server's `nginx`
compose service publishes it.

**Image** is pinned to the digest of the multi-arch index
(`linux/amd64` + `linux/arm64`), built and published by GitHub Actions from the
tagged release: https://github.com/Stadicus/popcorn-vote/releases/tag/v1.3.0

### Gallery images

Ready-made gallery slides in the store's 2880 × 1800 format, in case they save
you work; use or replace them as you see fit. Built from 3× captures of a demo
instance, sources in the app repository under `docs/store-gallery/`.

| | |
|---|---|
| ![Popcorn Vote](https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/docs/store-gallery/1.jpg) | ![Votes](https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/docs/store-gallery/2.jpg) |
| ![Tie wheel](https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/docs/store-gallery/3.jpg) | ![TV mode](https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/docs/store-gallery/4.jpg) |
| ![Archive](https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/docs/store-gallery/5.jpg) | |

### Screenshots

| | |
|---|---|
| ![Movie night](https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/docs/screenshots/movie-night.png) | ![Movie list](https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/docs/screenshots/movie-list.png) |
| ![Winner](https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/docs/screenshots/winner.png) | ![Tie wheel](https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/docs/screenshots/tie-wheel.png) |
| ![Search](https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/docs/screenshots/movie-search.png) | ![Settings](https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/docs/screenshots/settings.png) |

Logo: https://raw.githubusercontent.com/Stadicus/popcorn-vote/main/docs/website/assets/popcorn-vote-icon-512.png

