### PR TITLE
yuvomi: update to v2.39.0

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:2.36.0@sha256:176ef6f4ccda4cb78d47da6801b7a95c45cf185d616df425a8aa22882c0848e4
+    image: ghcr.io/ulsklyc/yuvomi:2.39.0@sha256:1adafdde4df6a24aa73852613190eacce620f378516abbea2b7aba4ec66e9e69
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "2.36.0"
+version: "2.39.0"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -51,39 +51,31 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  Times now read the same on every device in the household. The previous release
-  gave the household a time zone of its own; with this one the app's display
-  follows it too, so a phone that travels to another country shows the clock at
-  home rather than the one where it happens to be. It also settles an
-  inconsistency that was easy to see and hard to explain: an appointment you
-  typed in yourself and one synced from Google, Apple or a CalDAV server are
-  stored differently, and away from home the two used to show different times
-  even when they were the same appointment. Nothing changes unless the household
-  time zone is set under Settings, Personal, Appearance, Region; without it the
-  display keeps following each device as before.
+  Dragging your task categories into the order you want now actually changes the
+  order you see. Until this release the tasks page ignored it and sorted the
+  groups alphabetically instead, so a category you had pulled to the top stayed
+  wherever the alphabet put it. The order you set in "Manage categories" is now
+  the order the groups appear in, in every language.
 
 
-  An appointment that carries its own colour now keeps it, even when the
-  appointment is assigned to someone. Until now the colour of the assigned
-  person came first, which hid colours that had arrived from a CalDAV calendar
-  or been picked by hand. An appointment without its own colour still takes the
-  colour of the person it belongs to, and who it belongs to is shown by the
-  avatars beside it either way.
+  If you sign in to Yuvomi through your own identity provider, you can now
+  decide whether it may create accounts. Until now anyone who could sign in at
+  your provider got a Yuvomi account on their first attempt, which is fine when
+  you run that provider for this household alone and rather less so when you do
+  not. Setting OIDC_ALLOW_SIGNUP to false turns that off: people who already
+  have an account still sign in as before, and an account you created by hand is
+  still matched up on their first sign-in, but an unfamiliar login is turned
+  away with a message saying so instead of quietly becoming a new member of your
+  household.
 
 
-  Writing a note has more room. The note window used to be as narrow as a form
-  with a few short fields, which is the wrong shape for something that is mostly
-  text; it now opens at the width used elsewhere for documents and contacts, for
-  reading a note as well as writing one.
-
-
-  One smaller fix: the time zone setting introduced in the previous release
-  showed "Automatic" again the next time the page was opened, although the
-  choice had been saved correctly. It now shows what is actually set.
+  Nothing needs configuring and nothing changes about your data. The new setting
+  only takes effect if you set it yourself, so an existing installation behaves
+  exactly as it did before.
 
 
   Full release notes are available at
-  https://github.com/ulsklyc/yuvomi/releases/tag/v2.36.0
+  https://github.com/ulsklyc/yuvomi/releases/tag/v2.39.0
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db


### PR DESCRIPTION
Automated update of Yuvomi, prepared by the release workflow in `ulsklyc/yuvomi` and following this repo's `AGENTS.md`.

| | |
|---|---|
| Old version | `2.36.0` |
| New version | `2.39.0` |
| Upstream release | https://github.com/ulsklyc/yuvomi/releases/tag/v2.39.0 |
| Image | `ghcr.io/ulsklyc/yuvomi:2.39.0@sha256:1adafdde4df6a24aa73852613190eacce620f378516abbea2b7aba4ec66e9e69` |
| Architectures | linux/amd64, linux/arm64 |
| Linter | passed (`node .tools/lint-apps.mjs yuvomi --check-images`) |

**Package changes**

- `yuvomi/docker-compose.yml`
- `yuvomi/umbrel-app.yml`

Manifest `version`, `releaseNotes` and the pinned image digest. No changes to compose wiring, env vars, volumes, ports, `app_proxy`, hooks, exports or permissions, so there is nothing for existing installs to migrate.

**Breaking changes**

None. This is a patch/minor upstream release; see the upstream notes above for the user-visible list.

**Testing performed**

- Upstream CI (`npm test`) green on the release commit.
- Image pulled from the public registry and pinned by the multi-arch index digest; `linux/amd64` and `linux/arm64` verified to be present in the manifest list.
- Manifest and compose parsed as YAML after editing.
- Repo linter: passed (`node .tools/lint-apps.mjs yuvomi --check-images`)

**Not tested**: the update path was not exercised through umbrelOS itself - this workflow has no Umbrel instance. The package change is limited to the manifest version, the release notes and the image digest.
