### PR TITLE
Update EE Gateway to 0.10.8

### DIFF
--- a/ee-gateway/docker-compose.yml
+++ b/ee-gateway/docker-compose.yml
@@ -34,7 +34,7 @@ services:
   # extra download, and it is the only place root is used. This is NOT privileged
   # mode; the app containers themselves stay non-root.
   init_perms:
-    image: encryptedenergy/ee-gateway-worker:0.8.0@sha256:816e236ff47052e5d081cc4a99f56c40434df33aba1b0efd0badc4d30902ae04
+    image: encryptedenergy/ee-gateway-worker:0.8.1@sha256:cd0aa7400fedf314e826e00c6152025c1fe60d5a5c7594cafc49a7f3ddaa6258
     user: "0:0"
     entrypoint: ["sh", "-c", "chown -R 1000:1000 /data"]
     restart: on-failure
@@ -47,7 +47,7 @@ services:
   # Runs as uid 1000 (set in the image). init: true so SIGTERM reaches Flask
   # for a clean shutdown.
   ui:
-    image: encryptedenergy/ee-gateway-ui:0.6.4@sha256:c30e4b2a2bd640005499e4fe564a04f6650b920c0726b15e2437eaa41ffb25eb
+    image: encryptedenergy/ee-gateway-ui:0.6.5@sha256:cdfb8866e677ab206549c5ffab6bff7e9055969997230601ac098e2778ff0b5f
     init: true
     restart: on-failure
     depends_on:
@@ -67,7 +67,7 @@ services:
   # Python process runs as uid 1000; gpsd starts as root only to open the
   # serial device, then drops to user nobody.
   worker:
-    image: encryptedenergy/ee-gateway-worker:0.8.0@sha256:816e236ff47052e5d081cc4a99f56c40434df33aba1b0efd0badc4d30902ae04
+    image: encryptedenergy/ee-gateway-worker:0.8.1@sha256:cd0aa7400fedf314e826e00c6152025c1fe60d5a5c7594cafc49a7f3ddaa6258
     init: true
     restart: on-failure
     depends_on:

--- a/ee-gateway/umbrel-app.yml
+++ b/ee-gateway/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: ee-gateway
 category: networking
 name: EE Gateway
-version: "0.10.7"
+version: "0.10.8"
 tagline: Self-hosted Bluetooth gateway for open BLE networks
 description: >-
   EE Gateway turns your Umbrel into a self-hosted Bluetooth gateway for
@@ -27,27 +27,11 @@ description: >-
   encryptedenergy.com. It is an independent community project and is not
   affiliated with any specific BLE network.
 releaseNotes: >-
-  Big efficiency release. The worker now uploads queued packets in one
-  batch instead of one request per packet. On a busy gateway that cuts
-  network requests and SD card writes by up to 500 times, and uploads
-  clear much faster after the gateway comes back online.
-
-
-  Location reporting is more trustworthy too. Each packet now carries
-  the exact time its GPS coordinate was captured and how precise the
-  fix was, straight from your dongle. That lets the upstream network
-  verify your gateway's coverage is real, which protects your payout
-  eligibility as anti-fraud checks tighten.
-
-
-  Housekeeping: the last unused leftovers of the organization ID are
-  gone from the worker. Your API token alone connects the gateway, and
-  existing installs keep working with no changes. Worker 0.8.0, UI
-  0.6.4.
-developer: encryptedenergy.com
-website: https://encryptedenergy.com
-dependencies: []
-repo: https://github.com/Encrypted-Energy/gateway
+  Pick your gateway's location on a map or use a GPS dongle's fix with
+  one tap. Quiet areas now show a standing-by state: the dashboard says
+  the radio check is passing and explains that silence means no beacons
+  have passed yet, not a broken install. The worker also reports its
+  platform so fleet stats read one format. Worker 0.8.1, UI 0.6.5.
 support: https://github.com/Encrypted-Energy/gateway/issues
 port: 8083
 gallery:

--- a/ee-gateway/umbrel-app.yml
+++ b/ee-gateway/umbrel-app.yml
@@ -32,6 +32,10 @@ releaseNotes: >-
   the radio check is passing and explains that silence means no beacons
   have passed yet, not a broken install. The worker also reports its
   platform so fleet stats read one format. Worker 0.8.1, UI 0.6.5.
+developer: encryptedenergy.com
+website: https://encryptedenergy.com
+dependencies: []
+repo: https://github.com/Encrypted-Energy/gateway
 support: https://github.com/Encrypted-Energy/gateway/issues
 port: 8083
 gallery:


### PR DESCRIPTION
Quality-of-setup release. The location step gains a map picker (click to drop the pin, drag to fine-tune) and a one-tap "Use GPS position" shortcut when a GPS dongle has a live fix. The dashboard adds a standing-by state: a healthy scanner that hasn't heard a beacon yet says "Radio check: passing" and explains the silence. The worker now reports its platform and a prefixed version in heartbeats, so fleet stats read one format across Umbrel, iOS, and Android.

Image digest bumps and release notes only. The Leaflet map library is vendored into the UI image, and map tiles load from openstreetmap.org in the operator's browser only, so the containers gain no new network dependencies.

Full changelog: https://github.com/Encrypted-Energy/gateway/releases/tag/v0.10.8