### PR TITLE
satsbook: bump to v2.1.0

### DIFF
--- a/satsbook/docker-compose.yml
+++ b/satsbook/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3017
 
   server:
-    image: ghcr.io/satsbook/satsbook:2.0.0@sha256:70e752fe53adae9faa33994d6cb9cd4158b35ddb8454ad8d5a42cca117907b77
+    image: ghcr.io/satsbook/satsbook:2.1.0@sha256:073795941f3b9db24f63b4b2d2f3b45379d41e4ea616ad721efb51b21f1f1e3e
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/satsbook/umbrel-app.yml
+++ b/satsbook/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: satsbook
 category: bitcoin
 name: Satsbook
-version: "2.0.0"
+version: "2.1.0"
 tagline: Bitcoin accounting and tax export for Lightning node operators
 description: >-
   Track routing fees, import exchange transactions (Strike, River, Coinbase, Swan),
@@ -28,11 +28,13 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  v2.0.0 — Major release with paid tiers and full accounting.
-  Free: interactive portfolio donut chart, unified transaction ledger,
-  transfer tagging (auto-detects channel opens/closes), 4 exchange
-  CSV imports (Strike, River, Coinbase, Swan), watched wallet tracking.
-  Pro: FIFO/LIFO cost basis engine, Form 8949 tax export.
-  Power: Monarch Money BTC holdings and transaction sync.
+  v2.1.0 — Annual report, nav overhaul, and stability fixes.
+  New: year-in-review page with monthly routing fee chart, BTC purchase
+  totals, and disposal count. Nav reorganized into grouped dropdowns
+  (Node, Portfolio, Activity, Tax). Bug fixes: footer consistency,
+  tax guide navigation, settings node indicator.
+  v2.0.0: paid tiers, portfolio donut chart, unified transaction ledger,
+  transfer tagging, 4 exchange imports, watched wallets, Form 8949 export,
+  Monarch Money sync.
 submitter: brewgator
 submission: https://github.com/getumbrel/umbrel-apps/pull/5451


### PR DESCRIPTION
## App
**Satsbook** — Bitcoin accounting and tax export for Lightning node operators

## What's new in v2.1.0

**New:**
- Annual Report (`/year`) — monthly routing fee bar chart, BTC purchase totals, disposal count, and a shareable text card
- Tax Guide (`/tax/guide`) — plain-language walkthrough of Bitcoin tax rules for node operators
- Tier comparison page with contextual upgrade CTAs throughout the app
- Strike API auto-sync — connect a Strike API key to pull transactions automatically
- Coinbase CDP API auto-sync — same for Coinbase Advanced Trade
- Auto-transfer tagging — channel opens/closes detected and flagged automatically
- Database backup & restore in Settings

**Improvements:**
- CSV export for the unified transaction ledger
- Onboarding empty states when no data is present
- Nav reorganized into grouped dropdowns: Node, Portfolio, Activity, Tax
- Node alias now shows on every page header (falls back to saved alias when LND is unreachable)
- Footer consistently shows last sync time, BTC price, and tier badge on all pages

**Fixes:**
- Monarch Money: prevented duplicate account creation on repeated syncs
- Footer and node-info bar missing from several pages
- Monthly fee bar chart on Annual Report now renders correctly

## Changes
- `umbrel-app.yml` — version 2.1.0, updated description and release notes
- `docker-compose.yml` — image tag `ghcr.io/satsbook/satsbook:2.1.0@sha256:073795941f3b9db24f63b4b2d2f3b45379d41e4ea616ad721efb51b21f1f1e3e`

## Links
- GitHub release: https://github.com/satsbook/satsbook/releases/tag/v2.1.0
- Full changelog: https://github.com/satsbook/satsbook/compare/v2.0.0...v2.1.0
- Previous submission: https://github.com/getumbrel/umbrel-apps/pull/5722