### PR TITLE
Update Cloudflare Tunnel to 2026.8.3

### DIFF
--- a/cloudflared/docker-compose.yml
+++ b/cloudflared/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/radiokot/umbrel-cloudflared:1.0.2@sha256:9660fb4e90317036d2b418f1c9437cc2cdb7f7bdd8d820084237a0c37bb94f5b
+    image: ghcr.io/radiokot/umbrel-cloudflared:1.0.3@sha256:8acd17fcf7b9b9902fb12855f4667daf32c47a225ead6603b59bab9ae962b072
     restart: on-failure
     stop_grace_period: 1s
     depends_on:
@@ -20,7 +20,7 @@ services:
       CLOUDFLARED_TOKEN_FILE: "/app/data/token"
 
   connector:
-    image: ghcr.io/radiokot/umbrel-cloudflared-connector:1.0.1-cf.2026.7.3@sha256:843bf75f58000c352180697e349e939c9e2d1910f05f03b1b033459b7acff3f4
+    image: ghcr.io/radiokot/umbrel-cloudflared-connector:1.0.1-cf.2026.8.3@sha256:aba90ff688759d90f6495074ab39ed41987e843b3d6ca0a1a8af5a3eb24210bb
     restart: on-failure
     stop_grace_period: 3s
     volumes:

--- a/cloudflared/umbrel-app.yml
+++ b/cloudflared/umbrel-app.yml
@@ -3,7 +3,7 @@ id: cloudflared
 name: Cloudflare Tunnel
 tagline: Access your Umbrel apps from the Internet using Cloudflare network
 category: networking
-version: "2026.7.3"
+version: "2026.8.3"
 port: 4499
 description: >-
   Start a secure tunnel to access your Umbrel apps from the Internet using the Cloudflare network. 
@@ -34,7 +34,9 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  The tunneling daemon (cloudflared) has been updated to 2026.7.3
+  - The tunneling daemon (cloudflared) has been updated to 2026.8.3
+
+  - Wording has been updated to match the current Cloudflare terminology
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
<!--
Title format:
- Add <app name>
- Update <app name> to <version>
- Fix <app name> <issue>
-->

## Type

App update

## App

App ID: cloudflared
Upstream project: https://github.com/cloudflare/cloudflared
Version: 2026.8.3

## Summary

- The tunneling daemon (cloudflared) has been updated to 2026.8.3
- Wording has been updated to match the current Cloudflare terminology

## Verification

Umbrel testing performed:

Environment tested:
- [ ] Umbrel device
- [x] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64
