### PR TITLE
Add Click Miner

### DIFF
--- a/click-miner/docker-compose.yml
+++ b/click-miner/docker-compose.yml
@@ -1,0 +1,42 @@
+# Umbrel packaging. `app_proxy` is Umbrel's own reverse-proxy sidecar —
+# naming a service `app_proxy` and pointing it at our container via
+# APP_HOST/APP_PORT is how Umbrel apps expose a web UI on the dashboard;
+# the app itself does not publish a port directly. RPC connection details
+# come from Umbrel's Bitcoin Node app via the `dependencies` declaration
+# in umbrel-app.yml, injected here as $APP_BITCOIN_* env vars.
+#
+# This file is Umbrel-specific. For plain desktop use, see the Dockerfile
+# and `docker run` instructions in the README instead.
+
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: click-miner_app_1
+      APP_PORT: 3000
+
+  app:
+    # Multi-arch (linux/amd64 + linux/arm64) image built and pushed by
+    # .github/workflows/docker-publish.yml from the v0.1.0 tag. Pinned to
+    # the manifest-list digest, not an arch-specific one, per Umbrel's
+    # image-pinning rule. Bump the tag, re-run the workflow, and update
+    # this line for future releases. (This file is Umbrel-only — plain
+    # desktop use builds straight from the Dockerfile, see the README's
+    # "Quick start" section, so removing `build:` here doesn't affect it.)
+    image: ghcr.io/owencoles/click-miner:0.1.0@sha256:8070ccc2c169a267e0e11143fc026c9c1f7b862c07046e18963b7030243df675
+    restart: on-failure
+    stop_grace_period: 30s
+    environment:
+      PORT: 3000
+      DATA_DIR: /data
+      # app_proxy is a separate container, so the app must listen on the
+      # container network rather than loopback. Umbrel does not publish
+      # this port to the host; app_proxy is the only way in.
+      HOST: 0.0.0.0
+      RPC_HOST: $APP_BITCOIN_NODE_IP
+      RPC_PORT: $APP_BITCOIN_RPC_PORT
+      RPC_USER: $APP_BITCOIN_RPC_USER
+      RPC_PASSWORD: $APP_BITCOIN_RPC_PASS
+    volumes:
+      - ${APP_DATA_DIR}/data:/data

--- a/click-miner/umbrel-app.yml
+++ b/click-miner/umbrel-app.yml
@@ -52,7 +52,7 @@ description: >-
 
   Not a pool, not competitive, not financial advice — just you against
   2^256.
-releaseNotes: "Initial release."
+releaseNotes: ""
 
 developer: Click Miner Contributors
 website: "https://github.com/owencoles/Click-Miner"

--- a/click-miner/umbrel-app.yml
+++ b/click-miner/umbrel-app.yml
@@ -1,0 +1,72 @@
+# Umbrel app manifest. Field order and rules verified against Umbrel's own
+# app-store packaging guidance (getumbrel/umbrel-apps .claude/skills/
+# umbrel-package-app, as of 2026-08) plus a real shipped manifest
+# (getumbrel/umbrel-apps/mempool/umbrel-app.yml) as a field-shape reference.
+#
+# This file targets an OFFICIAL App Store submission (a PR to
+# getumbrel/umbrel-apps), which is why `icon` is omitted and `gallery` is
+# empty — see the notes on each below. If instead self-publishing this app
+# through a personal Umbrel Community App Store
+# (github.com/getumbrel/umbrel-community-app-store), add `icon:` and
+# `gallery:` back in as plain hosted URLs (that template's apps reference
+# externally-hosted images, not files bundled in the package) and prefix
+# `id` with your store's id.
+#
+# Official-submission notes:
+#   - Omit `icon`. Official icons are hosted with the App Store's other
+#     image assets outside the package repo; icon.svg (repo root, 1024px
+#     Click Miner mark) is submitted via the PR body instead, as source art.
+#   - Use `gallery: []`. The Umbrel team adds gallery images before merge
+#     from screenshots attached to the PR body — see docs/screenshots/ in
+#     this repo. Do not commit gallery images to the package itself.
+#   - `port: 3019` was picked by cross-checking both manifest `port:`
+#     values and raw docker-compose host-published ports across every app
+#     in a clone of getumbrel/umbrel-apps (as of 2026-08) — the linter
+#     catches manifest-vs-manifest collisions but not manifest-vs-raw-port
+#     ones, so both had to be checked by hand. Re-verify before submitting
+#     if much time has passed.
+#   - `docker-compose.yml`'s `build: .` must become a pinned, multi-arch,
+#     publicly pullable image (registry/repo:version@sha256:<digest>)
+#     before this is submission-ready. See
+#     .github/workflows/docker-publish.yml, which builds and pushes one.
+
+manifestVersion: 1
+id: click-miner
+category: bitcoin
+name: Click Miner
+version: "0.1.0"
+tagline: The world's least efficient Bitcoin miner
+description: >-
+  A free, open-source, educational manual Bitcoin miner. Click a button and
+  the app assembles one real block header from your own node's live data,
+  computes a single SHA256d hash against the current network target, and
+  shows you exactly what mining does — one hash at a time.
+
+
+  Requires an installed Bitcoin node app (Bitcoin Core or Bitcoin Knots) —
+  RPC connection details are filled in automatically from it. After
+  install, open the Settings tab and enter only your payout address (any
+  address type works); that's the only setup step. On the (nearly
+  impossible) chance you find a block, the reward pays out there directly.
+
+
+  Not a pool, not competitive, not financial advice — just you against
+  2^256.
+releaseNotes: "Initial release."
+
+developer: Click Miner Contributors
+website: "https://github.com/owencoles/Click-Miner"
+dependencies:
+  - bitcoin
+repo: "https://github.com/owencoles/Click-Miner"
+support: "https://github.com/owencoles/Click-Miner/issues"
+
+port: 3019
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+submitter: owencoles
+submission: ""

--- a/click-miner/umbrel-app.yml
+++ b/click-miner/umbrel-app.yml
@@ -69,4 +69,4 @@ defaultUsername: ""
 defaultPassword: ""
 
 submitter: owencoles
-submission: ""
+submission: "https://github.com/getumbrel/umbrel-apps/pull/6008"


### PR DESCRIPTION
## Click Miner

A free, open-source, educational manual Bitcoin miner. Click a button and the app assembles one real block header from your own node's live data, computes a single SHA256d hash against the current network target, and shows you exactly what mining does — one hash at a time. Not a pool, not competitive — just you against 2^256.

- Upstream/source: https://github.com/owencoles/Click-Miner
- Image: `ghcr.io/owencoles/click-miner:0.1.0`, built and pushed by the repo's own GitHub Actions workflow (multi-arch: linux/amd64 + linux/arm64), publicly pullable.
- Depends on Umbrel's `bitcoin` app for RPC connection details (auto-injected, no manual setup). Works with either Bitcoin Core or Bitcoin Knots as the provider, since Knots' manifest declares `implements: [bitcoin]` and exports the same `APP_BITCOIN_*` contract — confirmed live (see Testing performed).
- No login/auth of its own — connects only to the user's configured node and their own payout address. Never touches a private key.

### Logo

<img width="1024" height="1024" alt="icon" src="https://github.com/user-attachments/assets/c2219fa2-89df-45a5-af9c-515001a4f1dd" />


### Screenshots

<img width="2880" height="1800" alt="mine" src="https://github.com/user-attachments/assets/a4f7624a-696a-461d-9b90-9ddf0c0b9f25" />

<img width="2880" height="1800" alt="mine-found-block" src="https://github.com/user-attachments/assets/3805f858-4c32-49b6-b5a5-230c430227b0" />

<img width="2880" height="1800" alt="settings" src="https://github.com/user-attachments/assets/543fae2a-cc36-4834-a446-49c8035f0653" />

<img width="2880" height="1800" alt="learn" src="https://github.com/user-attachments/assets/34cf8d1b-afed-4142-ab4b-bf79a74bb49c" />


### Testing performed

- **Real Umbrel device** (x86_64/`linux/amd64`), fresh install via the app-store source sync path documented in this repo's own `umbrel-test-app` skill: package rsynced into the local app-store cache, installed with `umbreld client apps.install.mutate --appId click-miner --alternatives '{"bitcoin":"bitcoin-knots"}'`.
- Dependency provider used: **Bitcoin Knots** (`bitcoin-knots`), confirming the `dependencies: [bitcoin]` + `implements: [bitcoin]` alternative-resolution path works end to end, not just Bitcoin Core.
- Opened from the Umbrel home screen (not a raw port). Settings tab shows RPC host/port/username pre-filled from the dependency injection — no manual entry needed beyond the payout address.
- Entered a payout address, clicked Mine, confirmed it fetches a live block template and hashes against it.
- Restarted the app through Umbrel (`apps.restart.mutate`) and confirmed settings and hash count persist across restart.
- Also manually tested against a local regtest node during development: connects, fetches a live block template, submits a found block successfully (`submitblock accepted`).
- Verified via `node .tools/lint-apps.mjs click-miner --check-images` against this repo — 0 errors (aside from `submission`, filled in once this PR exists).
- Confirmed `linux/amd64` and `linux/arm64` both build and the published image is anonymously pullable (`docker buildx imagetools inspect` after `docker logout`).
- Checked `port: 3019` against every other app's manifest `port:` and raw compose ports in this repo for collisions.
- Not yet tested: Bitcoin Core (rather than Knots) as the dependency provider, and the update path (this is a first submission, no prior version to update from). Core's `exports.sh` exports the identical `APP_BITCOIN_*` variables Knots does, so the same mechanism applies, but it hasn't been exercised live.

### Notes for reviewers

- `gallery: []` and no `icon:` in the manifest are intentional per the packaging skill (screenshots/logo attached above instead).
- `data/.gitkeep` is committed so the `${APP_DATA_DIR}/data` bind mount has somewhere to land on first install.