### PR TITLE
yuvomi: update to v2.44.0

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:2.39.0@sha256:1adafdde4df6a24aa73852613190eacce620f378516abbea2b7aba4ec66e9e69
+    image: ghcr.io/ulsklyc/yuvomi:2.44.0@sha256:2d9487c6fe48d1df0012d0994f9387c60aa1ed8236b4d7eea53d03042987113c
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "2.39.0"
+version: "2.44.0"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -51,31 +51,39 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  Dragging your task categories into the order you want now actually changes the
-  order you see. Until this release the tasks page ignored it and sorted the
-  groups alphabetically instead, so a category you had pulled to the top stayed
-  wherever the alphabet put it. The order you set in "Manage categories" is now
-  the order the groups appear in, in every language.
+  The Tasks module now keeps a history of what was completed. Until now a task
+  simply carried the state "done", and nothing recorded when that happened or
+  who did it - so questions like "what did I get through today", "when did we
+  last clean the bathroom" or "who took the bins out" had no answer anywhere. A
+  third view sits beside List and Board: what was ticked off, grouped by day,
+  newest first, with the household member and the time. You can narrow it to one
+  person, and tapping an entry opens the task itself.
 
 
-  If you sign in to Yuvomi through your own identity provider, you can now
-  decide whether it may create accounts. Until now anyone who could sign in at
-  your provider got a Yuvomi account on their first attempt, which is fine when
-  you run that provider for this household alone and rather less so when you do
-  not. Setting OIDC_ALLOW_SIGNUP to false turns that off: people who already
-  have an account still sign in as before, and an account you created by hand is
-  still matched up on their first sign-in, but an unfamiliar login is turned
-  away with a message saying so instead of quietly becoming a new member of your
-  household.
+  A repeating task also shows when it was last done, going back through the
+  whole series rather than just the copy currently open. That is the question a
+  weekly chore actually raises, and it is the one the old "done" flag could
+  never answer, because completing a repeating task creates a fresh copy each
+  time.
 
 
-  Nothing needs configuring and nothing changes about your data. The new setting
-  only takes effect if you set it yourself, so an existing installation behaves
-  exactly as it did before.
+  The history starts empty, and that is expected. Recording begins with this
+  update - what your household ticked off before it was never written down
+  anywhere, so there is nothing to show yet. It fills up from the first task you
+  complete after updating.
+
+
+  The list respects who may see what, exactly as the task list does. A task kept
+  private stays out of everyone else's history, including after the fact: set a
+  task to private later, and it disappears from the history too.
+
+
+  Nothing needs configuring and there is nothing to do after the update - the
+  new table is created automatically on first start.
 
 
   Full release notes are available at
-  https://github.com/ulsklyc/yuvomi/releases/tag/v2.39.0
+  https://github.com/ulsklyc/yuvomi/releases/tag/v2.44.0
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db


### PR DESCRIPTION
Automated update of Yuvomi, prepared by the release workflow in `ulsklyc/yuvomi` and following this repo's `AGENTS.md`.

| | |
|---|---|
| Old version | `2.39.0` |
| New version | `2.44.0` |
| Upstream release | https://github.com/ulsklyc/yuvomi/releases/tag/v2.44.0 |
| Image | `ghcr.io/ulsklyc/yuvomi:2.44.0@sha256:2d9487c6fe48d1df0012d0994f9387c60aa1ed8236b4d7eea53d03042987113c` |
| Architectures | linux/amd64, linux/arm64 |
| Linter | passed (`node .tools/lint-apps.mjs yuvomi --check-images`) |

**Package changes**

- `yuvomi/docker-compose.yml`
- `yuvomi/umbrel-app.yml`

Manifest `version`, `releaseNotes` and the pinned image digest. No changes to compose wiring, env vars, volumes, ports, `app_proxy`, hooks, exports or permissions, so there is nothing for existing installs to migrate.

**Breaking changes**

None. This is a patch/minor upstream release; see the upstream notes above for the user-visible list.

**Testing performed**

- Upstream CI (`npm test`) green on the release commit.
- Image pulled from the public registry and pinned by the multi-arch index digest; `linux/amd64` and `linux/arm64` verified to be present in the manifest list.
- Manifest and compose parsed as YAML after editing.
- Repo linter: passed (`node .tools/lint-apps.mjs yuvomi --check-images`)

**Not tested**: the update path was not exercised through umbrelOS itself - this workflow has no Umbrel instance. The package change is limited to the manifest version, the release notes and the image digest.
