### PR TITLE
lightning-terminal: update to v0.17.3-alpha

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.17.2-alpha-docker@sha256:76f6ff1785cfeba76cacc3d4baa17beb57f2e0b8354c65e2c9a98cb940988e79
+    image: lightninglabs/lightning-terminal:v0.17.3-alpha@sha256:1f2844d20f0abe3effcdb2ff6a3473db92a5671345f0ed0f7fd1107b3220fd63
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.17.2-alpha"
+version: "0.17.3-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -58,7 +58,7 @@ deterministicPassword: true
 releaseNotes: >-
   ⚠️ Please update your Lightning Node app to the latest version available in the app store to ensure compatibility with Lightning Terminal.
 
-  This version of Lightning Terminal (LiT) ships lnd v0.21.2-beta, loop v0.34.0-beta-v0.8.1-tapd, faraday v0.2.16-alpha,
+  This version of Lightning Terminal (LiT) ships lnd v0.21.2-beta, loop v0.35.0-beta, faraday v0.2.18-alpha,
   pool v0.7.1-beta and tapd v0.8.1.
 
 
@@ -98,6 +98,6 @@ releaseNotes: >-
 
 
   This release packages LND v0.21.2-beta, Taproot Assets Daemon v0.8.1,
-  Loop v0.34.0-beta-v0.8.1-tapd, Pool v0.7.1-beta and Faraday v0.2.16-alpha.
+  Loop v0.35.0-beta, Pool v0.7.1-beta and Faraday v0.2.18-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
## Type

In this PR we update Litd to `v0.17.3-alpha`.

## App

`lightning-terminal`

## Summary

This release bumps the integrated `loop` to `v0.35.0-beta` & `faraday` to `v0.2.18-alpha` + additional updates and fixes within Litd.

See full release notes here:
https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.3-alpha
&
https://github.com/lightninglabs/lightning-terminal/blob/master/docs/release-notes/release-notes-0.17.3.md