### PR TITLE
Add MomentBackup Hub

### DIFF
--- a/momentbackup-hub/docker-compose.yml
+++ b/momentbackup-hub/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: momentbackup-hub_server_1
+      APP_PORT: 8675
+      # Enrolled MomentBackup computers post to these four paths and cannot send an Umbrel
+      # session cookie, so they have to bypass Umbrel auth. Each request carries its own
+      # bearer token or Ed25519-signed body, which the Hub verifies. Everything a browser
+      # touches — the dashboard, /setup, /login — stays behind Umbrel auth.
+      PROXY_AUTH_WHITELIST: "/api/heartbeat,/api/poll,/api/poll/result,/api/enroll/claim"
+
+  server:
+    image: ghcr.io/momentbackup/momentbackup-hub:1.0.6@sha256:105fdd243ef9df29cfda71f8a9b0ab0a7eef35512646a609452b634ebf49b234
+    user: "1000:1000"
+    restart: on-failure
+    init: true
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    stop_grace_period: 1m
+    volumes:
+      - ${APP_DATA_DIR}/data/hub:/data
+    environment:
+      # umbrelOS terminates nothing and serves apps over plain HTTP, so the Hub's own TLS is
+      # off and app_proxy is the only front door. The Hub refuses sign-in, enrollment,
+      # heartbeats, and command polls over plaintext unless this is set, and it prints what
+      # that exposes at every boot.
+      MBHUB_INSECURE: "1"
+      # The exact origin enrolled computers use. Changing it later means enrolling every
+      # computer again.
+      MBHUB_PUBLIC_URL: "http://${DEVICE_DOMAIN_NAME}:${APP_PROXY_PORT}"
+      # Empty means heartbeat mode: each MomentBackup app posts its own signed status report,
+      # and the Hub needs no access to the backup destinations.
+      MBHUB_SCAN_PATHS: ""
+      MBHUB_HEARTBEAT: "on"

--- a/momentbackup-hub/umbrel-app.yml
+++ b/momentbackup-hub/umbrel-app.yml
@@ -1,0 +1,52 @@
+manifestVersion: 1
+id: momentbackup-hub
+category: files
+name: MomentBackup Hub
+version: "1.0.6"
+tagline: One page showing whether each computer's backups are current
+description: >-
+  Open the app and create the owner account straight away. Until that account exists, anyone who
+  can reach the app can create it and take the Hub.
+
+
+  umbrelOS reaches apps over plain HTTP on your local network, so this package runs the Hub
+  without its own TLS and puts it behind Umbrel's app proxy. The dashboard is protected by your
+  Umbrel login. The four paths enrolled computers post to bypass Umbrel auth, because those
+  computers cannot send an Umbrel session cookie; each request carries its own token, which the
+  Hub checks. Those requests and the Hub's own sign-in travel unencrypted on your network, as
+  every other umbrelOS app does.
+
+
+  MomentBackup Hub is a free, self-hosted overview of MomentBackup backups. It shows whether each
+  computer is protected, when it last backed up and verified, and which computers need attention.
+  It is a companion to MomentBackup, the paid personal backup and recovery app for Windows,
+  macOS, and Linux.
+
+
+  There is no account with the vendor, no telemetry, no licence check, and no update check. The
+  Hub stores no backup data, and it never holds a backup encryption key, passphrase, or
+  destination credential. Notifications by ntfy, webhook, or SMTP are the only outbound
+  connections it makes, and it makes none until you configure one.
+
+
+  It runs in heartbeat mode: each MomentBackup app posts its own signed status report to the Hub,
+  so the Hub needs no access to the backup destinations. MomentBackup 1.0.13 or later is required
+  to join a Hub.
+
+
+  Everything the Hub knows lives in its app data: its signing identity, your sign-ins, which
+  signing key each computer is trusted under, and its audit history. Losing it means enrolling
+  every computer again, so keep Umbrel backups on for this app.
+releaseNotes: ""
+developer: Watari Labs Pty Ltd
+website: https://momentbackup.com
+dependencies: []
+repo: https://github.com/MomentBackup/momentbackup-hub/pkgs/container/momentbackup-hub
+support: https://momentbackup.com/support/
+port: 8677
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: Watari Labs Pty Ltd
+submission: https://github.com/getumbrel/umbrel-apps/pull/SUBMISSION_PR

--- a/momentbackup-hub/umbrel-app.yml
+++ b/momentbackup-hub/umbrel-app.yml
@@ -49,4 +49,4 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: Watari Labs Pty Ltd
-submission: https://github.com/getumbrel/umbrel-apps/pull/SUBMISSION_PR
+submission: https://github.com/getumbrel/umbrel-apps/pull/5997


### PR DESCRIPTION
## Type

New app

## App

App ID: `momentbackup-hub`
Upstream project: MomentBackup Hub by Watari Labs Pty Ltd — <https://momentbackup.com/hub/>
Version: 1.0.6

## Summary

MomentBackup Hub is a free, self-hosted overview of MomentBackup backups. It shows whether each computer is protected, when it last backed up and verified, and which computers need attention. It is a companion to MomentBackup, the paid personal backup and recovery app for Windows, macOS, and Linux.

There is no account with the vendor, no telemetry, no licence check, and no update check. The Hub stores no backup data, and it never holds a backup encryption key, passphrase, or destination credential. Notifications by ntfy, webhook, or SMTP are the only outbound connections it can make, and it makes none until one is configured.

It runs in heartbeat mode: each MomentBackup app posts its own Ed25519-signed status report, so the Hub needs no access to the backup destinations. It opens to a first-run page that creates the owner account, then to the dashboard — no SSH, no CLI, no file edits.

| | |
|---|---|
| Image | `ghcr.io/momentbackup/momentbackup-hub:1.0.6@sha256:105fdd243ef9df29cfda71f8a9b0ab0a7eef35512646a609452b634ebf49b234` |
| Platforms | `linux/amd64`, `linux/arm64` (multi-arch index digest, both built natively) |
| Manifest port | 8677 (`APP_PORT` 8675 internally) |
| Category | files |
| Repo field | public package page — the Hub's source tree is private |

## Transport: the upstream normally serves HTTPS, and this package turns that off

This is the one decision worth reviewing.

The Hub refuses every credential-carrying request over plaintext by default — creating the owner account, signing in, enrolling a computer, posting a heartbeat, and every command poll — and normally serves HTTPS on 8675 with a certificate it generates itself, which enrolled computers pin.

That does not compose with `app_proxy`. `app_proxy` does expose `APP_PROTOCOL`, but the target would be an upstream with a self-signed certificate that `http-proxy-middleware` rejects by default, the browser leg would still be plain HTTP, and `MBHUB_PUBLIC_URL` would have to name an `https://` origin that umbrelOS never serves.

So this package sets `MBHUB_INSECURE: "1"`. The Hub then serves plain HTTP on 8675 behind `app_proxy`, `MBHUB_PUBLIC_URL` is `http://${DEVICE_DOMAIN_NAME}:${APP_PROXY_PORT}`, and the boot log states plainly what that exposes. Practically: sign-in passwords, session cookies, and each enrolled computer's long-lived command token cross the local network unencrypted — the same posture as every other umbrelOS app, but worth naming here because this app's own docs treat it as the weakest of its three transport options. It is stated in the app description rather than buried.

`MBHUB_TRUST_PROXY=1` would also make the Hub serve HTTP, but it means "something in front of me terminated TLS", which is not true on umbrelOS. `MBHUB_INSECURE` is the accurate one.

## `PROXY_AUTH_WHITELIST`

```
/api/heartbeat,/api/poll,/api/poll/result,/api/enroll/claim
```

Those are the only four paths enrolled MomentBackup computers post to, and they cannot carry an Umbrel session cookie. Each request carries its own bearer token or Ed25519-signed body, which the Hub verifies; the list is exact paths, not a `/api/*` glob, so the dashboard's own `GET /api/status` and `/api/v1/*` stay behind Umbrel auth along with `/setup`, `/login`, and every page.

Umbrel auth in front of `/setup` is a real improvement here: on a bare deployment whoever reaches `/setup` first claims the Hub, and behind Umbrel auth that race is closed.

## Verification

Umbrel testing performed: none — I have no umbrelOS device or test environment. Please treat this as untested through Umbrel.

Environment tested:
- [ ] Umbrel device
- [ ] Local umbrelOS test environment
- [x] Not runtime tested

Architecture tested:
- [ ] amd64
- [ ] arm64

What I did verify:

- `npm run lint:apps -- momentbackup-hub --check-images` → **0 errors, 1 warning** (below)
- `git diff --check` → clean
- Image tag, index digest, and both platforms confirmed against the GHCR manifest list; the image is public and pulls with no credentials
- Port 8677 is free across every `umbrel-app.yml` `port:` and every host-published compose port in this repo (8675 and 8676 are taken)

Known lint warnings or caveats:

```
WARNING access.security_opt momentbackup-hub/docker-compose.yml:24
  Service `server` sets security options; justify this in the PR.
```

That is `no-new-privileges:true`, alongside `read_only: true` with `tmpfs: [/tmp]` and `cap_drop: [ALL]`. It is a restriction, not an escalation: the Hub writes only to `/data`, binds an unprivileged port, and never executes anything else, so it needs none of what those remove. Happy to drop them if you would rather packages not set `security_opt` at all.

## Notes

- **Persistence.** `${APP_DATA_DIR}/data/hub:/data` holds the Hub's command-signing identity, sign-in hashes, sealed two-factor secrets, which key each computer is trusted under, and the audit chain. Losing it means enrolling every computer again, so it should not be in `backupIgnore`. `data/hub/.gitkeep` is committed.
- **User.** The image defaults to uid/gid 10001 but supports any uid; this package runs `1000:1000` to match Umbrel's app-data ownership.
- **No host access.** No Docker socket, no privileged mode, no host networking, no device or host mounts, no permissions, no dependencies. One container plus `app_proxy`.
- **Client requirement.** Joining a Hub needs MomentBackup 1.0.13 or later on each computer. The Hub is free; the desktop app it reports on is paid. Restores never involve the Hub and are never licence-gated.
- **Source is private.** `repo:` points at the public GHCR package page, <https://github.com/MomentBackup/momentbackup-hub/pkgs/container/momentbackup-hub>. `website:` is <https://momentbackup.com>, and the reference compose plus the full configuration prose is at <https://momentbackup.com/hub/>. Every published tag keeps its own digest and keyless cosign signature; the verification command is on that page.
- **`submission:`** is set to this PR's URL.

### Assets

`gallery: []` and no `icon`, per the packaging guide.

- Logo source (SVG): <https://momentbackup.com/favicon.svg>
- Screenshot: not linked yet. The dashboard screenshot currently published on the vendor site carries stale UI wording that is being corrected upstream, and I would rather not hand you an asset that is about to be wrong. I will post a current screenshot in this thread as soon as the replacement is published — please tell me if you need it before review can start.
