### PR TITLE
Update Hashrate Autopilot to 1.18.1

### DIFF
--- a/hashrate-autopilot/docker-compose.yml
+++ b/hashrate-autopilot/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3010
 
   web:
-    image: ghcr.io/rdouma/hashrate-autopilot:1.17.6@sha256:5636d3560c995d7bed4ee6d2bc855999b19bc77bdb316e6485b941a546a99444
+    image: ghcr.io/rdouma/hashrate-autopilot:1.18.0@sha256:1a0be1f529a7926602e49820c4987f3b1adbf50079d039fa305a77d2cabba40e
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/hashrate-autopilot/docker-compose.yml
+++ b/hashrate-autopilot/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3010
 
   web:
-    image: ghcr.io/rdouma/hashrate-autopilot:1.18.0@sha256:1a0be1f529a7926602e49820c4987f3b1adbf50079d039fa305a77d2cabba40e
+    image: ghcr.io/rdouma/hashrate-autopilot:1.18.1@sha256:2aac024b743615a29c4f53a1a933610e008095227346bb1a0af730ca3931d6df
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/hashrate-autopilot/umbrel-app.yml
+++ b/hashrate-autopilot/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: hashrate-autopilot
 category: bitcoin
 name: Hashrate Autopilot
-version: "1.17.6"
+version: "1.18.0"
 tagline: Autopilot for renting hashrate to mine on Ocean Mining
 
 description: >-
@@ -73,16 +73,19 @@ defaultPassword: ""
 submitter: Remco Douma
 submission: https://github.com/getumbrel/umbrel-apps/pull/5685
 releaseNotes: >-
-  v1.17.6 - phantom Lightning payouts removed from Profit & Loss, and the dashboard API is locked to the dashboard itself.
+  v1.18.0 - choose which Ocean chain you mine on: full support for miners on Ocean's BIP110 endpoint.
 
 
-  Fixed: Profit & Loss no longer invents Lightning payouts you never received. A brief glitch in Ocean's reported unpaid balance could be read as a payout, inflating your "collected" total and understating your loss rate - and because the entry was recalculated from your history on every scan, even the Profit & Loss hard reset could not remove it. Impossible readings are now discarded rather than stored, and a drop only counts as a payout if the balance stays down: if it climbs back near its previous level within half an hour, it is treated as a reporting glitch. Existing false entries are deleted on upgrade and cannot come back. Genuine payouts, and any personal notes you attached to them, are left untouched.
+  New: Ocean chain selector (Config, Pool & Payout). Since the August 8 chain split, Ocean mines two chains with separate accounting, and miners on the BIP110 endpoint saw their Ocean stats stuck at zero because the dashboard read the mainstream chain's API. Declare which chain you mine on and the app adapts; mainstream (the default) is unchanged, and switching takes effect within a minute with no restart.
 
 
-  Fixed: The dashboard API now only answers browser requests coming from the dashboard itself. It previously told browsers that any website could make requests to it using your saved login, so a page in another tab could have acted on your behalf while you had the dashboard open. Nothing changes about how you reach the dashboard - a local address, a .local name, dynamic DNS, a VPN or a reverse proxy all keep working - and scripts or monitoring that call the API directly are unaffected.
+  On the BIP110 chain, Ocean provides no API (confirmed by Ocean support - none exists, none is planned, and scraping is not supported), so the app is honest about the gap instead of showing misleading zeros: the Ocean panel explains why hashrate, share log, and unpaid earnings can't be shown, and your collected earnings are derived directly from on-chain payouts seen by your own Bitcoin node. Lightning payouts can't be tracked there, and the panel says so. An Electrum server pointed at a node following the BIP110 chain is recommended.
 
 
-  Also includes routine dependency maintenance. No new settings. Safe to upgrade from any 1.17.x release.
+  No hashprice exists on the BIP110 chain, so the hashprice-based dynamic price cap and cheap mode are disabled there with a clear explanation - your fixed Maximum bid remains the only price ceiling and the autopilot keeps bidding. Stats tiles and chart options that need Ocean data are marked "n/a on BIP110" instead of showing dashes, and anything recorded before you switched chains still plots.
+
+
+  A new README chapter, "Mining on Ocean's BIP110 chain", walks through setup and summarizes exactly what changes. Also includes routine dependency maintenance (including a js-yaml security pin). Safe to upgrade from any 1.17.x release; if you mine mainstream Ocean, nothing changes.
 
 
   Migrating from the community-store version (rdouma-hashrate-autopilot)? One-time five-minute guide: https://github.com/rdouma/hashrate-autopilot/blob/main/docs/migrating-from-community-store.md

--- a/hashrate-autopilot/umbrel-app.yml
+++ b/hashrate-autopilot/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: hashrate-autopilot
 category: bitcoin
 name: Hashrate Autopilot
-version: "1.18.0"
+version: "1.18.1"
 tagline: Autopilot for renting hashrate to mine on Ocean Mining
 
 description: >-
@@ -73,6 +73,12 @@ defaultPassword: ""
 submitter: Remco Douma
 submission: https://github.com/getumbrel/umbrel-apps/pull/5685
 releaseNotes: >-
+  v1.18.1 - the v1.18.0 feature release plus an emergency fix that protects and restores unpaid-earnings history.
+
+
+  Fixed: a boot-time data cleanup could wipe the entire unpaid-earnings chart history if the unpaid balance ever legitimately climbed above 1.5M sats (larger hashrate targets, or an Ocean payout landing late). The cleanup is now strictly fenced to the old spring-2026 data problem it was written for, the daemon heals previously wiped history automatically on startup from its own decision log, and operators holding an old database copy can merge the remainder back via an ocean-unpaid-import.json drop-in. Recovery runs automatically after the update.
+
+
   v1.18.0 - choose which Ocean chain you mine on: full support for miners on Ocean's BIP110 endpoint.
 
 


### PR DESCRIPTION
## Type
- [x] App update

## App
Hashrate Autopilot 1.17.6 → 1.18.1

## Summary
Feature release plus an emergency data-protection fix, shipped together (this PR was bumped from 1.18.0 to 1.18.1 before review).

1.18.0: a new "Ocean chain" setting lets miners on Ocean's BIP110 endpoint declare which chain they mine on. Since the August 8 chain split, Ocean mines two chains with separate accounting, and BIP110-endpoint miners saw their Ocean stats stuck at zero because the app read the mainstream chain's API. On the BIP110 chain (Ocean provides no API for it, confirmed by Ocean support) the app derives collected earnings directly from on-chain payouts seen by the user's own Bitcoin node, clearly explains what cannot be shown, disables the hashprice-dependent controls with the reason, and marks unavailable stats as "n/a on BIP110". Mainstream-chain users see no behavior change.

1.18.1: fixes a boot-time cleanup that could wipe the unpaid-earnings chart history when the balance legitimately exceeded 1.5M sats; the daemon now also heals previously wiped history automatically on startup. Affects every release since v1.10.0, hence bundling it here.

Release notes: https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.18.0 and https://github.com/rdouma/hashrate-autopilot/releases/tag/v1.18.1

## Verification
- [x] Image is multi-arch (linux/amd64 + linux/arm64) and digest-pinned: `ghcr.io/rdouma/hashrate-autopilot:1.18.1@sha256:2aac024b743615a29c4f53a1a933610e008095227346bb1a0af730ca3931d6df`
- [x] `umbrel-app.yml` version and compose image bumped in lockstep
- [x] Upgrade path from 1.17.x/1.18.0 verified on community-store installs (SQLite migrations and the history self-heal run automatically on first boot)

## Notes
Two new automatic database migrations (0122/0123) add the chain columns; no user action required on upgrade. Community App Store (rdouma/hashrate-autopilot) is already serving 1.18.1.
