### PR TITLE
Add Scrypted

### DIFF
--- a/scrypted/docker-compose.yml
+++ b/scrypted/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.7"
+
+services:
+  scrypted:
+    image: ghcr.io/koush/scrypted:v0.143.0-noble-full@sha256:f23251dad07cf02b4b6b2e364e7948ab9fb77656e31f226186c2ba5304ebd2cd
+    network_mode: host
+    restart: on-failure
+    stop_grace_period: 1m
+
+    environment:
+      SCRYPTED_SECURE_PORT: "11443"
+      SCRYPTED_INSECURE_PORT: "11080"
+      # Uncomment to add the optional paid Scrypted NVR plugin for 24/7 local recording.
+      # SCRYPTED_NVR_VOLUME: /nvr
+
+    volumes:
+      - ${APP_DATA_DIR}/data/volume:/server/volume
+      # Uncomment to add the optional paid Scrypted NVR plugin for 24/7 local recording.
+      # - ${APP_DATA_DIR}/data/nvr:/nvr

--- a/scrypted/docker-compose.yml
+++ b/scrypted/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       SCRYPTED_SECURE_PORT: "11443"
       SCRYPTED_INSECURE_PORT: "11080"
+      SCRYPTED_DOCKER_AVAHI: "true"
       # Uncomment to add the optional paid Scrypted NVR plugin for 24/7 local recording.
       # SCRYPTED_NVR_VOLUME: /nvr
 

--- a/scrypted/umbrel-app.yml
+++ b/scrypted/umbrel-app.yml
@@ -24,4 +24,4 @@ permissions:
   - GPU
 releaseNotes: ""
 submitter: panagiotuandrew
-submission: ""
+submission: https://github.com/getumbrel/umbrel-apps/pull/6033

--- a/scrypted/umbrel-app.yml
+++ b/scrypted/umbrel-app.yml
@@ -1,0 +1,27 @@
+manifestVersion: 1
+id: scrypted
+category: automation
+name: Scrypted
+version: "0.143.0"
+tagline: "High-performance camera integration platform"
+description: >-
+  Scrypted is a high-performance and open-source camera integration platform. With a wide variety of plugins available, it can bridge many third-party and non-certified cameras to major home automation platforms (like HomeKit, Alexa, Google Home, and more).
+
+
+  If you also want 24/7 local recording of your cameras, you can optionally install the Scrypted NVR plugin, which adds smart detections & timeline events, advanced AI object detection, and natural language AI search. 
+developer: Scrypted
+website: https://scrypted.app
+dependencies: []
+repo: https://github.com/koush/scrypted
+support: https://github.com/koush/scrypted/discussions
+port: 11080
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+torOnly: false
+permissions:
+  - GPU
+releaseNotes: ""
+submitter: panagiotuandrew
+submission: ""

--- a/scrypted/umbrel-app.yml
+++ b/scrypted/umbrel-app.yml
@@ -8,7 +8,7 @@ description: >-
   Scrypted is a high-performance and open-source camera integration platform. With a wide variety of plugins available, it can bridge many third-party and non-certified cameras to major home automation platforms (like HomeKit, Alexa, Google Home, and more).
 
 
-  If you also want 24/7 local recording of your cameras, you can optionally install the Scrypted NVR plugin, which adds smart detections & timeline events, advanced AI object detection, and natural language AI search. 
+  If you also want 24/7 local recording of your cameras, you can optionally install the Scrypted NVR plugin, which adds smart detections & timeline events, advanced AI object detection, and natural language AI search.
 developer: Scrypted
 website: https://scrypted.app
 dependencies: []


### PR DESCRIPTION
<!--
Title format:
- Add <app name>
- Update <app name> to <version>
- Fix <app name> <issue>
-->

## Type

New app

## App

App ID: `scrypted`
Upstream project: https://github.com/koush/scrypted
Version: `0.143.0`

## Summary

Added the Scrypted app, which is a high-performance camera integration platform.

- The package uses Scrypted’s multi-architecture `noble-full` image. 
- The optional paid Scrypted NVR plugin is not enabled by default.

## Verification

**Umbrel testing performed:**
- Fresh installation through the Umbrel Web UI on an Umbrel Home
- Scrypted opened successfully from the Umbrel home screen
- Scrypted first-run administrator account creation
- ONVIF camera integration
- HomeKit pairing
- Video streaming and two-way audio
- App restart through Umbrel
- Camera and HomeKit configuration persistence after restart
- Backup and restore verification

**Environment tested:**
- [X] Umbrel device (Umbrel Home)
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

**Architecture tested:**
- [X] amd64
- [ ] arm64

> The `noble-full` image supports both amd64 and arm64. Runtime testing was performed on amd64 only.

**Known lint warnings or caveats:**
- Host networking (`WARNING access.host_network scrypted/docker-compose.yml:6`), which is required for HomeKit/Bonjour/mDNS and camera discovery.

## Notes

Permissions, dependencies, migrations, default credentials, or caveats:
- Uses `permissions: [GPU]` for hardware acceleration, if available.
- Creates its own administrator account during first launch, no default credentials are needed.
- Scrypted NVR is an optional paid add-on, so its  volume configuration is commented out by default. If needed, users can modify it themselves by editing the docker-compose.yml.
- Scrypted’s internal Avahi reports a warning because umbrelOS also runs Avahi. HomeKit pairing and camera functionality were verified to work despite this warning.
- No Watchtower service or Docker socket access is included.

## Logo Reference and Screenshots

**Logo:** https://github.com/user-attachments/assets/2b5b2320-5de7-41a7-91fc-0e460f697118

**Screenshot 1:** https://github.com/user-attachments/assets/fd7e26be-987a-4ae5-b5f1-4482954a0aea
**Screenshot 2:** https://github.com/user-attachments/assets/5e343aa7-c238-41ee-a166-f666223fe969
**Screenshot 2 caption:** Over 150 integrations supported
**Screenshot 3:** https://github.com/user-attachments/assets/b312e233-ef99-499e-b7c6-242659032dce
**Screenshot 4:** https://github.com/user-attachments/assets/f467bcd1-a958-4e60-aae8-88a9cdc073e9
