### PR TITLE
App Submission: Kaspa Solo Mining Console 1.3.0

### DIFF
--- a/kaspa-stratum-manager/docker-compose.yml
+++ b/kaspa-stratum-manager/docker-compose.yml
@@ -1,0 +1,55 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: kaspa-stratum-manager_web_1
+      APP_PORT: 8080
+
+  web:
+    image: ghcr.io/noillion-labs/kaspa-stratum-manager:1.3.0@sha256:fe7075cd5897c2cb20291728213f59b9c325912f48ffce2268b0bbb439ef8fd7
+    command: ["npm", "run", "start", "--", "--hostname", "0.0.0.0", "--port", "8080"]
+    restart: on-failure
+    stop_grace_period: 30s
+    depends_on:
+      - manager
+    environment:
+      MANAGER_INTERNAL_URL: http://manager:8081
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8080/').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  manager:
+    image: ghcr.io/noillion-labs/kaspa-stratum-manager:1.3.0@sha256:fe7075cd5897c2cb20291728213f59b9c325912f48ffce2268b0bbb439ef8fd7
+    command: ["node", "server/manager.mjs"]
+    restart: on-failure
+    stop_grace_period: 30s
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "5555:5555/tcp"
+    volumes:
+      - "${APP_DATA_DIR}/data:/data"
+    environment:
+      APP_VERSION: "1.3.0"
+      BRIDGE_VERSION: "2.0.1"
+      APP_PROFILE: umbrel
+      MANAGER_HOST: 0.0.0.0
+      MANAGER_PORT: 8081
+      KASPA_NODE_GRPC: host.docker.internal:16110
+      BRIDGE_API_URL: http://127.0.0.1:3030
+      BRIDGE_COMMAND: /usr/local/bin/stratum-bridge
+      BRIDGE_ARGS_JSON: '["--config","/data/config.yaml","--node-mode","external","--kaspad-address","host.docker.internal:16110","--web-dashboard-port",":3030"]'
+      BRIDGE_WORKING_DIRECTORY: /data
+      RKSTRATUM_ALLOW_CONFIG_WRITE: "0"
+      DATA_DIR: /data
+      UMBREL_LOCAL_IPS: ${APP_KASPA_STRATUM_MANAGER_LOCAL_IPS:-}
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8081/api/manager/status').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s

--- a/kaspa-stratum-manager/exports.sh
+++ b/kaspa-stratum-manager/exports.sh
@@ -1,0 +1,5 @@
+# Evaluated by Umbrel on the host and passed to the app only to display a LAN
+# miner connection address. The discovered values are not persisted or logged.
+primary_ip=$(ip -4 route get 1 2>/dev/null | awk '{for (i=1; i<=NF; i++) if ($i == "src") {print $(i+1); exit}}') || primary_ip=""
+local_ips=$(hostname --all-ip-addresses 2>/dev/null | tr ' ' ',') || local_ips=""
+export APP_KASPA_STRATUM_MANAGER_LOCAL_IPS="${primary_ip},${local_ips}"

--- a/kaspa-stratum-manager/umbrel-app.yml
+++ b/kaspa-stratum-manager/umbrel-app.yml
@@ -1,0 +1,37 @@
+manifestVersion: 1
+id: kaspa-stratum-manager
+category: crypto
+name: Kaspa Solo Mining Console
+version: "1.3.0"
+tagline: Manage, monitor and understand Kaspa solo mining
+description: >-
+  Run and monitor the official Rusty Kaspa Stratum Bridge from a clear,
+  browser-based interface on your Umbrel. Connect compatible ASIC miners to
+  your own Rusty Kaspad node, manage safe bridge settings, and follow hashrate,
+  accepted shares, confirmed blocks, block luck, round effort, and seven-day
+  solo-mining estimates.
+
+
+  Kaspa Solo Mining Console keeps configuration and mining history on your
+  Umbrel, follows locally found blocks through DAG resolution to realised
+  rewards, includes bridge lifecycle controls, logs and diagnostics, and
+  automatically restores the last-known-good configuration if a settings
+  change fails. The official Rusty Kaspad app is required.
+releaseNotes: ""
+
+developer: NoillioN Labs
+website: https://github.com/NoillioN-Labs/kaspa-stratum-manager-community-store
+dependencies:
+  - rusty-kaspad
+repo: https://github.com/NoillioN-Labs/kaspa-stratum-manager-community-store
+support: https://github.com/NoillioN-Labs/kaspa-stratum-manager-community-store/issues
+
+port: 5556
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+submitter: Nathan Oldaker
+submission: ""

--- a/kaspa-stratum-manager/umbrel-app.yml
+++ b/kaspa-stratum-manager/umbrel-app.yml
@@ -34,4 +34,4 @@ defaultUsername: ""
 defaultPassword: ""
 
 submitter: Nathan Oldaker
-submission: ""
+submission: https://github.com/getumbrel/umbrel-apps/pull/6044


### PR DESCRIPTION
## Type

New app

## App

App ID: `kaspa-stratum-manager`

Upstream project: https://github.com/NoillioN-Labs/kaspa-stratum-manager-community-store

Version: `1.3.0`

## Summary

Kaspa Solo Mining Console provides a browser-based umbrelOS interface for operating and monitoring the official Rusty Kaspa Stratum Bridge alongside the official Rusty Kaspad app.

It gives solo miners local bridge lifecycle controls, safe configuration, connected-miner visibility, live hashrate and share statistics, confirmed-block tracking, DAG reward analytics, historical performance estimates, logs and diagnostics. Configuration and mining history persist under the app's Umbrel data directory.

Release image: `ghcr.io/noillion-labs/kaspa-stratum-manager:1.3.0`

Immutable digest: `sha256:fe7075cd5897c2cb20291728213f59b9c325912f48ffce2268b0bbb439ef8fd7`

Platforms: `linux/amd64`, `linux/arm64`

License: MIT. The bundled Rusty Kaspa ISC notice is retained in the public source.

## Verification

Umbrel testing performed:

Environment tested:

- [x] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:

- [x] amd64
- [ ] arm64

Physical environment: umbrelOS 1.7.4 on x86_64 hardware.

- Native AMD64 and ARM64 release builds passed.
- The public manifest contains both platforms, with SBOM and SLSA provenance.
- Production build, 36 automated tests, lint, packaging and sensitive-data checks passed.
- Exact 1.3.0 Community update path passed.
- Browser launch through App Proxy and Umbrel authentication passed.
- Rusty Kaspad v2.0.1 connectivity passed.
- IceRiver KS7 Lite reconnection and mining passed.
- IceRiver KS0 Ultra connection and mining passed.
- Bridge controls, settings persistence, mining-history persistence, reward-history persistence and Umbrel reboot recovery passed.

Known lint warnings or caveats:

- The official Umbrel app linter and GitHub `Lint apps` check passed with no issues or warnings.
- A fresh install from the official source was not performed; the exact immutable runtime image was tested through the Community update path.
- Physical ARM64 umbrelOS validation was not performed. ARM64 is native-build and container-execution validated.

## Notes

- Requires the official `rusty-kaspad` app.
- Uses Umbrel `app_proxy` with authentication enabled.
- TCP 5555 is intentionally published for LAN Stratum miners.
- Manager port 8081 and bridge API port 3030 are not host-published.
- Persistent state is under `${APP_DATA_DIR}/data`.
- Runtime LAN address discovery is used only for connection guidance and is not persisted or logged.
- No default username or password is required.
- No host networking, privileged mode, Docker socket, broad host mounts, devices or additional capabilities are used.
- Rusty Kaspad exposes gRPC on host TCP 16110 without an exports contract, so the package uses a narrow `host.docker.internal:16110` host-gateway connection.

### App Store assets

Source logo:

![Kaspa Solo Mining Console icon](https://raw.githubusercontent.com/NoillioN-Labs/kaspa-stratum-manager-community-store/main/kaspa-stratum-manager/icon.svg)

Overview:

![Kaspa Solo Mining Console overview](https://raw.githubusercontent.com/NoillioN-Labs/kaspa-stratum-manager-community-store/main/kaspa-stratum-manager/1.png)

Miners and solo-mining outlook:

![Kaspa Solo Mining Console miners](https://raw.githubusercontent.com/NoillioN-Labs/kaspa-stratum-manager-community-store/main/kaspa-stratum-manager/2.png)

The package deliberately keeps `gallery: []` and contains no committed icon or screenshots so Umbrel can host the final App Store assets separately.