### PR TITLE
umbrelOS 2.0 cross vendor GPU support for apps

### DIFF
--- a/jupyterlab/umbrel-app.yml
+++ b/jupyterlab/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: jupyterlab
 category: developer
 name: JupyterLab
-version: "v4.6.3"
+version: "v4.6.3-patch.1"
 tagline: Next-generation web interface for interactive computing and data science
 description: >-
   JupyterLab is a next-generation web-based user interface for Project Jupyter. 
@@ -21,14 +21,10 @@ description: >-
 
 
   JupyterLab uses the same notebook document format as the classic Jupyter Notebook.
+permissions:
+  - GPU
 releaseNotes: >-
-  This release includes notebook and workflow fixes for JupyterLab:
-    - Fixes Shift-click cell selection after selecting editor text.
-    - Fixes notebook tools prompt blinking and prevents a related memory leak.
-    - Improves variable inspection, document autocomplete, toolbar item positioning, and kernel status reporting.
-
-
-  Full release notes can be found at https://github.com/jupyterlab/jupyterlab/releases/tag/v4.6.3
+  Adds GPU access so notebooks can use CUDA or ROCm frameworks when a supported GPU is available.
 developer: jupyterlab
 website: https://jupyterlab.readthedocs.io/en/latest/
 repo: https://github.com/jupyterlab/jupyterlab

--- a/jupyterlab/umbrel-app.yml
+++ b/jupyterlab/umbrel-app.yml
@@ -24,7 +24,7 @@ description: >-
 permissions:
   - GPU
 releaseNotes: >-
-  Adds GPU access so notebooks can use CUDA or ROCm frameworks when a supported GPU is available.
+  Adds GPU access so notebooks can use CUDA or ROCm frameworks when a supported GPU is available. Using an AMD or NVIDIA GPU requires umbrelOS 2.0 Beta or later.
 developer: jupyterlab
 website: https://jupyterlab.readthedocs.io/en/latest/
 repo: https://github.com/jupyterlab/jupyterlab

--- a/localai/docker-compose.yml
+++ b/localai/docker-compose.yml
@@ -17,6 +17,11 @@ services:
       - MODELS_PATH=/models
       - LOCALAI_BACKENDS_PATH=/backends
       - LOCALAI_EXTERNAL_BACKENDS=cpu-llama-cpp
+      # The image pins its backend capability to CPU; point the override file at a missing path so
+      # LocalAI detects the host GPU and offers matching CUDA/ROCm/SYCL backends in its gallery
+      - LOCALAI_FORCE_META_BACKEND_CAPABILITY_RUN_FILE=/nonexistent
+      # The image bakes a malformed NVIDIA_REQUIRE_CUDA that the NVIDIA container runtime rejects
+      - NVIDIA_DISABLE_REQUIRE=true
     volumes:
       - ${APP_DATA_DIR}/data/models:/models:cached
       - ${APP_DATA_DIR}/data/backends:/backends:cached

--- a/localai/umbrel-app.yml
+++ b/localai/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: localai
 category: ai
 name: LocalAI
-version: "v4.9.0"
+version: "v4.9.0-patch.1"
 tagline: Drop-in OpenAI replacement
 description: >-
   LocalAI is the free, Open Source OpenAI alternative. LocalAI act as a drop-in replacement REST API that's compatible with OpenAI API specifications for local inferencing.
@@ -14,17 +14,10 @@ description: >-
   ⚠️ Note
 
   Before running a model, make sure your device has enough free RAM to support it. Attempting to run a model that exceeds your available memory could cause your device to crash or become unresponsive. Always check the model requirements before downloading or starting it.
+permissions:
+  - GPU
 releaseNotes: >-
-  If you installed a backend in a LocalAI version before backend persistence was added, you may need to reinstall it once after updating.
-
-
-  This update makes authentication deny-by-default when LocalAI auth or API keys are enabled, protecting routes unless they are explicitly public.
-
-
-  It also adds opt-in chat context compression, streamlines model and backend management into one page each, and improves backend tracing, global admission control, parallel Hugging Face downloads, and vllm-cpp video/audio support.
-
-
-  Full release notes can be found at https://github.com/mudler/LocalAI/releases/tag/v4.9.0
+  Adds GPU support. LocalAI now detects NVIDIA, AMD, and Intel GPUs and offers the matching CUDA, ROCm, and SYCL backends in its Backends gallery. Install a GPU backend there to accelerate your models.
 backupIgnore:
   - data/models/*
   - data/backends/*

--- a/localai/umbrel-app.yml
+++ b/localai/umbrel-app.yml
@@ -17,7 +17,7 @@ description: >-
 permissions:
   - GPU
 releaseNotes: >-
-  Adds GPU support. LocalAI now detects NVIDIA, AMD, and Intel GPUs and offers the matching CUDA, ROCm, and SYCL backends in its Backends gallery. Install a GPU backend there to accelerate your models.
+  Adds GPU support. LocalAI now detects NVIDIA, AMD, and Intel GPUs and offers the matching CUDA, ROCm, and SYCL backends in its Backends gallery. Install a GPU backend there to accelerate your models. Using an AMD or NVIDIA GPU requires umbrelOS 2.0 Beta or later.
 backupIgnore:
   - data/models/*
   - data/backends/*

--- a/ollama/docker-compose.yml
+++ b/ollama/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     environment:
       OLLAMA_ORIGINS: "*"
       OLLAMA_CONTEXT_LENGTH: 8192
+      OLLAMA_VULKAN: "1"
+      OLLAMA_IGPU_ENABLE: "1"
     volumes:
       - ${APP_DATA_DIR}/data:/root/.ollama
     restart: on-failure

--- a/ollama/umbrel-app.yml
+++ b/ollama/umbrel-app.yml
@@ -40,5 +40,5 @@ dependencies: []
 permissions:
   - GPU
 releaseNotes: >-
-  Adds automatic hardware acceleration when a supported GPU is available. Ollama can now use CUDA on NVIDIA GPUs and Vulkan on compatible Intel, AMD, and NVIDIA GPUs.
+  Adds automatic hardware acceleration when a supported GPU is available. Ollama can now use CUDA on NVIDIA GPUs and Vulkan on compatible Intel, AMD, and NVIDIA GPUs. Using an AMD or NVIDIA GPU requires umbrelOS 2.0 Beta or later.
 path: ""

--- a/ollama/umbrel-app.yml
+++ b/ollama/umbrel-app.yml
@@ -3,7 +3,7 @@ id: ollama
 name: Ollama
 tagline: Self-host open source AI models like DeepSeek-R1, Llama, and more
 category: ai
-version: "0.33.0"
+version: "0.33.0-patch.1"
 port: 11434
 description: >-
   Ollama allows you to download and run advanced AI models directly on your own hardware. Self-hosting AI models ensures full control over your data and protects your privacy.
@@ -37,12 +37,8 @@ gallery:
 defaultUsername: ""
 defaultPassword: ""
 dependencies: []
+permissions:
+  - GPU
 releaseNotes: >-
-  Key highlights in this release:
-    - Added support for configuring Claude Desktop to use Ollama as a third-party gateway provider.
-    - Improved caching and prefill resume behavior for cancelled or retried requests.
-    - Fixed default Linux and Windows packaging issues caused by macOS-specific build assumptions.
-
-
-  Full release notes are available at https://github.com/ollama/ollama/releases/
+  Adds automatic hardware acceleration when a supported GPU is available. Ollama can now use CUDA on NVIDIA GPUs and Vulkan on compatible Intel, AMD, and NVIDIA GPUs.
 path: ""

--- a/photoprism/docker-compose.yml
+++ b/photoprism/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       PHOTOPRISM_SITE_CAPTION: "Digital Asset Management"
       PHOTOPRISM_SITE_DESCRIPTION: ""
       PHOTOPRISM_SITE_AUTHOR: ""
+      PHOTOPRISM_FFMPEG_ENCODER: "vaapi"
 
   db:
     image: mariadb:10.5.12@sha256:dfcba5641bdbfd7cbf5b07eeed707e6a3672f46823695a0d3aba2e49bbd9b1dd

--- a/photoprism/umbrel-app.yml
+++ b/photoprism/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: photoprism
 category: files
 name: PhotoPrism
-version: "260305-fad9d5395"
+version: "260305-fad9d5395-patch.1"
 tagline: Self-host your photo and video library
 description: >-
   PhotoPrism® is a privately hosted app for browsing, organizing, and
@@ -41,26 +41,9 @@ path: ""
 defaultUsername: "admin"
 deterministicPassword: true
 torOnly: false
+permissions:
+  - GPU
 releaseNotes: >-
-  This service release focuses on security hardening, interoperability improvements, and bug fixes.
-
-
-  Key features and improvements:
-    - Added support for Ollama configuration via OLLAMA_BASE_URL and OLLAMA_API_KEY environment variables
-    - Improved Ollama caption generation with better fallback handling for reasoning models
-    - Fixed merged photos incorrectly keeping image type after video file merges
-    - Fixed GPS coordinate handling near map boundaries in Places
-    - Fixed emoji subfolders conflicting with parent folder albums
-    - Fixed folder album path collisions caused by truncated slugs
-    - Hidden results now display file error reasons in Card and List views
-    - Improved WebDAV response headers for better interoperability
-    - Added HTTP security hardening configuration options
-    - Improved Gzip route exclusion performance
-    - Fixed issues when hosting on a shared domain
-    - Improved compatibility with Google OIDC identity provider
-    - Updated French, German, Latvian, and Romanian translations
-
-
-  Full release notes can be found at: https://github.com/photoprism/photoprism/releases/
+  Adds hardware-accelerated video transcoding on Intel and AMD GPUs. NVIDIA GPUs can be used by setting FFmpegEncoder to nvidia in PhotoPrism's options.yml.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/bf4c6f127f1fcf4dbe8eea55729502dfb34278e9

--- a/photoprism/umbrel-app.yml
+++ b/photoprism/umbrel-app.yml
@@ -44,6 +44,6 @@ torOnly: false
 permissions:
   - GPU
 releaseNotes: >-
-  Adds hardware-accelerated video transcoding on Intel and AMD GPUs. NVIDIA GPUs can be used by setting FFmpegEncoder to nvidia in PhotoPrism's options.yml.
+  Adds hardware-accelerated video transcoding on Intel and AMD GPUs. NVIDIA GPUs can be used by setting FFmpegEncoder to nvidia in PhotoPrism's options.yml. Using an AMD or NVIDIA GPU requires umbrelOS 2.0 Beta or later.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/commit/bf4c6f127f1fcf4dbe8eea55729502dfb34278e9


### PR DESCRIPTION
Changed: ollama, photoprism, localai, jupyterlab

Already had GPU accel and get enhanced multivendor support in umbrelOS 2.0: jellyfin, emby, ersatztv-legacy, frigate, immich, plex, homebridge, portainer, arcane, sabnzbd