### PR TITLE
Update BOLT12 Pay to 0.3.2

### DIFF
--- a/bolt12-pay/docker-compose.yml
+++ b/bolt12-pay/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8081
       PROXY_AUTH_WHITELIST: "/,/alias,/alias/*,/.well-known,/.well-known/*,/api/lnurl,/api/lnurl/*,/api/qr,/api/qr/*,/icon.svg,/icon.png,/service-worker.js,/public.webmanifest,/assets,/assets/*"
   web:
-    image: alex71btc/bolt12-pay:0.3.1@sha256:c5c6a440e76668f9deab72ba566f0ce3246bf65b37ddeffb59cafd566d3b2d35
+    image: alex71btc/bolt12-pay:0.3.2@sha256:04e3c39d41266ae9b8dbc153647d35e750a60c11d063c74b755a446ccb153260
     restart: on-failure
     depends_on:
       - lndk

--- a/bolt12-pay/umbrel-app.yml
+++ b/bolt12-pay/umbrel-app.yml
@@ -3,7 +3,7 @@ id: bolt12-pay
 name: BOLT12 Pay
 tagline: Self-hosted Lightning payments and identity with BOLT12, BIP353, LNURL, and Nostr
 category: bitcoin
-version: 0.3.1
+version: 0.3.2
 port: 8367
 description: >-
   BOLT12 Pay is a self-hosted Lightning payments and identity app for LND nodes.
@@ -151,54 +151,38 @@ submission: https://github.com/getumbrel/umbrel-apps/pull/5429
 repo: https://github.com/Alex71btc/lndk-pay
 support: https://github.com/Alex71btc/lndk-pay/issues
 releaseNotes: |
+  BIP353:
 
-  Highlights:
+  - Automatically detects missing public BIP353 TXT records in Cloudflare-managed setups
+  - Adds a guided repair flow before recreating a missing public BIP353 record
+  - Adds manual verification of published Alias Manager TXT records
+  - Adds manual verification of BIP353 addresses published from Offer History
+  - Verification distinguishes correct, missing, invalid and mismatched TXT records
+  - Draft and unpublished aliases are skipped during verification
 
-  - Introduces Contacts for reusable Lightning payment destinations
-  - Supports Lightning Address, BOLT12 Offer, LNURL, BIP353, Nostr and Node ID contacts
-  - Contacts are automatically matched in Lightning Activity
-  - Multiple payment targets can be stored per contact with a selectable default
-  - Contacts can be created, edited, searched and deleted directly from the Pay interface
+  DNS:
 
-  Keysend:
-
-  - Adds outgoing Keysend payments directly from BOLT12 Pay
-  - Node IDs are automatically detected as Keysend payment targets
-  - Optional Keysend messages are supported
-  - Incoming and outgoing Keysend payments are correctly classified in Lightning Activity
-  - Existing contacts are automatically matched by Node ID
-
-  Lightning Activity:
-
-  - Adds full-text search across the complete transaction history
-  - Search supports contact names, Lightning Addresses, BIP353 addresses, Node IDs, comments, payment hashes and payment methods
-  - Transaction history is loaded in efficient 50-payment pages
-  - "Load more" allows browsing arbitrarily old Lightning transactions without loading the entire history at once
-  - Closing Lightning Activity resets the view back to the latest 50 transactions
-  - Improved display of long BOLT12 Offers, Node IDs and technical payment data
-  - Improved contact, payment method and comment presentation
-
-  Payment Handling:
-
-  - Improved BOLT12, BIP353, Lightning Address, LNURL and BOLT11 history classification
-  - BIP353 payments preserve the original human-readable address in Lightning Activity
-  - BOLT11 invoices are not offered as reusable contacts
-  - Existing contacts can still be matched from BOLT11 destination Node IDs
-  - Improved preservation of payment metadata during LND history synchronization
+  - Fixes parsing of long BIP353 TXT records split into multiple quoted DNS strings
+  - Prevents valid Cloudflare TXT records from being incorrectly reported as containing a different offer
+  - Guided repair leaves existing invalid or unrelated TXT records untouched
 
   User Interface:
 
-  - Complete German and English translations for Contacts and Keysend
-  - Dynamic Contacts, Lightning Activity and NWC elements update correctly when switching language
-  - Improved Lightning Activity layout and handling of long payment identifiers
-  - Numerous UI refinements and bug fixes
+  - Fixes Contacts modal scrolling and usability on mobile screens
+  - Adds German and English BIP353 verification and repair messages
+  - Adds BIP353 verification controls to Alias Manager and Generated Offers
+  - Keeps the configured public BOLT12 address and QR code usable while its DNS record is missing
+
+  Diagnostics:
+
+  - Improves NWC logging while reducing exposure of long cryptographic identifiers
+  - Redacts BIP353 domains in logs while keeping useful troubleshooting context
 
   Upgrade Notes:
 
-  - Existing application data and payment history are preserved.
-  - No manual migration is required.
-  - Contacts are stored locally in the BOLT12 Pay database.
-  - LND v0.20.x and v0.21.x compatibility remains unchanged.
+  - Existing application data and payment history are preserved
+  - No manual migration is required
+  - LND v0.20.x and v0.21.x compatibility remains unchanged
 
 dependencies:
   - lightning


### PR DESCRIPTION
## BOLT12 Pay 0.3.2

Updates BOLT12 Pay from 0.3.1 to 0.3.2.

### BIP353 / Cloudflare DNS automation

The following BIP353 DNS features apply specifically when BOLT12 Pay is configured to use **Cloudflare DNS automation mode**:

- Adds automatic detection and guided repair for missing public BIP353 TXT records
- Adds manual verification of published Alias Manager BIP353 records
- Adds manual verification of BIP353 addresses published from Offer History
- Distinguishes correct, missing, invalid and mismatched TXT records
- Fixes parsing of long Cloudflare TXT records split into multiple DNS strings
- Prevents valid Cloudflare-managed BIP353 records from being incorrectly reported as containing a different offer
- Guided repair leaves existing invalid or unrelated TXT records untouched

Manual DNS setups and other DNS providers are not automatically modified or verified by these Cloudflare-specific features.

### Other changes

- Fixes Contacts modal scrolling and usability on mobile screens
- Adds German and English BIP353 verification and repair UI
- Improves NWC diagnostics while reducing exposure of long cryptographic identifiers

### Docker

`alex71btc/bolt12-pay:0.3.2`

Multi-arch image for:

- linux/amd64
- linux/arm64

Pinned digest:

`sha256:04e3c39d41266ae9b8dbc153647d35e750a60c11d063c74b755a446ccb153260`

### Testing

- Tested locally on Umbrel
- Cloudflare DNS automation BIP353 verification and repair tested
- Alias Manager verification tested in Cloudflare DNS automation mode
- Offer History BIP353 verification tested in Cloudflare DNS automation mode
- Mobile Contacts UI tested
- German and English UI verified