### PR TITLE
yuvomi: update to v2.54.0

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:2.50.3@sha256:80fe2a76ad0cbccd800c32d62d15db32d168024a2aaf816f94d0cdecbe4992ce
+    image: ghcr.io/ulsklyc/yuvomi:2.54.0@sha256:f9c6d450e7de817f84debaa028772f57111d9312922c21f17b744ecd428c1502
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "2.50.3"
+version: "2.54.0"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -51,33 +51,30 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  A design and usability release, with nothing to do by hand after the update.
+  The Calendar tile on the Overview can now leave birthdays out. If your
+  household keeps the Birthdays tile there as well, every birthday was showing
+  up twice - once under Birthdays, once among the next appointments - and hiding
+  the birthday layer inside the Calendar module did nothing about it. Open
+  Customise on the Overview, press the sliders button on the Calendar tile, and
+  the same "Birthdays" switch you know from the calendar's filter sheet is
+  there. Birthdays stay in unless you take them out, and taking them out fills
+  the freed rows with your next real appointments rather than leaving a shorter
+  list. It is a setting of your own account, so the wall tablet in the kitchen
+  and the phone in your pocket can each show what suits them.
 
 
-  Module headers across the app now keep every tool in reach. Tab bars and view
-  switchers used to squeeze into the title line — on desktop windows the Budget
-  header could show just one of its seven tabs, and the calendar's Agenda switch
-  hid behind a fade. Each of these bars now sits on its own full-width row, and
-  when one still overflows on a small phone, the next tab stays visibly cut at
-  the edge instead of disappearing.
+  The Notes tile now shows as many notes as it has room for. It was capped at
+  three regardless of how large you had made it, so at its normal size roughly a
+  third of the card sat empty - and a household with five pinned notes saw three
+  of them, while the figure next to it said five. It now fills the space it has:
+  five notes when the tile is tall, three when it is flat.
 
 
-  The install banner no longer covers what you are trying to tap: it steps aside
-  while the quick-add menu or the shopping bulk actions are open, and once
-  dismissed it stays away for a month instead of a week.
-
-
-  Phones gain room where it counts. Documents open in the compact list view by
-  default, medication names in Health wrap to a second line instead of being cut
-  off next to their button, and the empty meal slots stay hidden in the week
-  plan again. Recipes now show a small "Planned this week" note when they appear
-  in the current meal plan, and navigation badges tell their kind apart — an
-  upcoming birthday is no longer painted in the same alarm red as an overdue
-  task.
+  Nothing to do after the update - no migration, and no settings changed.
 
 
   Full release notes are available at
-  https://github.com/ulsklyc/yuvomi/releases/tag/v2.50.3
+  https://github.com/ulsklyc/yuvomi/releases/tag/v2.54.0
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db


### PR DESCRIPTION
Automated update of Yuvomi, prepared by the release workflow in `ulsklyc/yuvomi` and following this repo's `AGENTS.md`.

| | |
|---|---|
| Old version | `2.50.3` |
| New version | `2.54.0` |
| Upstream release | https://github.com/ulsklyc/yuvomi/releases/tag/v2.54.0 |
| Image | `ghcr.io/ulsklyc/yuvomi:2.54.0@sha256:f9c6d450e7de817f84debaa028772f57111d9312922c21f17b744ecd428c1502` |
| Architectures | linux/amd64, linux/arm64 |
| Linter | passed (`node .tools/lint-apps.mjs yuvomi --check-images`) |

**Package changes**

- `yuvomi/docker-compose.yml`
- `yuvomi/umbrel-app.yml`

Manifest `version`, `releaseNotes` and the pinned image digest. No changes to compose wiring, env vars, volumes, ports, `app_proxy`, hooks, exports or permissions, so there is nothing for existing installs to migrate.

**Breaking changes**

None. This is a patch/minor upstream release; see the upstream notes above for the user-visible list.

**Testing performed**

- Upstream CI (`npm test`) green on the release commit.
- Image pulled from the public registry and pinned by the multi-arch index digest; `linux/amd64` and `linux/arm64` verified to be present in the manifest list.
- Manifest and compose parsed as YAML after editing.
- Repo linter: passed (`node .tools/lint-apps.mjs yuvomi --check-images`)

**Not tested**: the update path was not exercised through umbrelOS itself - this workflow has no Umbrel instance. The package change is limited to the manifest version, the release notes and the image digest.
