### PR TITLE
Add Recat

### DIFF
--- a/recat/docker-compose.yml
+++ b/recat/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       #
       # Set APP_URL_LOCKED=true instead if this deployment should pin the
       # address and refuse edits from the UI.
-      APP_URL: http://umbrel.local:3009
+      APP_URL: http://umbrel.local:3019
       PORT: 3001
       DATABASE_URL: postgresql://recat:${APP_RECAT_DB_PASSWORD}@recat_db_1:5432/recat
       SESSION_SECRET: ${APP_RECAT_SESSION_SECRET}

--- a/recat/docker-compose.yml
+++ b/recat/docker-compose.yml
@@ -1,0 +1,125 @@
+services:
+  app_proxy:
+    environment:
+      APP_HOST: recat_server_1
+      APP_PORT: 3001
+
+      # Umbrel's dashboard auth defaults on (PROXY_AUTH_ADD defaults to true),
+      # and it only works from the dashboard origin, where the browser carries
+      # that session cookie. Behind a TLS front app_proxy 302s to
+      # http://127.0.0.1:2000, which nothing outside the box can reach.
+      # Measured on the device: 200 on loopback, 502 through Tailscale Serve,
+      # and 502 on /auth/qbo/callback — so the Intuit callback can never land
+      # and real QuickBooks cannot be connected at all.
+      #
+      # Whitelisting just the callback does not help: every UI request would
+      # still 302 to an unreachable address, leaving the app unusable through
+      # the front it needs for real books.
+      #
+      # Recat authenticates its own requests — sessions, magic links, the
+      # rate-limited local admin password, per-company roles — so Umbrel's
+      # layer is redundant here rather than protective.
+      #
+      # First-run used to be the exception: it is unauthenticated by necessity,
+      # since somebody has to create the first account. As of v0.1.3 that is
+      # closed. Creating the first administrator requires the app password this
+      # page displays, and /auth/magic-link neither bootstraps an account nor
+      # returns a sign-in link in its response while LOCAL_ADMIN_* is set —
+      # issued links reach this app's logs only (#53).
+      PROXY_AUTH_ADD: 'false'
+
+  server:
+    image: ghcr.io/tx-joshg/recat-qbo:0.1.5@sha256:b1c3d9d28d41b7f674e5f3823f5ca0e456f90196f5131d83030cf3082f28aa87
+    restart: on-failure
+    environment:
+      # The install's starting address, and the seed for origin checking — not
+      # a lock. An admin changes the public URL from the setup wizard or
+      # Settings, and the stored value then wins; see instanceSettings.appUrl.
+      #
+      # Do not remove this line. Without it the app falls back to its own
+      # localhost default, which is not an origin any Umbrel browser sends, so
+      # the CSRF check rejects the setup wizard itself and the install cannot
+      # be completed. Verified: POST /api/setup/admin returns 403.
+      #
+      # Set APP_URL_LOCKED=true instead if this deployment should pin the
+      # address and refuse edits from the UI.
+      APP_URL: http://umbrel.local:3009
+      PORT: 3001
+      DATABASE_URL: postgresql://recat:${APP_RECAT_DB_PASSWORD}@recat_db_1:5432/recat
+      SESSION_SECRET: ${APP_RECAT_SESSION_SECRET}
+      ENCRYPTION_KEY: ${APP_RECAT_ENCRYPTION_KEY}
+
+      # Local sign-in, because an Umbrel install has no outbound mail and
+      # magic links cannot deliver. The wizard must create this exact address
+      # as the first administrator; it is surfaced to the user as
+      # defaultUsername in the manifest.
+      LOCAL_ADMIN_EMAIL: admin@recat.local
+      LOCAL_ADMIN_PASSWORD: ${APP_PASSWORD}
+
+      # TRUSTED_PROXY_IPS stays unset — app_proxy's address is assigned by
+      # Docker and is not exposed as an Umbrel variable, so there is nothing to
+      # list, and a guessed CIDR would never match (compileTrustedProxy is an
+      # exact-match allowlist by design).
+      #
+      # TRUSTED_PROXY_HOP covers it instead: trust the immediate peer as a
+      # reverse proxy when that peer is on a private network. Safe here because
+      # this compose declares no `ports:` for the server, so app_proxy on the
+      # app network is the only route to it. Should that ever change, a public
+      # client's forwarded headers are ignored — the private-address check
+      # makes the failure mode "no worse than before" rather than "believes a
+      # stranger".
+      #
+      # Without it every caller shares app_proxy's address, so every rate limit
+      # is deployment-wide and anyone can lock the owner out of local sign-in
+      # indefinitely — the only way in on an install with no SMTP (#57).
+      TRUSTED_PROXY_HOP: 'true'
+
+      RECEIPT_EXTRACTOR_URL: http://recat_receipt-extractor_1:8485
+      RECEIPT_EXTRACTOR_TOKEN: ${APP_RECAT_EXTRACTOR_TOKEN}
+    depends_on:
+      db:
+        condition: service_healthy
+      receipt-extractor:
+        condition: service_healthy
+
+  db:
+    image: postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193
+    restart: on-failure
+    environment:
+      POSTGRES_USER: recat
+      POSTGRES_PASSWORD: ${APP_RECAT_DB_PASSWORD}
+      POSTGRES_DB: recat
+    volumes:
+      # Bind mount, not a named volume: Umbrel backs up and restores
+      # ${APP_DATA_DIR} and recreates containers on update.
+      - ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U recat -d recat"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  receipt-extractor:
+    image: ghcr.io/tx-joshg/recat-qbo/receipt-extractor:0.1.5@sha256:e3685b43e8da0b0a1a62754976eacb4ce0bd3577bf26d1076af6dcb6e832ecb7
+    restart: on-failure
+    environment:
+      RECEIPT_EXTRACTOR_TOKEN: ${APP_RECAT_EXTRACTOR_TOKEN}
+    # Not published to the host — reachable only from the app container.
+    read_only: true
+    tmpfs:
+      - /tmp:size=256m,mode=1777
+    mem_limit: 1g
+    pids_limit: 128
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - import urllib.request; urllib.request.urlopen('http://127.0.0.1:8485/healthz')
+      interval: 10s
+      timeout: 3s
+      retries: 10

--- a/recat/exports.sh
+++ b/recat/exports.sh
@@ -1,0 +1,23 @@
+# Package-generated local secrets. Each is an independent HMAC-SHA256 value
+# derived from the Umbrel seed, so they are stable across restarts and updates
+# but differ per install and per purpose.
+#
+# These protect only Recat's own state. The user's Intuit credentials and any AI
+# provider keys are entered in the app and encrypted at rest with
+# APP_RECAT_ENCRYPTION_KEY — they are never derived here.
+
+# Signs session cookies. Rotating it logs everyone out; nothing else breaks.
+export APP_RECAT_SESSION_SECRET="$(derive_entropy "app-recat-seed-session-secret")"
+
+# AES-256-GCM key for QuickBooks OAuth tokens and secrets at rest. The app
+# requires exactly 64 hex characters, which derive_entropy already produces.
+# Rotating this makes every stored token undecryptable — do not change it.
+export APP_RECAT_ENCRYPTION_KEY="$(derive_entropy "app-recat-seed-encryption-key")"
+
+# Authenticates the app container to the receipt extractor over the app's
+# private network. The extractor refuses to start on the dev default.
+export APP_RECAT_EXTRACTOR_TOKEN="$(derive_entropy "app-recat-seed-extractor-token")"
+
+# Postgres password. Only ever used over the app's internal network; the
+# database is not published to the host.
+export APP_RECAT_DB_PASSWORD="$(derive_entropy "app-recat-seed-db-password")"

--- a/recat/umbrel-app.yml
+++ b/recat/umbrel-app.yml
@@ -48,7 +48,7 @@ website: https://github.com/tx-joshg/recat-qbo
 dependencies: []
 repo: https://github.com/tx-joshg/recat-qbo
 support: https://github.com/tx-joshg/recat-qbo/issues
-port: 3009
+port: 3019
 path: ""
 gallery: []
 defaultUsername: admin@recat.local

--- a/recat/umbrel-app.yml
+++ b/recat/umbrel-app.yml
@@ -55,4 +55,4 @@ defaultUsername: admin@recat.local
 defaultPassword: ""
 deterministicPassword: true
 submitter: Josh Goble
-submission: https://github.com/getumbrel/umbrel-apps/pull/PENDING
+submission: https://github.com/getumbrel/umbrel-apps/pull/6019

--- a/recat/umbrel-app.yml
+++ b/recat/umbrel-app.yml
@@ -1,0 +1,58 @@
+manifestVersion: 1
+id: recat
+category: finance
+name: Recat
+tagline: Self-hosted transaction categorization and review queue for QuickBooks Online
+description: >-
+  Recat gives your team a simple queue for categorizing uncategorized QuickBooks
+  Online transactions, without giving everyone a QuickBooks login.
+
+
+  A QuickBooks bank rule auto-adds bank feed items to a holding account. Recat
+  syncs that account to your Umbrel, your team categorizes in the web UI, and
+  Recat writes each transaction back to QuickBooks with the correct category,
+  splits, or transfers. Every write is recorded in an append-only audit log
+  before it happens, and dry-run mode is on by default until you turn it off.
+
+
+  Includes rules, splits, transfer detection, bulk posting, sales-tax handling,
+  reports rendered from QuickBooks' own Reports API, private tags, receipt
+  capture and matching, and an MCP server so an AI assistant can work the queue
+  through the same verified paths the UI uses.
+
+
+  Your credentials, your server, your data. No third-party service in the
+  middle, no telemetry. You supply your own free Intuit developer keys, and the
+  first-run wizard walks you through everything — including a built-in demo
+  QuickBooks if you want to try it before connecting real books.
+
+
+  Connecting real QuickBooks needs an HTTPS address. Intuit will not accept a
+  plain http redirect URI for a production app, so umbrel.local cannot be
+  registered with them. If you front your Umbrel with TLS — Tailscale Serve and
+  Cloudflare Tunnel both issue real certificates — set that address in the setup
+  wizard and register the redirect URI it shows you. Without one, the built-in
+  demo QuickBooks works fully and real books will not connect.
+
+
+  Note on first run: the wizard asks for the app password shown on this page, so
+  that nobody but you can set this instance up. It fills in the administrator
+  address for you, and that same password signs you in afterwards. Change the
+  address and the password stops working — Umbrel installs have no outbound
+  email, so until you add SMTP in Settings you would have to fetch each sign-in
+  link from this app's logs by hand.
+version: "0.1.5"
+releaseNotes: ""
+developer: Josh Goble
+website: https://github.com/tx-joshg/recat-qbo
+dependencies: []
+repo: https://github.com/tx-joshg/recat-qbo
+support: https://github.com/tx-joshg/recat-qbo/issues
+port: 3009
+path: ""
+gallery: []
+defaultUsername: admin@recat.local
+defaultPassword: ""
+deterministicPassword: true
+submitter: Josh Goble
+submission: https://github.com/getumbrel/umbrel-apps/pull/PENDING


### PR DESCRIPTION
## App

**Recat** — self-hosted transaction categorization and review queue for QuickBooks Online.
Version `0.1.5`.

- Upstream project: https://github.com/tx-joshg/recat-qbo
- License: AGPL-3.0-only
- Support: https://github.com/tx-joshg/recat-qbo/issues

A QuickBooks bank rule auto-adds bank feed items to a holding account. Recat syncs that account, a team categorizes in the web UI without anyone needing a QuickBooks login, and each transaction is written back with its category, splits or transfers. Every write is recorded in an append-only audit log before it happens, and dry-run mode is on by default until the operator turns it off.

## Images

Built from the upstream repo by its own GitHub Actions workflow and published to GHCR. Pinned by **index digest**, so `docker pull` still resolves per architecture:

| image | digest | platforms |
|---|---|---|
| `ghcr.io/tx-joshg/recat-qbo` | `sha256:b1c3d9d2…` | `linux/amd64`, `linux/arm64` |
| `ghcr.io/tx-joshg/recat-qbo/receipt-extractor` | `sha256:e3685b43…` | `linux/amd64`, `linux/arm64` |
| `postgres:17-alpine` | `sha256:742f40ea…` | upstream |

## Setup behaviour and credentials

- `defaultUsername: admin@recat.local` with `deterministicPassword: true`. The package sets `LOCAL_ADMIN_PASSWORD=${APP_PASSWORD}`, and the first-run wizard **requires that password** before it will create the first administrator — an instance reachable by others cannot be claimed by whoever finds it first.
- No outbound email. Local sign-in is the way in; magic links are written to the app's logs rather than returned to unauthenticated callers.
- **`PROXY_AUTH_ADD: 'false'`** — needed, not incidental. With Umbrel's dashboard auth on, `app_proxy` redirects to `http://127.0.0.1:2000`, which nothing outside the box can reach, so the QuickBooks OAuth callback returns 502 through a TLS front and real books can never be connected. Measured on a device: 200 on loopback, 502 through Tailscale Serve, 502 on `/auth/qbo/callback`. Recat authenticates its own requests (sessions, magic links, a rate-limited local admin password, per-company roles).
- **`TRUSTED_PROXY_HOP: 'true'`** — trusts the immediate peer as a reverse proxy **only when that peer is on a private network**. Sound here because this compose publishes no `ports:` for the server, so `app_proxy` is the only route to it. Without it every caller shares `app_proxy`'s address, so rate limits are deployment-wide and anyone can lock the owner out of sign-in.
- `TRUSTED_PROXY_IPS` deliberately unset — `app_proxy`'s address is Docker-assigned and not exposed as a variable.
- Postgres uses a **bind mount** under `${APP_DATA_DIR}` rather than a named volume, so Umbrel's backup/restore and update cycle covers it.
- The receipt extractor is included but **receipt extraction is off by default**; enabling it sends receipt images to whichever provider the operator configures. It is not published to the host.
- No host access, no privileged containers, no device passthrough. The extractor runs `read_only` with `cap_drop: ALL` and `no-new-privileges`.

## Connecting real QuickBooks needs HTTPS

Intuit will not accept a plain-http redirect URI for a production app, so `umbrel.local` cannot be registered with them. An operator who fronts their Umbrel with TLS (Tailscale Serve, Cloudflare Tunnel) sets that address in the wizard and registers the redirect URI it produces. Without one the built-in demo QuickBooks works fully and real books will not connect. This is stated in the app description so it is not discovered at the Intuit step.

## Testing performed

**On real Umbrel hardware**, by a contributor running the package on their own device:
- Installs and boots clean from the package directory
- The first-run wizard completes and the displayed app password signs in, tested against an empty database
- **Real QuickBooks connects through a TLS front** — signed in via Tailscale Serve, `POST /api/companies/<id>/test-connection` returned `ok: true`, `environment: production`, `mode: quickbooks`, which is a live Intuit call rather than a cached flag. `/auth/qbo/callback` lands on the app instead of 502ing.

**On an arm64 host**, booted from the pinned digests with `derive_entropy` simulated and `app_proxy` replaced by a direct port publish:
- All migrations apply to an empty database and do not re-run on the next boot
- The extractor answers `/healthz` from the app container and refuses connections from the host
- Receipt extraction defaults to off in the created schema
- Data lands in the `APP_DATA_DIR` bind mount and survives a full `down`/`up`, which is what an update does

**Scope note, so the above is not read as more than it is:** the hardware run and the arm64 boot were against the `v0.1.3` images. This submission pins `v0.1.5`, which adds support for localized (non-US) QuickBooks companies. Those exact images have not themselves been booted — `git diff v0.1.3 v0.1.5` is empty for `prisma/migrations`, the server entrypoint, `env`, the `Dockerfile`, and the auth/setup/proxy code, so the boot-relevant surface is unchanged, but that is an argument rather than a run.

## Port and id

`port: 3009` and id `recat` were checked against every manifest in `master` at submission time — 391 apps parsed, both free. (`3001` is taken by `ride-the-lightning`.)

## Assets

`gallery: []` per the packaging guidance for new submissions. Logo and screenshots:

- Logo (512×512 SVG): https://github.com/tx-joshg/recat-qbo/blob/main/client/public/icon.svg
- ![Queue](https://raw.githubusercontent.com/tx-joshg/recat-qbo/main/docs/screenshots/queue.png)
- ![Dashboard](https://raw.githubusercontent.com/tx-joshg/recat-qbo/main/docs/screenshots/dashboard.png)
- ![Reports](https://raw.githubusercontent.com/tx-joshg/recat-qbo/main/docs/screenshots/reports.png)
- ![Rules](https://raw.githubusercontent.com/tx-joshg/recat-qbo/main/docs/screenshots/rules.png)
- ![Queue, dark](https://raw.githubusercontent.com/tx-joshg/recat-qbo/main/docs/screenshots/queue-dark.png)
- ![Queue, mobile](https://raw.githubusercontent.com/tx-joshg/recat-qbo/main/docs/screenshots/mobile-queue.png)

Happy to adjust anything here — including the port, if 3009 is spoken for by something in flight.