### PR TITLE
yuvomi: update to v2.36.0

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:2.25.1@sha256:7f075a1b0a03c1ecf4de0ee9f164bf8b2774a3c7a773bbaf9095b930d5ace9a2
+    image: ghcr.io/ulsklyc/yuvomi:2.36.0@sha256:176ef6f4ccda4cb78d47da6801b7a95c45cf185d616df425a8aa22882c0848e4
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "2.25.1"
+version: "2.36.0"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -51,21 +51,39 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  This update fixes a permissions issue affecting integrations for scripts and
-  AI assistants. Previously, members with restricted access to modules such as
-  Tasks could still view or modify content in those modules through these
-  integrations. Guest accounts for Shared Expenses could also access tools
-  outside their permitted area.
+  Times now read the same on every device in the household. The previous release
+  gave the household a time zone of its own; with this one the app's display
+  follows it too, so a phone that travels to another country shows the clock at
+  home rather than the one where it happens to be. It also settles an
+  inconsistency that was easy to see and hard to explain: an appointment you
+  typed in yourself and one synced from Google, Apple or a CalDAV server are
+  stored differently, and away from home the two used to show different times
+  even when they were the same appointment. Nothing changes unless the household
+  time zone is set under Settings, Personal, Appearance, Region; without it the
+  display keeps following each device as before.
 
 
-  Existing module permissions now apply consistently across the app and all
-  integrations. No configuration changes are required. If you previously
-  limited integration access to administrator accounts as a workaround, you can
-  now safely enable it for members with restricted permissions.
+  An appointment that carries its own colour now keeps it, even when the
+  appointment is assigned to someone. Until now the colour of the assigned
+  person came first, which hid colours that had arrived from a CalDAV calendar
+  or been picked by hand. An appointment without its own colour still takes the
+  colour of the person it belongs to, and who it belongs to is shown by the
+  avatars beside it either way.
+
+
+  Writing a note has more room. The note window used to be as narrow as a form
+  with a few short fields, which is the wrong shape for something that is mostly
+  text; it now opens at the width used elsewhere for documents and contacts, for
+  reading a note as well as writing one.
+
+
+  One smaller fix: the time zone setting introduced in the previous release
+  showed "Automatic" again the next time the page was opened, although the
+  choice had been saved correctly. It now shows what is actually set.
 
 
   Full release notes are available at
-  https://github.com/ulsklyc/yuvomi/releases/tag/v2.25.1
+  https://github.com/ulsklyc/yuvomi/releases/tag/v2.36.0
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db


### PR DESCRIPTION
Automated update of Yuvomi, prepared by the release workflow in `ulsklyc/yuvomi` and following this repo's `AGENTS.md`.

| | |
|---|---|
| Old version | `2.25.1` |
| New version | `2.36.0` |
| Upstream release | https://github.com/ulsklyc/yuvomi/releases/tag/v2.36.0 |
| Image | `ghcr.io/ulsklyc/yuvomi:2.36.0@sha256:176ef6f4ccda4cb78d47da6801b7a95c45cf185d616df425a8aa22882c0848e4` |
| Architectures | linux/amd64, linux/arm64 |
| Linter | passed (`node .tools/lint-apps.mjs yuvomi --check-images`) |

**Package changes**

- `yuvomi/docker-compose.yml`
- `yuvomi/umbrel-app.yml`

Manifest `version`, `releaseNotes` and the pinned image digest. No changes to compose wiring, env vars, volumes, ports, `app_proxy`, hooks, exports or permissions, so there is nothing for existing installs to migrate.

**Breaking changes**

None. This is a patch/minor upstream release; see the upstream notes above for the user-visible list.

**Testing performed**

- Upstream CI (`npm test`) green on the release commit.
- Image pulled from the public registry and pinned by the multi-arch index digest; `linux/amd64` and `linux/arm64` verified to be present in the manifest list.
- Manifest and compose parsed as YAML after editing.
- Repo linter: passed (`node .tools/lint-apps.mjs yuvomi --check-images`)

**Not tested**: the update path was not exercised through umbrelOS itself - this workflow has no Umbrel instance. The package change is limited to the manifest version, the release notes and the image digest.
