### PR TITLE
Add Clumoove

### DIFF
--- a/clumoove/data/postgres/.gitkeep
+++ b/clumoove/data/postgres/.gitkeep
@@ -1,0 +1,1 @@
+# gitkeep

--- a/clumoove/data/redis/.gitkeep
+++ b/clumoove/data/redis/.gitkeep
@@ -1,0 +1,1 @@
+# gitkeep

--- a/clumoove/data/storage/.gitkeep
+++ b/clumoove/data/storage/.gitkeep
@@ -1,0 +1,1 @@
+# gitkeep

--- a/clumoove/docker-compose.yml
+++ b/clumoove/docker-compose.yml
@@ -1,0 +1,66 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: clumoove_frontend_1
+      APP_PORT: 3000
+      PROXY_AUTH_ADD: "false"
+
+  postgres-db:
+    image: postgres:15-alpine@sha256:fe0737ba566a2c5b2a28f34433c0a423261900ec17b9bf7ad115e1aae7e57f1b
+    restart: on-failure
+    command: ["postgres", "-c", "max_connections=300"]
+    environment:
+      POSTGRES_USER: clumoove
+      POSTGRES_PASSWORD: ${APP_PASSWORD}
+      POSTGRES_DB: cloud_migration_db
+    volumes:
+      - ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
+
+  redis-queue:
+    image: redis:7-alpine@sha256:ff02b58f971e7d7d156a1267e283fcbbeee91773b6aa36c49dac28ecfe28eadf
+    restart: on-failure
+    command: redis-server --appendonly yes --requirepass "${APP_PASSWORD}" --bind 0.0.0.0
+    volumes:
+      - ${APP_DATA_DIR}/data/redis:/data
+
+  api-backend:
+    image: ghcr.io/xxroxxerxx/clumoove-api:v0.16.0@sha256:e089bb8ef0268bfc6b53337ad3e0f5ca3d2d22bcc56fc2940242be99005a2fc1
+    restart: on-failure
+    environment:
+      - DATABASE_URL=postgres://clumoove:${APP_PASSWORD}@postgres-db:5432/cloud_migration_db?sslmode=disable
+      - REDIS_URL=redis://:${APP_PASSWORD}@redis-queue:6379
+      - PORT=8000
+      - ENCRYPTION_SECRET_KEY=enc_${APP_PASSWORD}_clumoove_encryption_key_v1
+      - JWT_SECRET_KEY=jwt_${APP_PASSWORD}_clumoove_jwt_signing_key_32bytes_v1
+      - TRUSTED_PROXY=1
+      - LOCAL_STORAGE_ROOT=/clumoove
+    volumes:
+      - ${APP_DATA_DIR}/data/storage:/clumoove
+    depends_on:
+      - postgres-db
+      - redis-queue
+
+  migration-worker:
+    image: ghcr.io/xxroxxerxx/clumoove-worker:v0.16.0@sha256:a8d2a17ed3250684a7a6e4514b17f0a949b28dbfd193766c401e90e549e5de85
+    restart: on-failure
+    command: ["/app/worker"]
+    environment:
+      - DATABASE_URL=postgres://clumoove:${APP_PASSWORD}@postgres-db:5432/cloud_migration_db?sslmode=disable
+      - REDIS_URL=redis://:${APP_PASSWORD}@redis-queue:6379
+      - ENCRYPTION_SECRET_KEY=enc_${APP_PASSWORD}_clumoove_encryption_key_v1
+      - LOCAL_STORAGE_ROOT=/clumoove
+    volumes:
+      - ${APP_DATA_DIR}/data/storage:/clumoove
+    depends_on:
+      - postgres-db
+      - redis-queue
+
+  frontend:
+    image: ghcr.io/xxroxxerxx/clumoove-frontend:v0.16.0@sha256:16ea89b67068b49d5413d5eb354520da717418da823d13553756ab176c549f70
+    restart: on-failure
+    environment:
+      - CLUMOOVE_API_URL=
+    depends_on:
+      - api-backend

--- a/clumoove/umbrel-app.yml
+++ b/clumoove/umbrel-app.yml
@@ -1,0 +1,44 @@
+manifestVersion: 1
+id: clumoove
+category: files
+name: Clumoove
+version: 0.16.0
+tagline: Self-hosted cloud data migration & sync manager
+description: >-
+  Clumoove is a self-hosted cloud data migration and sync engine for files, calendars, and contacts.
+
+
+  Easily connect and sync data between cloud providers including Nextcloud, Google Drive, Dropbox, OneDrive, HiDrive, S3, WebDAV, SMB, SFTP, FTP, Immich, Seafile, Koofr, MEGA, and local storage.
+
+
+  - Zero-disk streaming transfers (no local disk retention)
+
+  - Multi-threaded background migrations and cron schedules
+
+  - 3-way hash verification & conflict resolution strategies
+
+  - Built-in cloud file manager with previews and thumbnail support
+
+  - Multi-channel completion notifications (Email, Telegram, Discord, Gotify, ntfy)
+
+  - Security-first architecture with AES-256-GCM encryption & audit logging
+releaseNotes: ""
+
+developer: Marcel Meyer
+website: https://github.com/xXRoxXeRXx/clumoove
+dependencies: []
+repo: https://github.com/xXRoxXeRXx/clumoove
+support: https://github.com/xXRoxXeRXx/clumoove/issues
+
+port: 8380
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+backupIgnore:
+  - data/redis/*
+
+submitter: Marcel Meyer
+submission: https://github.com/getumbrel/umbrel-apps


### PR DESCRIPTION
### App Details
- **App ID**: `clumoove`
- **App Name**: Clumoove
- **Version**: `0.16.0`
- **Category**: Files
- **Port**: `8380`
- **Upstream Repository**: https://github.com/xXRoxXeRXx/clumoove
- **Website**: https://clumoove.com/
- **License**: AGPL-3.0

### Image Sources & Architectures
All runtime images are publicly hosted on GitHub Container Registry (GHCR) with multi-architecture support (`linux/amd64`, `linux/arm64`):
- `ghcr.io/xxroxxerxx/clumoove-api:v0.16.0`
- `ghcr.io/xxroxxerxx/clumoove-worker:v0.16.0`
- `ghcr.io/xxroxxerxx/clumoove-frontend:v0.16.0`
- Base images: `postgres:15-alpine`, `redis:7-alpine`

### Overview
Clumoove is a self-hosted cloud data migration, sync, and snapshot backup engine for files, calendars, and contacts.
- **Zero-disk streaming transfers**: Direct memory streaming between providers without intermediate disk caching.
- **Multi-cloud connectivity**: Nextcloud, Google Drive, Dropbox, OneDrive, HiDrive, S3, WebDAV, SMB, SFTP, FTP, Immich, Seafile, Koofr, MEGA, and local storage.
- **Snapshot Backup & Restore**: Block-level deduplication (4-MiB SHA-256 blocks), 64-MiB immutable packs, two-phase restore with conflict preview, and retention policies.
- **Built-in Cloud File Manager**: Direct cloud browsing, in-browser previews (PDF, Office docs, media), and multi-file uploads.
- **Multi-channel Notifications**: Telegram, Discord, Gotify, ntfy, and Email.

---

### Permissions, Host Access & Security
- **Host Privileges**: None. No Docker socket access, no `privileged` mode, no `host` networking. All services run in an isolated bridge network.
- **Permissions**: None.
- **Data Persistence**: Strictly confined to `${APP_DATA_DIR}/data/` (`postgres`, `redis`, and local sandbox `storage`).
- **Secrets Handling**: Cryptographic key segregation derived from `${APP_PASSWORD}` for AES-256-GCM credential encryption and JWT signing. Ephemeral Redis queue data is excluded via `backupIgnore`.

---

### Onboarding & Authentication
- **Default Credentials**: None (`defaultUsername: ""`, `defaultPassword: ""`).
- **First-Run Experience**: Clumoove features a 1-click web onboarding flow. On cold start, the web UI automatically detects an empty database and presents the interactive Admin Setup Wizard (`/api/auth/setup-admin`) to create the initial admin account.
- **Routing**: `app_proxy` is configured with `PROXY_AUTH_ADD: "false"` so Clumoove manages its own user sessions, roles, and optional TOTP 2FA.

---

### Testing Performed
- [x] **Static Linter**: Passed `npm run lint:apps -- clumoove --check-images` and `git diff --check`.
- [x] **Automated Test Suites**: Passed 224 frontend unit/integration tests (vitest), Go backend test suite (`go test ./...`), Go vet (`go vet ./...`), ESLint, and TypeScript typechecks.
- [x] **Runtime Verification**: Tested on umbrelOS instance:
  - Clean 1-click install via `umbreld client apps.install.mutate --appId clumoove`.
  - Browser access via `app_proxy` on port 8380.
  - Interactive admin creation wizard on fresh install.
  - Container restart (`umbreld client apps.restart.mutate`) and persistence validation under `${APP_DATA_DIR}`.
  - Storage profile configuration and background transfer execution.

---

### App Store Review Assets (For Maintainers)

> *Note: In accordance with Umbrel submission guidelines, asset files are not committed to the package directory. Below are the reference assets for store review:*

* **App Logo**:
  https://raw.githubusercontent.com/xXRoxXeRXx/clumoove/master/frontend/public/clumoove_logo.svg

* **App Screenshot (Dashboard)**:
  ![Clumoove Dashboard](https://raw.githubusercontent.com/xXRoxXeRXx/clumoove/master/docs/assets/dashboard.png)
