### PR TITLE
Add WebDataStudio 1.3.0

### DIFF
--- a/webdatastudio/docker-compose.yml
+++ b/webdatastudio/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: webdatastudio_server_1
+      APP_PORT: 8080
+
+  server:
+    image: ghcr.io/fgilde/webdatastudio:v1.3.0@sha256:e7769d9690315217296bc7cb7bd0ea278ea02eef41c7cb4911e5b767f0ed3347
+    restart: on-failure
+    stop_grace_period: 1m
+    user: "1000:1000"
+    environment:
+      # Both halves together turn the login screen on. With neither set the studio serves without
+      # one, which is the wrong default for something that holds database credentials.
+      WDS_USER: admin
+      WDS_PASSWORD: ${APP_PASSWORD}
+      WDS_TITLE: WebDataStudio
+    volumes:
+      # Saved connections, query history, layouts and the studio's own SQLite database.
+      - ${APP_DATA_DIR}/data:/data

--- a/webdatastudio/umbrel-app.yml
+++ b/webdatastudio/umbrel-app.yml
@@ -1,0 +1,70 @@
+manifestVersion: 1
+id: webdatastudio
+category: developer
+name: WebDataStudio
+version: "1.3.0"
+tagline: A database studio that runs in your browser
+description: >-
+  WebDataStudio is a database client that lives on your server instead of on one laptop:
+  PostgreSQL, MySQL/MariaDB, SQL Server, SQLite, Oracle, DuckDB, ClickHouse, MongoDB and Redis, all
+  from a browser tab.
+
+
+  Sign in with the user name and password shown on this page. Connections are added in the studio and
+  kept in its own data directory, so nothing about your databases is written anywhere else.
+
+
+  🔍 EXPLORE
+
+
+  - Schema tree per connection: tables, views, columns, indexes, keys and routines
+
+  - ER diagrams drawn from the foreign keys, and a column-by-column comparison of two connections
+
+  - Row counts, sizes and a data preview without writing a statement
+
+
+  📝 QUERY
+
+
+  - SQL editor with completion from the live schema, history and saved queries
+
+  - A visual query builder for joins, filters and aggregates without SQL
+
+  - Results as a grid or a chart, exportable as CSV, JSON, Excel or SQL
+
+
+  🛠️ CHANGE
+
+
+  - Create and alter tables, columns, indexes and constraints in the UI
+
+  - Edit rows in the grid, with the statement shown before it runs
+
+  - Scheduled queries that write their result to a file
+
+
+  🤖 AGENTS
+
+
+  - An MCP endpoint gives an AI agent the same connections under the same rules
+
+  - Read-only connections are enforced in the driver, not only in the interface
+releaseNotes: ""
+
+developer: Florian Gilde
+website: https://fgilde.github.io/WebDataStudio/
+dependencies: []
+repo: https://github.com/fgilde/WebDataStudio
+support: https://github.com/fgilde/WebDataStudio/issues
+
+port: 8118
+gallery: []
+path: ""
+
+defaultUsername: "admin"
+defaultPassword: ""
+deterministicPassword: true
+
+submitter: Florian Gilde
+submission: ""

--- a/webdatastudio/umbrel-app.yml
+++ b/webdatastudio/umbrel-app.yml
@@ -67,4 +67,4 @@ defaultPassword: ""
 deterministicPassword: true
 
 submitter: Florian Gilde
-submission: ""
+submission: https://github.com/getumbrel/umbrel-apps/pull/6039


### PR DESCRIPTION
## WebDataStudio 1.3.0

A database client that runs on the server instead of on one laptop: PostgreSQL, MySQL/MariaDB, SQL
Server, SQLite, Oracle, DuckDB, ClickHouse, MongoDB and Redis in one container. Schema explorer, SQL
editor with completion and history, a visual query builder, result charts, ER diagrams drawn from the
foreign keys, schema editing, a column-by-column comparison between two connections, saved and
scheduled queries with file export, and an MCP endpoint so an agent can query the same connections
under the same rules.

- Upstream: https://github.com/fgilde/WebDataStudio (MIT)
- Docs: https://fgilde.github.io/WebDataStudio/
- Image: `ghcr.io/fgilde/webdatastudio:v1.3.0`, pinned to the manifest-list digest
  `sha256:e7769d9690315217296bc7cb7bd0ea278ea02eef41c7cb4911e5b767f0ed3347`
  (`linux/amd64` + `linux/arm64`, public, built by the project's own CI)
- I am the developer of the app and the submitter of this package.

## Package

```
webdatastudio/
  umbrel-app.yml
  docker-compose.yml
  data/.gitkeep
```

One service behind `app_proxy` (`port: 8118` → container `8080`), running as `1000:1000`, with
`${APP_DATA_DIR}/data:/data` for saved connections, query history, layouts and the studio's own
SQLite database. No host paths, no Docker socket, no privileged mode, no extra capabilities, no
raw published ports, no dependencies.

## Credentials

The studio has **no login screen at all** when neither `WDS_USER` nor `WDS_PASSWORD` is set, so the
package always sets both: `admin` and `${APP_PASSWORD}`, with `deterministicPassword: true` so
umbrelOS shows the password on the app page.

## Testing

- `npm run lint:apps -- webdatastudio --check-images`: clean.
- `docker buildx imagetools inspect ghcr.io/fgilde/webdatastudio:v1.3.0` lists `linux/amd64` and
  `linux/arm64` under the pinned index digest.
- Ran the pinned image with `--user 1000:1000` and the same bind mount: the UI answers, `/api/*`
  gives `401` without a session, a login with the packaged credentials returns `200` and a wrong
  password `401`, and `webdatastudio.db` is created in the mounted directory. Restarting the
  container against the same directory keeps the data.
- Screenshots and the logo are attached below for App Store assets; nothing image-related is
  committed in this PR.

## Screenshots and logo

Logo: https://raw.githubusercontent.com/fgilde/WebDataStudio/master/docs/assets/icon.png (SVG source:
https://raw.githubusercontent.com/fgilde/WebDataStudio/master/docs/assets/icon.svg)

Screenshots:

![SQL editor](https://raw.githubusercontent.com/fgilde/WebDataStudio/master/store/casaos/Apps/WebDataStudio/screenshot-1.png)
![Query builder](https://raw.githubusercontent.com/fgilde/WebDataStudio/master/store/casaos/Apps/WebDataStudio/screenshot-2.png)
![ER diagram](https://raw.githubusercontent.com/fgilde/WebDataStudio/master/store/casaos/Apps/WebDataStudio/screenshot-3.png)
