### PR TITLE
Add Videola 0.9.2

### DIFF
--- a/videola/docker-compose.yml
+++ b/videola/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: videola_server_1
+      APP_PORT: 7331
+
+  server:
+    image: ghcr.io/fgilde/videola:v0.9.2@sha256:503622ba8518e84e0f5e6b4cca786f1dde8dbce74301f23e54bef1954a5a8f09
+    restart: on-failure
+    stop_grace_period: 1m
+    environment:
+      # Bound to every interface inside its own container, because the proxy in front of it is a
+      # different container: 127.0.0.1 would be reachable only from this container's namespace.
+      VIDEOLA_HOST: 0.0.0.0
+      VIDEOLA_PORT: 7331
+      VIDEOLA_STORAGE_ROOT: /data
+      # Every /api call carries this as `Authorization: Bearer`, and the server refuses to listen on
+      # a reachable address without one - so this line is what makes the app start at all.
+      VIDEOLA_TOKEN: ${APP_SEED}
+      VIDEOLA_LOCALE: en
+    volumes:
+      # Projects and imported media.
+      - ${APP_DATA_DIR}/data:/data
+    healthcheck:
+      # Through the API rather than against the port: a listening socket says the process started,
+      # and what matters is that the core loaded and the storage root is writable.
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:7331/api/health',{headers:{authorization:'Bearer '+process.env.VIDEOLA_TOKEN}}).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s

--- a/videola/umbrel-app.yml
+++ b/videola/umbrel-app.yml
@@ -1,0 +1,65 @@
+manifestVersion: 1
+id: videola
+category: media
+name: Videola
+version: "0.9.2"
+tagline: Cut, grade, mix and export video in your browser
+description: >-
+  Videola is a video editor that runs in a browser and keeps its project model, its command
+  bus and its file format in a Rust core compiled to WebAssembly. Import footage, cut it on a
+  timeline, keyframe anything, grade it against real scopes, mix the sound to a loudness
+  target and export an MP4 — on this device, with nothing uploaded anywhere.
+
+
+  ✂️ EDITING
+
+
+  - Move and trim clips across tracks, ripple delete and trim, roll, slip and slide, group,
+    split, markers, snapping, and zoom from a single frame to the whole project
+
+  - One pointer path for mouse, pen and touch: it works on a tablet and on a phone
+
+  - Thirteen templates that bake into ordinary editable projects
+
+
+  🎨 PICTURE
+
+
+  - Grading against real scopes: waveform, vectorscope, histogram and parade
+
+  - Effects and transitions with keyframes on anything
+
+  - Motion blur averaged over eight real instants of a shutter
+
+
+  🔊 SOUND
+
+
+  - Mixing to a loudness target, stereo or 5.1 surround with a position per track
+
+  - Spectral noise reduction learned from the pauses in a recording
+
+
+  🤖 AND FOR AGENTS
+
+
+  - An HTTP API and an MCP server, so an agent can edit a project and look at what it did
+
+  - Every /api call needs the token Umbrel generates for this app
+releaseNotes: ""
+
+developer: gilde.org
+website: https://videola.app/
+dependencies: []
+repo: https://github.com/fgilde/videola
+support: https://github.com/fgilde/videola/issues
+
+port: 7331
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+submitter: Florian Gilde
+submission: ""

--- a/videola/umbrel-app.yml
+++ b/videola/umbrel-app.yml
@@ -62,4 +62,4 @@ defaultUsername: ""
 defaultPassword: ""
 
 submitter: Florian Gilde
-submission: ""
+submission: https://github.com/getumbrel/umbrel-apps/pull/6042


### PR DESCRIPTION
## Videola 0.9.2

A video editor that runs in a browser and keeps its project model, its command bus and its file
format in a Rust core compiled to WebAssembly. Import footage, cut it on a timeline, keyframe
anything, grade it against real scopes, mix the sound to a loudness target and export an MP4 — on the
device running the app, with nothing uploaded anywhere. Also thirteen templates that bake into
ordinary editable projects, motion blur averaged over eight real instants of a shutter, spectral
noise reduction, 5.1 surround with a position per track, scene detection, an HTTP API and an MCP
server.

- Upstream: https://github.com/fgilde/videola (GPL-3.0) · site https://videola.app/
- Image: `ghcr.io/fgilde/videola:v0.9.2`
  (`sha256:503622ba8518e84e0f5e6b4cca786f1dde8dbce74301f23e54bef1954a5a8f09`), public, manifest list
  with `linux/amd64` and `linux/arm64`
- I am the developer of the app and the submitter of this package.

## Package

```
videola/
  umbrel-app.yml
  docker-compose.yml
  data/.gitkeep
```

One service behind `app_proxy` (`port: 7331` → container `7331`), `${APP_DATA_DIR}/data:/data` for
projects and imported media. No host paths, no Docker socket, no privileged mode, no capabilities,
no raw published ports, no dependencies.

`VIDEOLA_TOKEN` is `${APP_SEED}`. That is not optional hardening: every `/api` call carries it as
`Authorization: Bearer`, and the server refuses to listen on anything but loopback without one, so
the app would not serve at all without it. The health check goes through `/api/health` with the same
token, because a check against the open port would only say the process started.

## Credentials

None to show. The editor opens straight into an empty project; the token is used by the app itself
and by anything driving the API, and Umbrel's own auth sits in front of the whole app.

## Testing

- `npm run lint:apps -- videola --check-images`: clean.
- `docker buildx imagetools inspect ghcr.io/fgilde/videola:v0.9.2` lists `linux/amd64` and
  `linux/arm64` under the pinned index digest. arm64 is new in this release: each architecture builds
  on a runner of that architecture and the two digests are merged, because the Rust/WASM build under
  emulation does not finish in a CI run.
- The image was run with exactly this environment and mount: the editor loads, `/api/health` without
  the token answers `401` and with it `200` plus the storage root it is using, and a restart against
  the same volume keeps the projects.
- The same package shape is checked against the server's own code by the project's test suite
  (`apps/server/src/deploy.test.ts`): the port, the storage root, the image tag and the token
  requirement are read from the code rather than typed out, so a drifting package fails that build.

## Screenshots and logo

Logo: https://raw.githubusercontent.com/fgilde/videola/main/brand/videola-icon.png

![The editor](https://raw.githubusercontent.com/fgilde/videola/main/store-assets/screenshot-1.png)
![Effects](https://raw.githubusercontent.com/fgilde/videola/main/store-assets/screenshot-2.png)
![Templates](https://raw.githubusercontent.com/fgilde/videola/main/store-assets/screenshot-3.png)
