### PR TITLE
yuvomi: update to v2.25.1

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:2.23.1@sha256:8c0faefff998de55073ad561b0b239aa36ed3671bd2cfcf022848b9a07ff4b92
+    image: ghcr.io/ulsklyc/yuvomi:2.25.1@sha256:7f075a1b0a03c1ecf4de0ee9f164bf8b2774a3c7a773bbaf9095b930d5ace9a2
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "2.23.1"
+version: "2.25.1"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -51,16 +51,25 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  The line under a birthday reads as separate facts again. Yesterday's update
-  took a tinted capsule off the countdown, and with it the only thing that had
-  been keeping the countdown apart from the date, the age and the note - "in 12
-  days 30.08.2026 turns 37 Linda's sister" ran together as one stretch of text.
-  The parts are separated again, and the note no longer sits flush against the
-  age either, which it had been doing for much longer than a day.
+  Wer einzelnen Mitgliedern oder Familienrollen den Zugriff auf Module
+  eingeschraenkt hat und zugleich einen Zugang fuer Skripte oder KI-Assistenten
+  vergibt, sollte dieses Update einspielen. Ein Mitglied, dem zum Beispiel die
+  Aufgaben entzogen waren, bekam sie in der App korrekt verweigert - ueber die
+  Schnittstelle fuer KI-Assistenten wurden sie ihm aber trotzdem herausgegeben,
+  lesend wie schreibend. Beide Wege halten sich jetzt an dieselben Rechte, und
+  dasselbe gilt fuer Gastkonten der geteilten Ausgaben, die ausserhalb ihres
+  Bereichs nichts mehr erreichen.
+
+
+  Einzustellen ist dafuer nichts: die vergebenen Rechte gelten ab dem Update
+  auch dort, und Haushalte ohne eingeschraenkte Mitglieder merken keinen
+  Unterschied. Wer diesen Zugang bisher bewusst nur Verwaltungskonten gegeben
+  hat, weil ein normales Mitglied darueber zu viel sehen konnte, kann ihn jetzt
+  wieder freigeben.
 
 
   Full release notes are available at
-  https://github.com/ulsklyc/yuvomi/releases/tag/v2.23.1
+  https://github.com/ulsklyc/yuvomi/releases/tag/v2.25.1
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -51,21 +51,17 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  Wer einzelnen Mitgliedern oder Familienrollen den Zugriff auf Module
-  eingeschraenkt hat und zugleich einen Zugang fuer Skripte oder KI-Assistenten
-  vergibt, sollte dieses Update einspielen. Ein Mitglied, dem zum Beispiel die
-  Aufgaben entzogen waren, bekam sie in der App korrekt verweigert - ueber die
-  Schnittstelle fuer KI-Assistenten wurden sie ihm aber trotzdem herausgegeben,
-  lesend wie schreibend. Beide Wege halten sich jetzt an dieselben Rechte, und
-  dasselbe gilt fuer Gastkonten der geteilten Ausgaben, die ausserhalb ihres
-  Bereichs nichts mehr erreichen.
+  This update fixes a permissions issue affecting integrations for scripts and
+  AI assistants. Previously, members with restricted access to modules such as
+  Tasks could still view or modify content in those modules through these
+  integrations. Guest accounts for Shared Expenses could also access tools
+  outside their permitted area.
 
 
-  Einzustellen ist dafuer nichts: die vergebenen Rechte gelten ab dem Update
-  auch dort, und Haushalte ohne eingeschraenkte Mitglieder merken keinen
-  Unterschied. Wer diesen Zugang bisher bewusst nur Verwaltungskonten gegeben
-  hat, weil ein normales Mitglied darueber zu viel sehen konnte, kann ihn jetzt
-  wieder freigeben.
+  Existing module permissions now apply consistently across the app and all
+  integrations. No configuration changes are required. If you previously
+  limited integration access to administrator accounts as a workaround, you can
+  now safely enable it for members with restricted permissions.
 
 
   Full release notes are available at


### PR DESCRIPTION
Automated update of Yuvomi, prepared by the release workflow in `ulsklyc/yuvomi` and following this repo's `AGENTS.md`.

| | |
|---|---|
| Old version | `2.23.1` |
| New version | `2.25.1` |
| Upstream release | https://github.com/ulsklyc/yuvomi/releases/tag/v2.25.1 |
| Image | `ghcr.io/ulsklyc/yuvomi:2.25.1@sha256:7f075a1b0a03c1ecf4de0ee9f164bf8b2774a3c7a773bbaf9095b930d5ace9a2` |
| Architectures | linux/amd64, linux/arm64 |
| Linter | passed (`node .tools/lint-apps.mjs yuvomi --check-images`) |

**Package changes**

- `yuvomi/docker-compose.yml`
- `yuvomi/umbrel-app.yml`

Manifest `version`, `releaseNotes` and the pinned image digest. No changes to compose wiring, env vars, volumes, ports, `app_proxy`, hooks, exports or permissions, so there is nothing for existing installs to migrate.

**Breaking changes**

None. This is a patch/minor upstream release; see the upstream notes above for the user-visible list.

**Testing performed**

- Upstream CI (`npm test`) green on the release commit.
- Image pulled from the public registry and pinned by the multi-arch index digest; `linux/amd64` and `linux/arm64` verified to be present in the manifest list.
- Manifest and compose parsed as YAML after editing.
- Repo linter: passed (`node .tools/lint-apps.mjs yuvomi --check-images`)

**Not tested**: the update path was not exercised through umbrelOS itself - this workflow has no Umbrel instance. The package change is limited to the manifest version, the release notes and the image digest.
