### PR TITLE
Update fedimintd to v0.12.0

### DIFF
--- a/fedimintd/docker-compose.yml
+++ b/fedimintd/docker-compose.yml
@@ -22,4 +22,18 @@ services:
       FM_BITCOIND_PASSWORD: ${APP_BITCOIN_RPC_PASS}
       FM_BITCOIND_URL: "http://${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_RPC_PORT}"
       FM_BIND_UI: 0.0.0.0:8175
+      # Guardian admin credentials, split in two since v0.12.0.
+      #
+      # FM_PASSWORD_UI gates the web UI. When unset, fedimintd falls back to the
+      # legacy password.private file, and if that is absent too it serves the UI
+      # with no login form. Upstream treats that as safe only for the default
+      # loopback bind, but we bind 0.0.0.0 above.
+      #
+      # FM_PASSWORD_API gates admin RPCs on the public API (WS on bind-api and
+      # iroh on 8174/udp) and is what fedimint-cli admin authenticates with.
+      # It never falls back to disk; unset means admin RPCs return 401. Public
+      # client endpoints are unaffected either way. Same value as the UI so the
+      # guardian can read it from Umbrel's "Show password".
+      FM_PASSWORD_UI: "${APP_PASSWORD}"
+      FM_PASSWORD_API: "${APP_PASSWORD}"
     restart: on-failure

--- a/fedimintd/docker-compose.yml
+++ b/fedimintd/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8175 # ui
 
   fedimintd:
-    image: fedimint/fedimintd:v0.11.1@sha256:ba23a29ae5b71cf7685c0a4f6594ac92dc9fd6c8915fccc09c8100710177283e
+    image: fedimint/fedimintd:v0.12.0@sha256:f95630927a8ac902723fca1d7824ba76b3b80156599395c73d9bce7c92bf177d
     ports:
       - 8173:8173/tcp # p2p tls
       - 8173:8173/udp # p2p iroh

--- a/fedimintd/umbrel-app.yml
+++ b/fedimintd/umbrel-app.yml
@@ -61,10 +61,13 @@ gallery:
   - 3.jpg
 path: ""
 defaultUsername: ""
-defaultPassword: ""
+deterministicPassword: true
 submitter: Fedimint Developers
 submission: https://github.com/getumbrel/umbrel-apps/pull/3371
 releaseNotes: >-
+
+ - ⚠️ Your guardian UI password has changed.
+   The guardian password is now supplied by Umbrel instead of being chosen during setup. Find it under the app's "Show password" in the Umbrel dashboard. Your federation, funds and guardian config are unaffected — in v0.12.0 this password is only an admin credential and no longer encrypts anything. The same password authenticates fedimint-cli admin commands against your guardian.
 
  - V2 modules are now the default.
    Freshly set up federations run the lnv2, mintv2 and walletv2 modules by default instead of the v1 module set; the v1 modules are now labeled "legacy" in the setup UI. Existing federations keep their configured module set and are unaffected.

--- a/fedimintd/umbrel-app.yml
+++ b/fedimintd/umbrel-app.yml
@@ -65,10 +65,19 @@ deterministicPassword: true
 submitter: Fedimint Developers
 submission: https://github.com/getumbrel/umbrel-apps/pull/3371
 releaseNotes: >-
-  ⚠️ Guardians in an existing Iroh-based federation must coordinate this update. Iroh 1.0 guardian P2P is not wire-compatible with earlier releases, so consensus may pause until the upgraded guardians reach quorum. Rolling back after the new Iroh identity is advertised is unsupported. Review the full upstream upgrade notes with the other guardians before updating.
+  ⚠️ **Important: Please read both notices before updating.**
 
 
-  ⚠️ Your guardian admin password has changed. Umbrel now provides a unique password for the app instead of asking you to choose one during setup. It is shown when you first open the app and can be found again through the app's settings or credentials menu. This password is used for both the guardian UI and fedimint-cli admin commands; it no longer encrypts the guardian configuration.
+  **1. Coordinate with the other guardians**
+
+
+  If this guardian is part of an existing multi-guardian federation, coordinate the update. The Iroh networking change is incompatible with older releases, so consensus may pause until enough guardians upgrade. Rolling back after the new Iroh identity is published is unsupported.
+
+
+  **2. Your guardian admin password will change**
+
+
+  After updating, use the unique password provided by Umbrel—your previous password will no longer work. Find it when opening the app or in the app's settings or credentials menu.
 
 
   Highlights in this release:

--- a/fedimintd/umbrel-app.yml
+++ b/fedimintd/umbrel-app.yml
@@ -23,8 +23,8 @@ description: >-
   1. Install & Launch this Fedimint app (fedimintd) on your Umbrel
      Each participating guardian runs their own instance of fedimintd.
 
-  2. Get Your Guardian Password
-     Umbrel generates the guardian admin password. Open "Show password" for the app in the Umbrel dashboard, then use it to sign in.
+  2. Find Your Guardian Password
+     Umbrel provides a unique guardian admin password for the app. It is shown when you first open the app and can be found again through the app's settings or credentials menu.
 
   3. Generate Setup Code
      After signing in, a unique setup code is generated for each guardian.
@@ -68,7 +68,7 @@ releaseNotes: >-
   ⚠️ Guardians in an existing Iroh-based federation must coordinate this update. Iroh 1.0 guardian P2P is not wire-compatible with earlier releases, so consensus may pause until the upgraded guardians reach quorum. Rolling back after the new Iroh identity is advertised is unsupported. Review the full upstream upgrade notes with the other guardians before updating.
 
 
-  ⚠️ Your guardian admin password has changed. Umbrel now supplies it under the app's "Show password" option instead of asking you to choose one during setup. This password is used for both the guardian UI and fedimint-cli admin commands; it no longer encrypts the guardian configuration.
+  ⚠️ Your guardian admin password has changed. Umbrel now provides a unique password for the app instead of asking you to choose one during setup. It is shown when you first open the app and can be found again through the app's settings or credentials menu. This password is used for both the guardian UI and fedimint-cli admin commands; it no longer encrypts the guardian configuration.
 
 
   Highlights in this release:

--- a/fedimintd/umbrel-app.yml
+++ b/fedimintd/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: fedimintd
 category: bitcoin
 name: Fedimint
-version: "v0.11.1"
+version: "v0.12.0"
 tagline: Federated Chaumian E-Cash Mint for Bitcoin
 description: >-
   Fedimint is a federated Chaumian E-Cash Mint to custody and transact bitcoin in a community. It allows groups of trusted individuals, 
@@ -65,32 +65,29 @@ defaultPassword: ""
 submitter: Fedimint Developers
 submission: https://github.com/getumbrel/umbrel-apps/pull/3371
 releaseNotes: >-
-  This release includes major improvements to the Gateway experience, guardian discovery, and overall reliability:
 
+ - V2 modules are now the default.
+   Freshly set up federations run the lnv2, mintv2 and walletv2 modules by default instead of the v1 module set; the v1 modules are now labeled "legacy" in the setup UI. Existing federations keep their configured module set and are unaffected.
 
-  Gateway improvements:
-    - New first-boot mnemonic setup and recovery flow for gateways
-    - Export and import federation invite codes for easier recovery
-    - BOLT12 send/receive support in the gateway UI
-    - Balance display toggle between msats, sats, and BTC
-    - One-click channel opens to existing peers
-    - Payment event filtering in the payment log
-    - Peers and Notes tabs added to the gateway UI
-    - Parallelized HTLC handling for better payment throughput
+ - Iroh 1.0
+   Guardian P2P and the client API migrated to Iroh 1.0, with clients running dual-stack so older federations keep working. New federations set up in production now default to the iroh networking stack. Plus many robustness fixes: idle connection reaping, request timeouts, stalled connection eviction, explicit QUIC keep-alive, and a pkarr resolver fallback. 
 
-  Guardian & Federation improvements:
-    - Guardians now publish their identity to the decentralized Pkarr DNS system for easier peer discovery
-    - Modernized setup and dashboard UI with Material-style design
-    - QR code display and scanning for setup codes
-    - Network connectivity indicator in setup and dashboard UI
-    - Setup code now embeds federation size for verification
-    - Maximum guardian limit raised to 19
+ - Recovery without downtime
+   Client modules that support it (notably mintv2) stay usable while they recover, failed recoveries are reported instead of blocking forever, and recovery no longer stalls on an unresponsive guardian.
 
-  Performance & reliability:
-    - Drastically lower memory usage — fixed a backtrace caching issue that reduced gatewayd memory from ~1.6GB to under 200MB
-    - RocksDB defaults tuned for lower memory usage in constrained environments
-    - Expanded Prometheus metrics for networking, iroh connections, HTLC handling, and Bitcoin RPC calls
-    - Fixed DB migration issue
+ - Faster Lightning payments
+   A concerted push to drive down LNv2 payment latency: transaction submission now long-polls the federation until consensus acceptance instead of retrying with backoff, decryption key shares are long-polled as well, and the payment preimage is returned to the sender as soon as it is available rather than only after the gateway's claim settles.
 
+ - UniFFI bindings for the client
+   The client and the ln/mint/wallet/meta client modules can now be consumed from Kotlin, Swift and other languages via a feature-gated uniffi build, replacing the previous standalone bindings crate.
+
+ - Fee transparency and full sweeps
+   New fee quote and per-operation fee APIs let clients know costs up front, and the gateway can now sweep a wallet completely on-chain, correctly accounting for module and on-chain fees.
+
+ - Simple guardian setup
+   The guardian password no longer encrypts config files and is purely an admin API/UI credential, setup codes embed the release version and Bitcoin network to catch mismatched guardians early, and the setup UI gained a guardian restore flow.
+
+ - Security fixes
+   This release contains the coordinated set of security hardening fixes across the server, Lightning modules, wallet, backup and DKG that was already shipped to guardians in v0.11.2/v0.10.1 and communicated separately, plus a few follow-ups landed since. All federations should run v0.11.2 or later. 
 
   Full release notes can be found at https://github.com/fedimint/fedimint/releases

--- a/fedimintd/umbrel-app.yml
+++ b/fedimintd/umbrel-app.yml
@@ -5,7 +5,7 @@ name: Fedimint
 version: "v0.12.0"
 tagline: Federated Chaumian E-Cash Mint for Bitcoin
 description: >-
-  Fedimint is a federated Chaumian E-Cash Mint to custody and transact bitcoin in a community. It allows groups of trusted individuals, 
+  Fedimint is a federated Chaumian E-Cash Mint to custody and transact bitcoin in a community. It allows groups of trusted individuals,
   called guardians, to jointly operate a multi-signature e-cash mint.
 
   # Setting Up a Federation
@@ -23,11 +23,11 @@ description: >-
   1. Install & Launch this Fedimint app (fedimintd) on your Umbrel
      Each participating guardian runs their own instance of fedimintd.
 
-  2. Set a Password
-     When starting fedimintd for the first time, each guardian must create a secure password.
+  2. Get Your Guardian Password
+     Umbrel generates the guardian admin password. Open "Show password" for the app in the Umbrel dashboard, then use it to sign in.
 
   3. Generate Setup Code
-     After entering the password, a unique setup code is generated for each guardian.
+     After signing in, a unique setup code is generated for each guardian.
 
   4. Exchange Setup Codes
      All guardians must share their setup codes with each other (every guardian needs every other guardian's code).
@@ -47,7 +47,7 @@ description: >-
 
   2. Use an existing Lightning Gateway. [Reach out on Discord to get setup](https://chat.fedimint.org).
 
-  
+
 developer: Fedimint Developers
 website: https://fedimint.org/
 dependencies:
@@ -65,32 +65,18 @@ deterministicPassword: true
 submitter: Fedimint Developers
 submission: https://github.com/getumbrel/umbrel-apps/pull/3371
 releaseNotes: >-
+  ⚠️ Guardians in an existing Iroh-based federation must coordinate this update. Iroh 1.0 guardian P2P is not wire-compatible with earlier releases, so consensus may pause until the upgraded guardians reach quorum. Rolling back after the new Iroh identity is advertised is unsupported. Review the full upstream upgrade notes with the other guardians before updating.
 
- - ⚠️ Your guardian UI password has changed.
-   The guardian password is now supplied by Umbrel instead of being chosen during setup. Find it under the app's "Show password" in the Umbrel dashboard. Your federation, funds and guardian config are unaffected — in v0.12.0 this password is only an admin credential and no longer encrypts anything. The same password authenticates fedimint-cli admin commands against your guardian.
 
- - V2 modules are now the default.
-   Freshly set up federations run the lnv2, mintv2 and walletv2 modules by default instead of the v1 module set; the v1 modules are now labeled "legacy" in the setup UI. Existing federations keep their configured module set and are unaffected.
+  ⚠️ Your guardian admin password has changed. Umbrel now supplies it under the app's "Show password" option instead of asking you to choose one during setup. This password is used for both the guardian UI and fedimint-cli admin commands; it no longer encrypts the guardian configuration.
 
- - Iroh 1.0
-   Guardian P2P and the client API migrated to Iroh 1.0, with clients running dual-stack so older federations keep working. New federations set up in production now default to the iroh networking stack. Plus many robustness fixes: idle connection reaping, request timeouts, stalled connection eviction, explicit QUIC keep-alive, and a pkarr resolver fallback. 
 
- - Recovery without downtime
-   Client modules that support it (notably mintv2) stay usable while they recover, failed recoveries are reported instead of blocking forever, and recovery no longer stalls on an unresponsive guardian.
+  Highlights in this release:
+    - New federations use the lnv2, mintv2, and walletv2 modules by default; existing federations keep their configured modules
+    - Setup codes now detect guardian version and Bitcoin network mismatches
+    - Adds guardian restore support and improves recovery behavior
+    - Improves Lightning payment latency, fee handling, consensus reliability, and Iroh connectivity
+    - Includes the security fixes previously released in v0.11.2
 
- - Faster Lightning payments
-   A concerted push to drive down LNv2 payment latency: transaction submission now long-polls the federation until consensus acceptance instead of retrying with backoff, decryption key shares are long-polled as well, and the payment preimage is returned to the sender as soon as it is available rather than only after the gateway's claim settles.
 
- - UniFFI bindings for the client
-   The client and the ln/mint/wallet/meta client modules can now be consumed from Kotlin, Swift and other languages via a feature-gated uniffi build, replacing the previous standalone bindings crate.
-
- - Fee transparency and full sweeps
-   New fee quote and per-operation fee APIs let clients know costs up front, and the gateway can now sweep a wallet completely on-chain, correctly accounting for module and on-chain fees.
-
- - Simple guardian setup
-   The guardian password no longer encrypts config files and is purely an admin API/UI credential, setup codes embed the release version and Bitcoin network to catch mismatched guardians early, and the setup UI gained a guardian restore flow.
-
- - Security fixes
-   This release contains the coordinated set of security hardening fixes across the server, Lightning modules, wallet, backup and DKG that was already shipped to guardians in v0.11.2/v0.10.1 and communicated separately, plus a few follow-ups landed since. All federations should run v0.11.2 or later. 
-
-  Full release notes can be found at https://github.com/fedimint/fedimint/releases
+  Full release notes can be found at https://github.com/fedimint/fedimint/releases/tag/v0.12.0


### PR DESCRIPTION
## Type

App update

## App

App ID: fedimintd
Upstream project: https://github.com/fedimint/fedimint
Version: v0.12.0

## Summary

Just updating the release to the v0.12.0 release. Lots has changed, mainly security fixes that are important to get to users. Full release notes here: https://github.com/fedimint/fedimint/releases/tag/v0.12.0

## Verification

Umbrel testing performed:

Environment tested:
- [X] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [X] amd64
- [ ] arm64

## Notes

Tested on my Umbrel
