### PR TITLE
Update Alby Hub to v1.24.0

### DIFF
--- a/albyhub/docker-compose.yml
+++ b/albyhub/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       APP_HOST: albyhub_server_1
       APP_PORT: 8080
   server:
-    image: ghcr.io/getalby/hub:v1.23.0@sha256:03074e1cb7a1814fcecedfd6e2bf2b2fe8643b2891db03cfb634076252138962
+    image: ghcr.io/getalby/hub:v1.24.0@sha256:0227bdc79afd20eb689c922c96cf0546576b608c5cbb07b13658956d54e8133d
     user: 1000:1000
     volumes:
       - ${APP_DATA_DIR}/data:/data

--- a/albyhub/umbrel-app.yml
+++ b/albyhub/umbrel-app.yml
@@ -3,7 +3,7 @@ id: albyhub
 name: Alby Hub ✨
 tagline: Self-custodial Lightning wallet with integrated node and app connections
 category: bitcoin
-version: "1.23.0"
+version: "1.24.0"
 port: 59000
 description: >-
   Alby Hub is an open-source, self-custodial Bitcoin Lightning wallet, with the easiest-to-use Lightning Network node for everyone.
@@ -40,12 +40,11 @@ gallery:
   - 4.jpg
 releaseNotes: >-
   Key changes in this release:
-    - Added Just-in-Time channels to automatically open inbound liquidity when needed
-    - Added a Cards page for one-click debit card top-ups
-    - Added an experimental Bark backend
-    - Redesigned the home page with stories and improved currency input
-    - Improved Core Lightning backend support
-    - Various bugfixes and minor improvements
+    - Refreshed payment QR codes and payment status screens
+    - Added transaction filtering
+    - Added invoice receiving for connected apps
+    - Improved wallet migrations, including PostgreSQL to SQLite
+    - Improved card naming and fixed security, reliability, and usability issues
 
 
   Full release notes are found at https://github.com/getAlby/hub/releases


### PR DESCRIPTION
## Summary

- update Alby Hub from v1.23.0 to v1.24.0
- pin the v1.24.0 multi-architecture OCI image digest
- refresh the Umbrel update notes with user-visible changes

Upstream release: https://github.com/getAlby/hub/releases/tag/v1.24.0

## Verification

- `npm ci`
- `npm run lint:apps -- albyhub --check-images`
- `git diff --check`
- verified the pinned OCI index digest and its `linux/amd64` and `linux/arm64` manifests against GHCR

An Umbrel device/local umbrelOS runtime was not available, so the installed-app update path was not exercised.
