### PR TITLE
yuvomi: update to v2.50.3

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:2.44.0@sha256:2d9487c6fe48d1df0012d0994f9387c60aa1ed8236b4d7eea53d03042987113c
+    image: ghcr.io/ulsklyc/yuvomi:2.50.3@sha256:80fe2a76ad0cbccd800c32d62d15db32d168024a2aaf816f94d0cdecbe4992ce
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "2.44.0"
+version: "2.50.3"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -51,39 +51,33 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  The Tasks module now keeps a history of what was completed. Until now a task
-  simply carried the state "done", and nothing recorded when that happened or
-  who did it - so questions like "what did I get through today", "when did we
-  last clean the bathroom" or "who took the bins out" had no answer anywhere. A
-  third view sits beside List and Board: what was ticked off, grouped by day,
-  newest first, with the household member and the time. You can narrow it to one
-  person, and tapping an entry opens the task itself.
+  A design and usability release, with nothing to do by hand after the update.
 
 
-  A repeating task also shows when it was last done, going back through the
-  whole series rather than just the copy currently open. That is the question a
-  weekly chore actually raises, and it is the one the old "done" flag could
-  never answer, because completing a repeating task creates a fresh copy each
-  time.
+  Module headers across the app now keep every tool in reach. Tab bars and view
+  switchers used to squeeze into the title line — on desktop windows the Budget
+  header could show just one of its seven tabs, and the calendar's Agenda switch
+  hid behind a fade. Each of these bars now sits on its own full-width row, and
+  when one still overflows on a small phone, the next tab stays visibly cut at
+  the edge instead of disappearing.
 
 
-  The history starts empty, and that is expected. Recording begins with this
-  update - what your household ticked off before it was never written down
-  anywhere, so there is nothing to show yet. It fills up from the first task you
-  complete after updating.
+  The install banner no longer covers what you are trying to tap: it steps aside
+  while the quick-add menu or the shopping bulk actions are open, and once
+  dismissed it stays away for a month instead of a week.
 
 
-  The list respects who may see what, exactly as the task list does. A task kept
-  private stays out of everyone else's history, including after the fact: set a
-  task to private later, and it disappears from the history too.
-
-
-  Nothing needs configuring and there is nothing to do after the update - the
-  new table is created automatically on first start.
+  Phones gain room where it counts. Documents open in the compact list view by
+  default, medication names in Health wrap to a second line instead of being cut
+  off next to their button, and the empty meal slots stay hidden in the week
+  plan again. Recipes now show a small "Planned this week" note when they appear
+  in the current meal plan, and navigation badges tell their kind apart — an
+  upcoming birthday is no longer painted in the same alarm red as an overdue
+  task.
 
 
   Full release notes are available at
-  https://github.com/ulsklyc/yuvomi/releases/tag/v2.44.0
+  https://github.com/ulsklyc/yuvomi/releases/tag/v2.50.3
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db


### PR DESCRIPTION
Automated update of Yuvomi, prepared by the release workflow in `ulsklyc/yuvomi` and following this repo's `AGENTS.md`.

| | |
|---|---|
| Old version | `2.44.0` |
| New version | `2.50.3` |
| Upstream release | https://github.com/ulsklyc/yuvomi/releases/tag/v2.50.3 |
| Image | `ghcr.io/ulsklyc/yuvomi:2.50.3@sha256:80fe2a76ad0cbccd800c32d62d15db32d168024a2aaf816f94d0cdecbe4992ce` |
| Architectures | linux/amd64, linux/arm64 |
| Linter | passed (`node .tools/lint-apps.mjs yuvomi --check-images`) |

**Package changes**

- `yuvomi/docker-compose.yml`
- `yuvomi/umbrel-app.yml`

Manifest `version`, `releaseNotes` and the pinned image digest. No changes to compose wiring, env vars, volumes, ports, `app_proxy`, hooks, exports or permissions, so there is nothing for existing installs to migrate.

**Breaking changes**

None. This is a patch/minor upstream release; see the upstream notes above for the user-visible list.

**Testing performed**

- Upstream CI (`npm test`) green on the release commit.
- Image pulled from the public registry and pinned by the multi-arch index digest; `linux/amd64` and `linux/arm64` verified to be present in the manifest list.
- Manifest and compose parsed as YAML after editing.
- Repo linter: passed (`node .tools/lint-apps.mjs yuvomi --check-images`)

**Not tested**: the update path was not exercised through umbrelOS itself - this workflow has no Umbrel instance. The package change is limited to the manifest version, the release notes and the image digest.
