### PR TITLE
Update fedimint-gateway to v0.12.0

### DIFF
--- a/fedimint-gateway/data/entrypoint.sh
+++ b/fedimint-gateway/data/entrypoint.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# Bcrypt hash the password before giving it to the gateway
-export FM_GATEWAY_BCRYPT_PASSWORD_HASH=$(gateway-cli create-password-hash $APP_PASSWORD \
-  | sed 's/^"//; s/"$//' \
-  | sed 's/\$/$$/g'
-)
-
-gatewayd lnd

--- a/fedimint-gateway/docker-compose.yml
+++ b/fedimint-gateway/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8178 # ui
 
   gatewayd:
-    image: fedimint/gatewayd:v0.11.1@sha256:65365fceb2e85dfb01837553be53a3372f118e094a23f672ef52bc38baf28ddf
+    image: fedimint/gatewayd:v0.12.0@sha256:6533b149d413157948660d33fb0a97d38fcd64bb131bce94ad26f16b4c9893d7
     restart: on-failure
     ports:
       - 8177:8177/udp # iroh
@@ -30,4 +30,13 @@ services:
       FM_BITCOIND_USERNAME: ${APP_BITCOIN_RPC_USER}
       FM_BITCOIND_PASSWORD: ${APP_BITCOIN_RPC_PASS}
       FM_BITCOIND_URL: "http://${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_RPC_PORT}"
-    entrypoint: /data/entrypoint.sh
+    # Bcrypt-hash the app password before handing it to gatewayd. `$$` escapes a
+    # literal `$` for Compose interpolation, so the container's shell sees a single `$`.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        FM_GATEWAY_BCRYPT_PASSWORD_HASH=$$(gateway-cli create-password-hash "$$APP_PASSWORD" | tr -d '"')
+        export FM_GATEWAY_BCRYPT_PASSWORD_HASH
+        exec gatewayd lnd

--- a/fedimint-gateway/umbrel-app.yml
+++ b/fedimint-gateway/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: fedimint-gateway
 category: bitcoin
 name: Fedimint Lightning Gateway
-version: "v0.11.1"
+version: "v0.12.0"
 tagline: Lightning routing for Fedimints
 description: >-
   The Fedimint Lightning Gateway is an ecash wallet that connects Fedimint users to the broader Lightning Network. Operators can earn fees by providing outbound
@@ -48,19 +48,51 @@ defaultPassword: ""
 submitter: Fedimint Developers
 submission: https://github.com/getumbrel/umbrel-apps/pull/4554
 releaseNotes: >-
-  ⚠️ Gateway first-boot behavior has changed: a mnemonic setup/recovery screen is now presented instead of auto-generating credentials. If automating setup, use the skip_setup flag.
 
+ - On-chain sweep of the full gateway balance, accounting for module and on-chain fees
 
-  Highlights in this release:
-    - Gateway recovery and mnemonic management — create or restore your gateway from a mnemonic on first boot, and export/import federation invite codes for recovery
-    - Guardian discovery via Pkarr — guardians now publish their identity and API addresses to the decentralized Pkarr DNS system for peer discovery without centralized coordination
-    - Gateway UI overhaul — BOLT12 send/receive, one-click channel opens to existing peers, balance display in sats/BTC, payment filtering, peer and notes tabs, and a modernized Material-style design
-    - Drastically lower memory usage — fixed a backtrace caching issue that reduced gatewayd memory from ~1.6GB to under 200MB, with tuned RocksDB defaults for constrained environments
-    - Comprehensive observability — Prometheus metrics for networking, iroh connections, HTLC handling, Bitcoin RPC calls, and gateway-to-LN-node latency
-    - Parallelized HTLC handling for better payment throughput
-    - Liquidity Manager role with restricted permissions
-    - Export/import federation invite codes for easier recovery
-    - DB migration fix included in this patch release
+ - Max affordable send amount computation, with fast startup
 
+ - Edit channel fees from the gateway UI, and set feerate and routing fees when opening a channel
+
+ - Connect-peer action in the gateway UI; manually connected peers are persisted across restarts
+
+ - Total inbound/outbound liquidity shown in the gateway UI
+
+ - List all hold invoices
+
+ - Federation-scoped capability health reporting
+
+ - Custom LND routing timeout and time preference
+
+ - LND route hints built from the remote peer's fee policy
+
+ - Cancel unmatched federation HTLCs instead of forwarding them; serialize same-circuit LNv1 HTLC handling; make HTLC interception idempotent on replay
+
+ - Outgoing contracts are bound to the invoice being paid; outgoing claims deduplicated in the gateway's global database
+
+ - Stricter fee limit verification on payment paths
+
+ - Gateway disconnects a federation when its LNv1/LNv2 tasks exit unexpectedly
+
+ - Fixed a deadlock on gateway shutdown, a panic on amountless invoices, and gateway UI auth issues
+
+ - LNv2 preimage returned to the sender without waiting for the gateway's claim to settle (faster payments)
+
+ - LNv2: only a single payment attempt per invoice; send status and preimage exposed to integrators; invoice amount and fee reported in payment events
+
+ - LNv2 decryption key share endpoint long-polled; LNURL receive no longer holds a database transaction across the long-poll
+
+ - LNv1: manual reclaim of stuck receives; pay idempotency checked before invoice expiry
+
+ - LNURL: invoice amount verified against the requested amount
+
+ - recurringd: selects available, vetted gateways sorted by fees, caches the selection, and repairs consecutive orphaned invoices
+
+ - Removed LDK bolt11 payment polling; LDK logs redirected into the gateway log
+
+ - Gateway verify endpoint handled correctly over Iroh; liquidity manager route prefix handling fixed
+
+ - Corrected Lagrange multiplier in threshold decryption with a single share
 
   Full release notes can be found at https://github.com/fedimint/fedimint/releases

--- a/fedimint-gateway/umbrel-app.yml
+++ b/fedimint-gateway/umbrel-app.yml
@@ -48,51 +48,13 @@ defaultPassword: ""
 submitter: Fedimint Developers
 submission: https://github.com/getumbrel/umbrel-apps/pull/4554
 releaseNotes: >-
+  This release updates Fedimint Lightning Gateway to v0.12.0 with the following improvements:
+    - Adds full on-chain wallet sweeps with fee-aware maximum send amounts
+    - Adds channel fee controls, persistent peer connections, and improved liquidity information
+    - Speeds up LNv2 payments and improves payment status reporting
+    - Hardens HTLC, invoice, fee-limit, and outgoing-contract handling
+    - Fixes gateway shutdown, amountless invoice, and UI authentication issues
+    - Includes the security fixes previously released in v0.11.2
 
- - On-chain sweep of the full gateway balance, accounting for module and on-chain fees
 
- - Max affordable send amount computation, with fast startup
-
- - Edit channel fees from the gateway UI, and set feerate and routing fees when opening a channel
-
- - Connect-peer action in the gateway UI; manually connected peers are persisted across restarts
-
- - Total inbound/outbound liquidity shown in the gateway UI
-
- - List all hold invoices
-
- - Federation-scoped capability health reporting
-
- - Custom LND routing timeout and time preference
-
- - LND route hints built from the remote peer's fee policy
-
- - Cancel unmatched federation HTLCs instead of forwarding them; serialize same-circuit LNv1 HTLC handling; make HTLC interception idempotent on replay
-
- - Outgoing contracts are bound to the invoice being paid; outgoing claims deduplicated in the gateway's global database
-
- - Stricter fee limit verification on payment paths
-
- - Gateway disconnects a federation when its LNv1/LNv2 tasks exit unexpectedly
-
- - Fixed a deadlock on gateway shutdown, a panic on amountless invoices, and gateway UI auth issues
-
- - LNv2 preimage returned to the sender without waiting for the gateway's claim to settle (faster payments)
-
- - LNv2: only a single payment attempt per invoice; send status and preimage exposed to integrators; invoice amount and fee reported in payment events
-
- - LNv2 decryption key share endpoint long-polled; LNURL receive no longer holds a database transaction across the long-poll
-
- - LNv1: manual reclaim of stuck receives; pay idempotency checked before invoice expiry
-
- - LNURL: invoice amount verified against the requested amount
-
- - recurringd: selects available, vetted gateways sorted by fees, caches the selection, and repairs consecutive orphaned invoices
-
- - Removed LDK bolt11 payment polling; LDK logs redirected into the gateway log
-
- - Gateway verify endpoint handled correctly over Iroh; liquidity manager route prefix handling fixed
-
- - Corrected Lagrange multiplier in threshold decryption with a single share
-
-  Full release notes can be found at https://github.com/fedimint/fedimint/releases
+  Full release notes can be found at https://github.com/fedimint/fedimint/releases/tag/v0.12.0


### PR DESCRIPTION
## Type

 App update

## App

App ID: fedimint-gateway
Upstream project: https://github.com/fedimint/fedimint
Version: v0.12.0

## Summary

Just updating the release to the v0.12.0 release. Lots has changed, mainly security fixes that are important to get to users. Full release notes here: https://github.com/fedimint/fedimint/releases/tag/v0.12.0

## Verification

Umbrel testing performed:

Environment tested:
- [X] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [X] amd64
- [ ] arm64

Known lint warnings or caveats:

## Notes
Tested on my Umbrel
