### PR TITLE
yuvomi: update to v2.62.0

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:2.54.0@sha256:f9c6d450e7de817f84debaa028772f57111d9312922c21f17b744ecd428c1502
+    image: ghcr.io/ulsklyc/yuvomi:2.62.0@sha256:8a45f3cab10feb241573a926a1dc25e2b415a21f20cefee2f380288819d435a9
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "2.54.0"
+version: "2.62.0"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -51,30 +51,48 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  The Calendar tile on the Overview can now leave birthdays out. If your
-  household keeps the Birthdays tile there as well, every birthday was showing
-  up twice - once under Birthdays, once among the next appointments - and hiding
-  the birthday layer inside the Calendar module did nothing about it. Open
-  Customise on the Overview, press the sliders button on the Calendar tile, and
-  the same "Birthdays" switch you know from the calendar's filter sheet is
-  there. Birthdays stay in unless you take them out, and taking them out fills
-  the freed rows with your next real appointments rather than leaving a shorter
-  list. It is a setting of your own account, so the wall tablet in the kitchen
-  and the phone in your pocket can each show what suits them.
+  An invitation now decides what the new member can see, before they first sign
+  in. Until now anyone you invited started with access to every module and you
+  could only take things away afterwards, which is the wrong way round: access
+  can be widened later, but somebody who has already seen something cannot
+  un-see it. The invitation form has a new "starting permissions" field, and it
+  starts on the narrow option, which leaves Health, Budget and Documents locked.
+  Underneath, the form tells you what your choice means right now. Nothing
+  changes for the people already in your household, for invitations you have
+  already sent, or for the permissions you have configured.
 
 
-  The Notes tile now shows as many notes as it has room for. It was capped at
-  three regardless of how large you had made it, so at its normal size roughly a
-  third of the card sat empty - and a household with five pinned notes saw three
-  of them, while the figure next to it said five. It now fills the space it has:
-  five notes when the tile is tall, three when it is flat.
+  Each person can now choose what their own new health entries start as, per
+  measurement. The request was to make blood pressure visible to the family by
+  default, so that in an emergency somebody knows the usual values. Changing
+  that for everyone would have shared readings that people expected to stay
+  private, so the choice sits with you instead: under Settings, Personal, Health
+  you set it for blood pressure, blood sugar, weight and the rest separately,
+  plus medications, lab reports and activities. Entries you have already
+  recorded keep their current visibility, and after a change the page offers to
+  move them along. Sharing your blood pressure does not share your mood, and the
+  private/family switch on each individual entry is unchanged.
 
 
-  Nothing to do after the update - no migration, and no settings changed.
+  The changelog opens with what has changed in your app since you last looked.
+  Releases arrive quickly here, and following them meant reading a long list.
+  Now the view starts with a short, scannable summary of the changes between the
+  version you last saw and the one you are running, each line expandable if you
+  want the reasoning. Two things are worth knowing after this update: what you
+  have seen is now remembered on your account rather than in the browser, so a
+  phone and a tablet no longer show you the same news twice, and the summary
+  will be empty the first time you open it, because there is no earlier mark to
+  compare against yet. From your next update onwards it will be filled.
+
+
+  Yuvomi also links to a user guide now, written and maintained by a member of
+  the community in their own repository. You will find it in the app under Help,
+  in the README and on yuvomi.cloud, marked as community-maintained so nobody
+  mistakes it for an official reference: it can lag behind a release.
 
 
   Full release notes are available at
-  https://github.com/ulsklyc/yuvomi/releases/tag/v2.54.0
+  https://github.com/ulsklyc/yuvomi/releases/tag/v2.62.0
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db


### PR DESCRIPTION
Automated update of Yuvomi, prepared by the release workflow in `ulsklyc/yuvomi` and following this repo's `AGENTS.md`.

| | |
|---|---|
| Old version | `2.54.0` |
| New version | `2.62.0` |
| Upstream release | https://github.com/ulsklyc/yuvomi/releases/tag/v2.62.0 |
| Image | `ghcr.io/ulsklyc/yuvomi:2.62.0@sha256:8a45f3cab10feb241573a926a1dc25e2b415a21f20cefee2f380288819d435a9` |
| Architectures | linux/amd64, linux/arm64 |
| Linter | passed (`node .tools/lint-apps.mjs yuvomi --check-images`) |

**Package changes**

- `yuvomi/docker-compose.yml`
- `yuvomi/umbrel-app.yml`

Manifest `version`, `releaseNotes` and the pinned image digest. No changes to compose wiring, env vars, volumes, ports, `app_proxy`, hooks, exports or permissions, so there is nothing for existing installs to migrate.

**Breaking changes**

None. This is a patch/minor upstream release; see the upstream notes above for the user-visible list.

**Testing performed**

- Upstream CI (`npm test`) green on the release commit.
- Image pulled from the public registry and pinned by the multi-arch index digest; `linux/amd64` and `linux/arm64` verified to be present in the manifest list.
- Manifest and compose parsed as YAML after editing.
- Repo linter: passed (`node .tools/lint-apps.mjs yuvomi --check-images`)

**Not tested**: the update path was not exercised through umbrelOS itself - this workflow has no Umbrel instance. The package change is limited to the manifest version, the release notes and the image digest.
