### PR TITLE
yuvomi: update to v2.23.1

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:2.16.1@sha256:ef038c3eab85c29c39f216f21086a64083f47e710ca1f78a2bc55f80b280600d
+    image: ghcr.io/ulsklyc/yuvomi:2.23.1@sha256:8c0faefff998de55073ad561b0b239aa36ed3671bd2cfcf022848b9a07ff4b92
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "2.16.1"
+version: "2.23.1"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -51,19 +51,16 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  Editing a reward no longer replaces its icon with the word "null". Any reward
-  you had created without an icon lost it the first time you changed anything
-  else about it - the price, the name - and showed a stray piece of text in its
-  place. Clearing the description of a reward did the same to the description.
-
-
-  Rewards that already carry that text are cleaned up while the app starts,
-  including the copy kept in the redemption history, so there is nothing for you
-  to correct by hand.
+  The line under a birthday reads as separate facts again. Yesterday's update
+  took a tinted capsule off the countdown, and with it the only thing that had
+  been keeping the countdown apart from the date, the age and the note - "in 12
+  days 30.08.2026 turns 37 Linda's sister" ran together as one stretch of text.
+  The parts are separated again, and the note no longer sits flush against the
+  age either, which it had been doing for much longer than a day.
 
 
   Full release notes are available at
-  https://github.com/ulsklyc/yuvomi/releases/tag/v2.16.1
+  https://github.com/ulsklyc/yuvomi/releases/tag/v2.23.1
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db


### PR DESCRIPTION
Automated update of Yuvomi, prepared by the release workflow in `ulsklyc/yuvomi` and following this repo's `AGENTS.md`.

| | |
|---|---|
| Old version | `2.16.1` |
| New version | `2.23.1` |
| Upstream release | https://github.com/ulsklyc/yuvomi/releases/tag/v2.23.1 |
| Image | `ghcr.io/ulsklyc/yuvomi:2.23.1@sha256:8c0faefff998de55073ad561b0b239aa36ed3671bd2cfcf022848b9a07ff4b92` |
| Architectures | linux/amd64, linux/arm64 |
| Linter | passed (`node .tools/lint-apps.mjs yuvomi --check-images`) |

**Package changes**

- `yuvomi/docker-compose.yml`
- `yuvomi/umbrel-app.yml`

Manifest `version`, `releaseNotes` and the pinned image digest. No changes to compose wiring, env vars, volumes, ports, `app_proxy`, hooks, exports or permissions, so there is nothing for existing installs to migrate.

**Breaking changes**

None. This is a patch/minor upstream release; see the upstream notes above for the user-visible list.

**Testing performed**

- Upstream CI (`npm test`) green on the release commit.
- Image pulled from the public registry and pinned by the multi-arch index digest; `linux/amd64` and `linux/arm64` verified to be present in the manifest list.
- Manifest and compose parsed as YAML after editing.
- Repo linter: passed (`node .tools/lint-apps.mjs yuvomi --check-images`)

**Not tested**: the update path was not exercised through umbrelOS itself - this workflow has no Umbrel instance. The package change is limited to the manifest version, the release notes and the image digest.
