### PR TITLE
Update BOLT12 Pay to 0.3.1

### DIFF
--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.3.0.7@sha256:8b24d40b6a45e9abee202dbbc528780084b9f07d720b5c5bfbcea6628be32e5b
+    image: alex71btc/bolt12-pay:0.3.1@sha256:c5c6a440e76668f9deab72ba566f0ce3246bf65b37ddeffb59cafd566d3b2d35
     restart: on-failure
     depends_on:
       - lndk

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.3.0.7
+version: 0.3.1
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
@@ -154,22 +154,51 @@ releaseNotes: |
 
   Highlights:
 
-  - Fixes BIP353 resolution on recent StartOS releases
-  - Restores Lightning Address payments on StartOS 0.4.x
-  - Improves Lightning Address fallback behaviour during temporary DNS transport failures
-  - Uses the system DNS resolver for improved compatibility across platforms
+  - Introduces Contacts for reusable Lightning payment destinations
+  - Supports Lightning Address, BOLT12 Offer, LNURL, BIP353, Nostr and Node ID contacts
+  - Contacts are automatically matched in Lightning Activity
+  - Multiple payment targets can be stored per contact with a selectable default
+  - Contacts can be created, edited, searched and deleted directly from the Pay interface
 
-  Compatibility:
+  Keysend:
 
-  - Verified on Docker deployments
-  - Verified on Umbrel
-  - Verified on StartOS 0.4.x
-  - Preserves existing DNSSEC behaviour and interoperability
+  - Adds outgoing Keysend payments directly from BOLT12 Pay
+  - Node IDs are automatically detected as Keysend payment targets
+  - Optional Keysend messages are supported
+  - Incoming and outgoing Keysend payments are correctly classified in Lightning Activity
+  - Existing contacts are automatically matched by Node ID
 
-  Notes:
+  Lightning Activity:
 
-  - No configuration changes are required.
-  - Existing Lightning Addresses, BIP353 addresses and BOLT12 Offers continue to work as before.
+  - Adds full-text search across the complete transaction history
+  - Search supports contact names, Lightning Addresses, BIP353 addresses, Node IDs, comments, payment hashes and payment methods
+  - Transaction history is loaded in efficient 50-payment pages
+  - "Load more" allows browsing arbitrarily old Lightning transactions without loading the entire history at once
+  - Closing Lightning Activity resets the view back to the latest 50 transactions
+  - Improved display of long BOLT12 Offers, Node IDs and technical payment data
+  - Improved contact, payment method and comment presentation
+
+  Payment Handling:
+
+  - Improved BOLT12, BIP353, Lightning Address, LNURL and BOLT11 history classification
+  - BIP353 payments preserve the original human-readable address in Lightning Activity
+  - BOLT11 invoices are not offered as reusable contacts
+  - Existing contacts can still be matched from BOLT11 destination Node IDs
+  - Improved preservation of payment metadata during LND history synchronization
+
+  User Interface:
+
+  - Complete German and English translations for Contacts and Keysend
+  - Dynamic Contacts, Lightning Activity and NWC elements update correctly when switching language
+  - Improved Lightning Activity layout and handling of long payment identifiers
+  - Numerous UI refinements and bug fixes
+
+  Upgrade Notes:
+
+  - Existing application data and payment history are preserved.
+  - No manual migration is required.
+  - Contacts are stored locally in the BOLT12 Pay database.
+  - LND v0.20.x and v0.21.x compatibility remains unchanged.
 
 dependencies:
   - lightning


### PR DESCRIPTION
This release introduces Contacts as a major new feature, adds outgoing Keysend payments, and improves Lightning Activity with full-history search and paginated loading.
Tested on Umbrel with BOLT12, BIP353, Lightning Address, BOLT11, Keysend, NWC, incoming Lightning Address, incoming Nostr Zap, Contacts matching, and transaction history search/pagination.
Existing application data and payment history are preserved. No manual migration is required.