### PR TITLE
Release Bisq 2 Node 2.1.12.0

### DIFF
--- a/bisq2-node/docker-compose.yml
+++ b/bisq2-node/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       APP_PORT: 8091
 
   server:
-    image: ghcr.io/bisq-network/bisq2-api:2.1.11.2@sha256:3dd9152da26fa6d409707e16b4e0a5725ed95e59383de02a1f5778ec75d69306
+    image: ghcr.io/bisq-network/bisq2-api:2.1.12.0@sha256:beba2f2db5aefca0f4b8d49285b105cb0b29d0eb0ed0f8136712aace0e167906
     restart: on-failure
     stop_grace_period: 1m
     mem_limit: 2g
@@ -24,7 +24,7 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   web:
-    image: ghcr.io/bisq-network/bisq2-api-web-ui:2.1.11.2@sha256:86b93c3b99661bed88011842b2e02504147546687af62b86fdd0a4a5e937add4
+    image: ghcr.io/bisq-network/bisq2-api-web-ui:2.1.12.0@sha256:d64c335cc21c69dc8d62f360e5d29ab974d0949f320ba1658cab0a4d5cc7f310
     restart: on-failure
     network_mode: "service:server"
     volumes:

--- a/bisq2-node/umbrel-app.yml
+++ b/bisq2-node/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bisq2-node
 category: bitcoin
 name: Bisq 2 Node
-version: "2.1.11.2"
+version: "2.1.12.0"
 tagline: Run your own Bisq 2 node for private Bitcoin trading
 description: >-
   Bisq Connect lets you buy and sell Bitcoin peer-to-peer from your phone. This
@@ -34,4 +34,4 @@ defaultUsername: ""
 defaultPassword: ""
 submitter: rodvar
 submission: https://github.com/getumbrel/umbrel-apps/pull/5850
-releaseNotes: "Bisq 2 Node 2.1.11.2 — Bisq 2 API 2.1.11 (bisq2 @ 9322011). Changes since 2.1.11.1: https://github.com/bisq-network/bisq2/compare/285cf42b5259c34f50a586620a75c6a8b1a158ab...932201100b181e1ecf6fd5f0fb3f0943c8ddd453"
+releaseNotes: "Maintenance update with the latest Bisq 2 upstream fixes and improvements (Bisq 2 API 2.1.12, bisq2 @ a1f8db1). Full changes: https://github.com/bisq-network/bisq2/compare/9322011...a1f8db1"

--- a/bisq2-node/umbrel-app.yml
+++ b/bisq2-node/umbrel-app.yml
@@ -34,4 +34,8 @@ defaultUsername: ""
 defaultPassword: ""
 submitter: rodvar
 submission: https://github.com/getumbrel/umbrel-apps/pull/5850
-releaseNotes: "Maintenance update with the latest Bisq 2 upstream fixes and improvements (Bisq 2 API 2.1.12, bisq2 @ a1f8db1). Full changes: https://github.com/bisq-network/bisq2/compare/9322011...a1f8db1"
+releaseNotes: >-
+  Important security update that fixes vulnerabilities identified during Bisq's recent security audit. Updating to this version is required to continue trading.
+
+
+  Full release notes can be found at https://github.com/bisq-network/bisq2/releases/tag/v2.1.12


### PR DESCRIPTION
Automated by the Release Umbrel images workflow (channel: official), opened from fork `rodvar/umbrel-apps` (we have pull-only access to `getumbrel/umbrel-apps`). Digest-pins the freshly-built images and bumps the manifest version to `2.1.12.0`. Merge to publish.