### PR TITLE
Add Cantinarr

### DIFF
--- a/cantinarr/docker-compose.yml
+++ b/cantinarr/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: ghcr.io/windoze95/cantinarr:0.6.0@sha256:3701a2f596261f5f569cc85dc5ab82a6cee6f0bd2afc9310ac00ff387c81aa98
+    image: ghcr.io/windoze95/cantinarr:0.7.0@sha256:ada2c0a075668f1b7ddfa05b2b8d7e059db0a75238f211bb1b960e7ca42d5d08
     restart: on-failure
     environment:
       CANTINARR_PUSH_GATEWAY_URL: "https://push.julian.codes"

--- a/cantinarr/docker-compose.yml
+++ b/cantinarr/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     image: ghcr.io/windoze95/cantinarr:0.8.0@sha256:21bc13d84e6f5ba656eae3176f0947dff1ffa80b0d74072afdf2e6a15c014371
     restart: on-failure
     environment:
-      CANTINARR_PUSH_GATEWAY_URL: "https://push.julian.codes"
+      CANTINARR_PUSH_GATEWAY_URL: "https://push.cantinarr.com"
       # Origin the Radarr/Sonarr/Chaptarr containers POST webhooks back to.
       # Cross-app container DNS works on Umbrel, so point them at this container.
       CANTINARR_ARR_CALLBACK_URL: "http://cantinarr_server_1:8585"

--- a/cantinarr/docker-compose.yml
+++ b/cantinarr/docker-compose.yml
@@ -11,13 +11,13 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: ghcr.io/windoze95/cantinarr:0.2.0@sha256:87fea4db9ce2278842c9b33a2276b199ca767021e61d4c345027ea15c02cf36d
+    image: ghcr.io/windoze95/cantinarr:0.3.0@sha256:d49dd64daf7f7b0c90dd56989b565783130b9ddf24603a4ec8317c55d6bd1797
     restart: on-failure
     environment:
       CANTINARR_PUSH_GATEWAY_URL: "https://push.julian.codes"
       # Origin the Radarr/Sonarr/Chaptarr containers POST webhooks back to.
       # Cross-app container DNS works on Umbrel, so point them at this container.
-      CANTINARR_PUBLIC_URL: "http://cantinarr_server_1:8585"
+      CANTINARR_ARR_CALLBACK_URL: "http://cantinarr_server_1:8585"
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
     healthcheck:

--- a/cantinarr/docker-compose.yml
+++ b/cantinarr/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: ghcr.io/windoze95/cantinarr:0.7.0@sha256:ada2c0a075668f1b7ddfa05b2b8d7e059db0a75238f211bb1b960e7ca42d5d08
+    image: ghcr.io/windoze95/cantinarr:0.8.0@sha256:21bc13d84e6f5ba656eae3176f0947dff1ffa80b0d74072afdf2e6a15c014371
     restart: on-failure
     environment:
       CANTINARR_PUSH_GATEWAY_URL: "https://push.julian.codes"

--- a/cantinarr/docker-compose.yml
+++ b/cantinarr/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: cantinarr_server_1
+      APP_PORT: 8585
+      # Cantinarr is multi-user with its own auth: household members join via
+      # connect links and the companion phone apps talk REST/WebSocket to this
+      # server, none of which can carry Umbrel auth cookies.
+      PROXY_AUTH_ADD: "false"
+
+  server:
+    image: ghcr.io/windoze95/cantinarr:0.2.0@sha256:87fea4db9ce2278842c9b33a2276b199ca767021e61d4c345027ea15c02cf36d
+    restart: on-failure
+    environment:
+      CANTINARR_PUSH_GATEWAY_URL: "https://push.julian.codes"
+      # Origin the Radarr/Sonarr/Chaptarr containers POST webhooks back to.
+      # Cross-app container DNS works on Umbrel, so point them at this container.
+      CANTINARR_PUBLIC_URL: "http://cantinarr_server_1:8585"
+    volumes:
+      - ${APP_DATA_DIR}/data/config:/config
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:8585/api/health || exit 1
+      start_period: 20s
+      timeout: 5s
+      interval: 30s
+      retries: 3

--- a/cantinarr/docker-compose.yml
+++ b/cantinarr/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: ghcr.io/windoze95/cantinarr:0.8.0@sha256:21bc13d84e6f5ba656eae3176f0947dff1ffa80b0d74072afdf2e6a15c014371
+    image: ghcr.io/windoze95/cantinarr:0.9.0@sha256:7e1d148ec4ae90ed1ac194cfd715294867cbc807b2c32193ef96deaf66a4d154
     restart: on-failure
     environment:
       CANTINARR_PUSH_GATEWAY_URL: "https://push.cantinarr.com"

--- a/cantinarr/docker-compose.yml
+++ b/cantinarr/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: ghcr.io/windoze95/cantinarr:0.5.0@sha256:b16cf256eeb543cb13c16dedfeaf342bc2a85dabef7d647645720251873f6996
+    image: ghcr.io/windoze95/cantinarr:0.6.0@sha256:3701a2f596261f5f569cc85dc5ab82a6cee6f0bd2afc9310ac00ff387c81aa98
     restart: on-failure
     environment:
       CANTINARR_PUSH_GATEWAY_URL: "https://push.julian.codes"

--- a/cantinarr/docker-compose.yml
+++ b/cantinarr/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: ghcr.io/windoze95/cantinarr:0.3.0@sha256:d49dd64daf7f7b0c90dd56989b565783130b9ddf24603a4ec8317c55d6bd1797
+    image: ghcr.io/windoze95/cantinarr:0.4.0@sha256:9f832c0d1db5a11f787db20632218ac1f76c555514778d8af1f5de6790921b37
     restart: on-failure
     environment:
       CANTINARR_PUSH_GATEWAY_URL: "https://push.julian.codes"

--- a/cantinarr/docker-compose.yml
+++ b/cantinarr/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: ghcr.io/windoze95/cantinarr:0.4.0@sha256:9f832c0d1db5a11f787db20632218ac1f76c555514778d8af1f5de6790921b37
+    image: ghcr.io/windoze95/cantinarr:0.5.0@sha256:b16cf256eeb543cb13c16dedfeaf342bc2a85dabef7d647645720251873f6996
     restart: on-failure
     environment:
       CANTINARR_PUSH_GATEWAY_URL: "https://push.julian.codes"

--- a/cantinarr/docker-compose.yml
+++ b/cantinarr/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: ghcr.io/windoze95/cantinarr:0.10.0@sha256:20a49827de845f6cb97dfc0a3175e241b596637d4630185439978487ab187629
+    image: ghcr.io/windoze95/cantinarr:0.10.1@sha256:b3a7c729f061a0c1c54936ae0ce2b34ae4e67a94a27da04c26c5ad1dcaa1dd73
     restart: on-failure
     environment:
       CANTINARR_PUSH_GATEWAY_URL: "https://push.cantinarr.com"

--- a/cantinarr/docker-compose.yml
+++ b/cantinarr/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: ghcr.io/windoze95/cantinarr:0.9.0@sha256:7e1d148ec4ae90ed1ac194cfd715294867cbc807b2c32193ef96deaf66a4d154
+    image: ghcr.io/windoze95/cantinarr:0.10.0@sha256:20a49827de845f6cb97dfc0a3175e241b596637d4630185439978487ab187629
     restart: on-failure
     environment:
       CANTINARR_PUSH_GATEWAY_URL: "https://push.cantinarr.com"

--- a/cantinarr/umbrel-app.yml
+++ b/cantinarr/umbrel-app.yml
@@ -42,4 +42,4 @@ defaultUsername: ""
 defaultPassword: ""
 
 submitter: windoze95
-submission: https://github.com/getumbrel/umbrel-apps
+submission: https://github.com/getumbrel/umbrel-apps/pull/5998

--- a/cantinarr/umbrel-app.yml
+++ b/cantinarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: cantinarr
 category: media
 name: Cantinarr
-version: "0.8.0"
+version: "0.9.0"
 tagline: Your media server just learned to run itself
 description: >-
   Cantinarr is one app over your whole media stack. The people in your house browse, request movies, TV, books, and music from the web app or the companion iPhone and Android apps, and get a push notification when something is ready. You get everything behind that: Radarr, Sonarr, Chaptarr, and Lidarr controlled down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, and Plex invites.

--- a/cantinarr/umbrel-app.yml
+++ b/cantinarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: cantinarr
 category: media
 name: Cantinarr
-version: "0.2.0"
+version: "0.3.0"
 tagline: Your media server just learned to run itself
 description: >-
   Cantinarr is one app over your whole media stack. The people in your house browse, request movies, TV, and books from the web app or the companion iPhone and Android apps, and get a push notification when something is ready. You get everything behind that: Radarr, Sonarr, and Chaptarr controlled down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, and Plex invites.

--- a/cantinarr/umbrel-app.yml
+++ b/cantinarr/umbrel-app.yml
@@ -1,0 +1,45 @@
+manifestVersion: 1
+id: cantinarr
+category: media
+name: Cantinarr
+version: "0.2.0"
+tagline: Your media server just learned to run itself
+description: >-
+  Cantinarr is one app over your whole media stack. The people in your house browse, request movies, TV, and books from the web app or the companion iPhone and Android apps, and get a push notification when something is ready. You get everything behind that: Radarr, Sonarr, and Chaptarr controlled down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, and Plex invites.
+
+
+  It is also an MCP server: connect Claude or any MCP client and manage your library with the same tools that power the built-in AI agents. No one but you sees an API key or a quality profile.
+
+
+  When a download gets stuck, Cantinarr reads what your services already know and tells you in plain English what went wrong, then offers to fix it. You can also turn the agent on. It watches for the same problems, waits to see whether Sonarr or Radarr sorts things out on its own, and only then brings you something to approve. You set what it is allowed to do, and nothing destructive happens without your approval.
+
+
+  Cantinarr uses its own accounts, so Umbrel's app login is bypassed for it: the web app opens ready for you, and household members and the phone apps sign in through connect links you send them. Sign-in is passwordless by default, with passwords and passkeys available if you want them. API keys and download client passwords are AES-256-GCM encrypted in Cantinarr's database and never come back out through the API.
+
+
+  🛠️ SET-UP INSTRUCTIONS
+
+
+  When adding your services inside Cantinarr, you can use the following addresses:
+    - **Radarr:** radarr_server_1:7878
+    - **Sonarr:** sonarr_server_1:8989
+
+
+  For other services, use your Umbrel device's IP address and the service's port. You can find your device's IP address in the Umbrel Settings.
+releaseNotes: ""
+
+developer: windoze95
+website: https://cantinarr.com
+dependencies: []
+repo: https://github.com/windoze95/cantinarr
+support: https://github.com/windoze95/cantinarr/issues
+
+port: 8585
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+submitter: windoze95
+submission: https://github.com/getumbrel/umbrel-apps

--- a/cantinarr/umbrel-app.yml
+++ b/cantinarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: cantinarr
 category: media
 name: Cantinarr
-version: "0.4.0"
+version: "0.5.0"
 tagline: Your media server just learned to run itself
 description: >-
   Cantinarr is one app over your whole media stack. The people in your house browse, request movies, TV, and books from the web app or the companion iPhone and Android apps, and get a push notification when something is ready. You get everything behind that: Radarr, Sonarr, and Chaptarr controlled down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, and Plex invites.

--- a/cantinarr/umbrel-app.yml
+++ b/cantinarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: cantinarr
 category: media
 name: Cantinarr
-version: "0.6.0"
+version: "0.7.0"
 tagline: Your media server just learned to run itself
 description: >-
   Cantinarr is one app over your whole media stack. The people in your house browse, request movies, TV, and books from the web app or the companion iPhone and Android apps, and get a push notification when something is ready. You get everything behind that: Radarr, Sonarr, and Chaptarr controlled down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, and Plex invites.

--- a/cantinarr/umbrel-app.yml
+++ b/cantinarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: cantinarr
 category: media
 name: Cantinarr
-version: "0.5.0"
+version: "0.6.0"
 tagline: Your media server just learned to run itself
 description: >-
   Cantinarr is one app over your whole media stack. The people in your house browse, request movies, TV, and books from the web app or the companion iPhone and Android apps, and get a push notification when something is ready. You get everything behind that: Radarr, Sonarr, and Chaptarr controlled down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, and Plex invites.

--- a/cantinarr/umbrel-app.yml
+++ b/cantinarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: cantinarr
 category: media
 name: Cantinarr
-version: "0.3.0"
+version: "0.4.0"
 tagline: Your media server just learned to run itself
 description: >-
   Cantinarr is one app over your whole media stack. The people in your house browse, request movies, TV, and books from the web app or the companion iPhone and Android apps, and get a push notification when something is ready. You get everything behind that: Radarr, Sonarr, and Chaptarr controlled down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, and Plex invites.

--- a/cantinarr/umbrel-app.yml
+++ b/cantinarr/umbrel-app.yml
@@ -5,7 +5,7 @@ name: Cantinarr
 version: "0.8.0"
 tagline: Your media server just learned to run itself
 description: >-
-  Cantinarr is one app over your whole media stack. The people in your house browse, request movies, TV, and books from the web app or the companion iPhone and Android apps, and get a push notification when something is ready. You get everything behind that: Radarr, Sonarr, and Chaptarr controlled down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, and Plex invites.
+  Cantinarr is one app over your whole media stack. The people in your house browse, request movies, TV, books, and music from the web app or the companion iPhone and Android apps, and get a push notification when something is ready. You get everything behind that: Radarr, Sonarr, Chaptarr, and Lidarr controlled down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, and Plex invites.
 
 
   It is also an MCP server: connect Claude or any MCP client and manage your library with the same tools that power the built-in AI agents. No one but you sees an API key or a quality profile.

--- a/cantinarr/umbrel-app.yml
+++ b/cantinarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: cantinarr
 category: media
 name: Cantinarr
-version: "0.7.0"
+version: "0.8.0"
 tagline: Your media server just learned to run itself
 description: >-
   Cantinarr is one app over your whole media stack. The people in your house browse, request movies, TV, and books from the web app or the companion iPhone and Android apps, and get a push notification when something is ready. You get everything behind that: Radarr, Sonarr, and Chaptarr controlled down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, and Plex invites.

--- a/cantinarr/umbrel-app.yml
+++ b/cantinarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: cantinarr
 category: media
 name: Cantinarr
-version: "0.9.0"
+version: "0.10.0"
 tagline: Your media server just learned to run itself
 description: >-
   Cantinarr is one app over your whole media stack. The people in your house browse, request movies, TV, books, and music from the web app or the companion iPhone and Android apps, and get a push notification when something is ready. You get everything behind that: Radarr, Sonarr, Chaptarr, and Lidarr controlled down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, and Plex invites.

--- a/cantinarr/umbrel-app.yml
+++ b/cantinarr/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: cantinarr
 category: media
 name: Cantinarr
-version: "0.10.0"
+version: "0.10.1"
 tagline: Your media server just learned to run itself
 description: >-
   Cantinarr is one app over your whole media stack. The people in your house browse, request movies, TV, books, and music from the web app or the companion iPhone and Android apps, and get a push notification when something is ready. You get everything behind that: Radarr, Sonarr, Chaptarr, and Lidarr controlled down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, and Plex invites.


### PR DESCRIPTION
## Type

New app

## App

App ID: cantinarr
Upstream project: https://github.com/windoze95/cantinarr
Version: 0.14.0
Upstream release: https://github.com/windoze95/cantinarr/releases/tag/v0.14.0

## Summary

Adds Cantinarr, a self-hosted media-stack manager I develop: household members browse and request movies, TV, books, and music (from the web app or the companion iPhone/Android apps, with push notifications), and the admin gets Radarr/Sonarr/Chaptarr/Lidarr control down to the individual episode, live download queues (SABnzbd, qBittorrent, NZBGet, Transmission, Deluge, and rTorrent through ruTorrent), Tautulli/Tracearr monitoring, read-only Tdarr activity and library progress under Transcoding, Plex invites, plain-English diagnosis and fixes for stuck downloads, and an MCP server usable by Claude or any MCP client. Single container, one web port, all state under `${APP_DATA_DIR}/data/config`.

## Verification

This revision updates the unmerged submission from 0.13.0 to 0.14.0. The release adds read-only Tdarr activity/library progress grouped under Transcoding, optional issue notes, and admin issue reopening. The package changes only its version and image pin; ports, environment variables, authentication, and persistence are unchanged.

`npm run lint:apps -- cantinarr --check-images` and `git diff --check` pass with no issues. The public `0.14.0` image tag and pinned OCI index digest `sha256:58333230fbcc433ebf24cba72e996496219861b43d3379be1676bfd8a68aeea5` match and include linux/amd64 and linux/arm64. This is the exact tested candidate digest, promoted without rebuilding. The server reports `v0.14.0`; OCI version metadata retains the candidate identity `0.14.0-rc.1234`, and its source revision is `ab61a233e4d5442ad9b8147c7c42eac8cb1f01de`.

[Upstream main CI](https://github.com/windoze95/cantinarr/actions/runs/35033860252), [candidate CI](https://github.com/windoze95/cantinarr/actions/runs/35035314330), [multi-arch candidate build and smoke checks](https://github.com/windoze95/cantinarr/actions/runs/35035380282), and [stable promotion](https://github.com/windoze95/cantinarr/actions/runs/35048112573) passed. The release archives the exact server and combined verification receipts.

[Linux bundle publication](https://github.com/windoze95/cantinarr/actions/runs/35049719710) also passed after an upstream packaging-workflow repair. Both downloaded archives passed their SHA-256 checks, and their Cantinarr and Codex binaries exactly match the corresponding binaries from the tested image. The repair did not change the release tag or image.

On Docker Desktop on an arm64 Mac, the pinned image passed a native arm64 upgrade from a synthetic populated v0.13.0 config. Accounts, admin/requester device sessions, encrypted instance credentials, grants, requests, notification preferences, and issues survived the upgrade and restart. The nullable issue-reopening migration ran once, with valid SQLite integrity/foreign keys and WAL. Restoring the pre-upgrade database with its matching encryption key recovered the old server's data and session. Embedded web routing and bundled runtime notices passed.

The same digest's amd64 image, run with local emulation, passed fresh setup, authenticated version checks, the embedded Transcoding web bundle, and normalized activity/libraries/stats against a real disposable Tdarr 2.87.01 server with one idle node and no libraries. Anonymous and requester access was denied; the generic Tdarr proxy was also denied for admins. These tests cover the published containers, not installation through Umbrel. No independent physical amd64 host, active transcoding in this fixture, production-scale/oldest-supported DB upgrade, or physical phone/passkey/push checks were performed.

No configured local umbrelOS test environment was available; installation and upgrade through Umbrel were not tested. `releaseNotes` remains empty while this initial listing is unmerged.

Umbrel environment tested:

- [ ] Umbrel device
- [ ] Local umbrelOS test environment
- [x] Not runtime tested

Architecture tested through Umbrel:

- [ ] amd64
- [ ] arm64

Known lint warnings or caveats: none from the linter.

## Notes

- **`PROXY_AUTH_ADD: "false"`** — Cantinarr is multi-user with its own auth: the admin sends household members connect links (passwordless device sessions), and the companion iOS/Android apps talk REST + WebSocket to this server. Neither flow can carry Umbrel auth cookies, and Umbrel's wall would break onboarding for non-owner household members, so this is the "app with its own login that Umbrel auth would break" case rather than a `PROXY_AUTH_WHITELIST` case.
- `CANTINARR_ARR_CALLBACK_URL` is preset to `http://cantinarr_server_1:8585` so Radarr/Sonarr containers on the same Umbrel can POST webhooks back for instant library updates.
- `CANTINARR_PUSH_GATEWAY_URL` defaults to the project's push gateway (zero-config enrollment, no account); users can clear it to disable push or point it at a self-hosted gateway.
- No default credentials: first run opens Cantinarr's own setup, and sign-in is passwordless by default with passwords/passkeys available.

**Assets for the gallery team:**

- Logo (512 PNG): https://raw.githubusercontent.com/windoze95/cantinarr/main/app/web/icons/Icon-512.png
- Screenshots (desktop): https://raw.githubusercontent.com/windoze95/cantinarr-unraid/main/screenshots/01-discover.jpg · https://raw.githubusercontent.com/windoze95/cantinarr-unraid/main/screenshots/04-request.png · https://raw.githubusercontent.com/windoze95/cantinarr-unraid/main/screenshots/03-sonarr-library.jpg · https://raw.githubusercontent.com/windoze95/cantinarr-unraid/main/screenshots/02-issues.png
- Screenshots (phone): https://raw.githubusercontent.com/windoze95/cantinarr-unraid/main/screenshots/05-phone-discover.jpg · https://raw.githubusercontent.com/windoze95/cantinarr-unraid/main/screenshots/06-phone-seasons.jpg · https://raw.githubusercontent.com/windoze95/cantinarr-unraid/main/screenshots/07-phone-downloads.jpg
