### PR TITLE
Update n8n to v2.35.7

### DIFF
--- a/n8n/docker-compose.yml
+++ b/n8n/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       PROXY_AUTH_WHITELIST: "/webhook-test/*,/webhook/*,/form-test/*,/form/*,/form-waiting/*"
 
   server:
-    image: n8nio/n8n:2.35.5@sha256:c5861e6016c8f283142584190e3874e6aa6f322eca8771ceead09d08b4766a1e
+    image: n8nio/n8n:2.35.7@sha256:166d7e3ca384afdffe75394bf00046c299d84a4bf17b19b35d6cf7773af0a147
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/home/node/.n8n

--- a/n8n/umbrel-app.yml
+++ b/n8n/umbrel-app.yml
@@ -2,24 +2,27 @@ manifestVersion: 1
 id: n8n
 category: automation
 name: n8n
-version: "2.35.5"
+version: "2.35.7"
 releaseNotes: >-
-  ⚠️ If you're updating from n8n 2.27.3 or earlier, this update includes the database index migration for workflow executions introduced in 2.27.4. Large n8n instances may take several minutes to finish the migration.
+  Updates n8n from 2.35.5 to 2.35.7.
 
 
-  This update fixes task-runner handling so slow runners are not restarted unnecessarily.
+  Fixes included:
 
 
-  Test webhook teardown is now handled more cleanly, and the expression engine only starts for commands that need it.
+  - Environment values are normalized before schema-based parsing, so configs that previously misparsed now behave predictably.
+
+  - End-user credentials resolve correctly when loading node parameters.
+
+  - A trigger's closeFunction is wrapped in an expression isolate at creation time.
+
+  - The AI Assistant model verification token limit was raised.
 
 
-  The editor's Edit Fields type selector styles have been restored.
+  No migration or manual action is needed for this update; existing workflows and credentials are preserved.
 
 
-  Public Form Trigger paths (`/form/*`, `/form-test/*`, `/form-waiting/*`) remain available without Umbrel login, while the n8n editor remains protected by your Umbrel login.
-
-
-  Full release notes can be found at https://github.com/n8n-io/n8n/releases/tag/n8n%402.35.5
+  Full upstream release notes: https://github.com/n8n-io/n8n/releases/tag/n8n%402.35.7
 tagline: Build complex workflows, really fast
 description: >-
   n8n is an extendable workflow automation tool. With a fair-code distribution model, n8n will always have visible source code, 


### PR DESCRIPTION
Updates n8n from **2.35.5** to **2.35.7**.

## Upstream changes included
- [n8n@2.35.6](https://github.com/n8n-io/n8n/releases/tag/n8n%402.35.6): normalize env values before schema-based parsing; resolve end-user credentials when loading node parameters; wrap a trigger's closeFunction in an expression isolate at creation time
- [n8n@2.35.7](https://github.com/n8n-io/n8n/releases/tag/n8n%402.35.7): raise AI Assistant model verification token limit

## Changes
- \docker-compose.yml\: image tag+digest bumped together (\
8nio/n8n:2.35.7@sha256:166d...\), digest is a multi-arch manifest list (linux/amd64 + linux/arm64)
- \umbrel-app.yml\: version bump + user-facing releaseNotes (update dialog)

No compose/env/persistence/hook changes required by this update; existing installs keep data at \\/data\ untouched.

## Testing performed
- Pulled the exact pinned digest and ran it locally (Docker, linux/amd64): container boots, DB migrations complete, editor serves HTTP 200 on port 5678 with the same env vars the package sets
- Official linter passes (\--check-images\), \git diff --check\ clean
- Not tested through a real umbrelOS update path (no umbrel device available); fresh-container behavior verified as above