### PR TITLE
lightning-terminal: update to `v0.17.2-alpha`

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.17.0-alpha@sha256:fd6d6040f78e0a342437312f3a3c154f4b63d79172c6b466e2dfd242b06b4a1c
+    image: lightninglabs/lightning-terminal:v0.17.2-alpha-docker@sha256:76f6ff1785cfeba76cacc3d4baa17beb57f2e0b8354c65e2c9a98cb940988e79
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.17.0-alpha"
+version: "0.17.2-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -58,12 +58,8 @@ deterministicPassword: true
 releaseNotes: >-
   ⚠️ Please update your Lightning Node app to the latest version available in the app store to ensure compatibility with Lightning Terminal.
 
-
-  This update automatically migrates Lightning Terminal's internal database from bbolt to SQLite on first startup. No action is required, but the first startup after updating may take longer than usual while the migration runs.
-
-
-  This version of Lightning Terminal (LiT) ships lnd v0.21.1-beta, loop v0.33.3-beta, faraday v0.2.16-alpha,
-  pool v0.7.1-beta and tapd v0.8.0.
+  This version of Lightning Terminal (LiT) ships lnd v0.21.2-beta, loop v0.34.0-beta-v0.8.1-tapd, faraday v0.2.16-alpha,
+  pool v0.7.1-beta and tapd v0.8.1.
 
 
   IMPORTANT NOTE: To avoid loss of funds, it's imperative that you read the
@@ -101,7 +97,7 @@ releaseNotes: >-
   feedback from the community.
 
 
-  This release packages LND v0.21.1-beta, Taproot Assets Daemon v0.8.0,
-  Loop v0.33.3-beta, Pool v0.7.1-beta and Faraday v0.2.16-alpha.
+  This release packages LND v0.21.2-beta, Taproot Assets Daemon v0.8.1,
+  Loop v0.34.0-beta-v0.8.1-tapd, Pool v0.7.1-beta and Faraday v0.2.16-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
In this PR we bump Litd to `v0.17.2-alpha`.

Thank you @nmfretz for updating the previous PR with the necessary env variable to trigger the SQL migration :pray:. I've removed that part of the release notes message you added in the previous PR for this release, but please feel free to re-add it in case you think it makes sense to still include it.

Some other things worth noting:
1. This PR is targeting the `v0.17.2-alpha-docker` tag in `litd` and not the actual `v0.17.2-alpha` tag. We had an issue that caused the `v0.17.2-alpha` tag to not be pushed to docker hub, and therefore had to push separate `v0.17.2-alpha-docker` tag & sem-version. The `v0.17.2-alpha-docker` tag references a branch which is based on the tagged `v0.17.2-alpha` commit but which additionally also adds a small fix to the CI job which pushes the tag to docker hub: 
Tag: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.2-alpha-docker
Branch: https://github.com/lightninglabs/lightning-terminal/tree/v0_17_2-alpha_docker
I still set the version in `lightning-terminal/umbrel-app.yml` to `0.17.2-alpha` as the referenced tag is effectively the `v0.17.2-alpha` release, but with just that small CI job fix added. But feel free to update `lightning-terminal/umbrel-app.yml` to `0_17_2-alpha_docker` if the version should correspond to the exact semversion of the referenced tag!
2. I never created any Umbrel PR for `v0.17.1-alpha` as there was a bug in that release which caused very large LND nodes to error on startup. We therefore published a new `v0.17.2-alpha` release shortly after. 