### PR TITLE
canary: Update to v1.6.1

### DIFF
--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.1@sha256:9bf6cb584b64ccd94c37fe758d58d0bfb132e8181c739517034ec33d9734632b
+    image: schjonhaug/canary-backend:v1.6.1@sha256:4f088cbe2636b04d550c424da15e8f3dc88c168e1666e9dbead6aa1ae9945a22
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.1@sha256:879539cd47a84ff0bbbc069cafb3d032e3af29a097bd1218a37d72e2b26133a8
+    image: schjonhaug/canary-frontend:v1.6.1@sha256:2a971a11b0ef39703e883450453ab920a3192caa450a5b60fcdcc09d8c0b38d2
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.1@sha256:4f088cbe2636b04d550c424da15e8f3dc88c168e1666e9dbead6aa1ae9945a22
+    image: schjonhaug/canary-backend:v1.6.1@sha256:e040fe13ac1530703523abd665c5235812b069f60ed78c4037b2fc97b52d45eb
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.1@sha256:2a971a11b0ef39703e883450453ab920a3192caa450a5b60fcdcc09d8c0b38d2
+    image: schjonhaug/canary-frontend:v1.6.1@sha256:fec8c795a12e7cc6bfc1ac62e20cca6b32dcd8efa56dda97d7418388debaa56d
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.1@sha256:a316bba55d157ef4ef60ea10fe4bf51b827a04c39d23d5cac6ff419ae66519d0
+    image: schjonhaug/canary-backend:v1.6.1@sha256:5cf351492d4e0ddb8dc9575ce10ee7f52435e744c823c2594e6fe6f8b4e7cf3b
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.1@sha256:c2340c90076edd6629710ebf670a9c1bc13ba498e014df399d325f8a09b52ebc
+    image: schjonhaug/canary-frontend:v1.6.1@sha256:c121e722892016a609b7a8441aebbbbb81658dd6027d5eea62477579c16fffe7
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.1@sha256:6218e58605f429a22e2d381fa792891db69f1b1a57e80ac5fdb1edbda1e933ce
+    image: schjonhaug/canary-backend:v1.6.1@sha256:1d144f0f20cc1ac19a9af4c9e07abd8ec081b0fb71642ab46604a689b16af083
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.1@sha256:3df9c674354dff633f1c60e1bf86b8ce6fb2cc7ddc3f4818515cb82b224e25ed
+    image: schjonhaug/canary-frontend:v1.6.1@sha256:be7752194a8c09ab2ca22821318ad65ca5b58d432dd40e97e9dcf8a0c72a8083
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.1@sha256:6b06991759d7d422589c16f939ce3f444d57203ba398b4bb5c3473e34169f47a
+    image: schjonhaug/canary-backend:v1.6.1@sha256:a316bba55d157ef4ef60ea10fe4bf51b827a04c39d23d5cac6ff419ae66519d0
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.1@sha256:094830af8f98e422f56e0d06d0f9a31e1dec4d41b4f8d700d412e9f24fa2b578
+    image: schjonhaug/canary-frontend:v1.6.1@sha256:c2340c90076edd6629710ebf670a9c1bc13ba498e014df399d325f8a09b52ebc
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.0@sha256:f7df6bc424b78734c5d05626c806975ab546aadc0862c9b0cf77714e9b937763
+    image: schjonhaug/canary-backend:v1.6.1@sha256:9bf6cb584b64ccd94c37fe758d58d0bfb132e8181c739517034ec33d9734632b
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.0@sha256:635be0978c8e158191f4e8e5ec26482c428744cf6cf35140785c54bcdc11f733
+    image: schjonhaug/canary-frontend:v1.6.1@sha256:879539cd47a84ff0bbbc069cafb3d032e3af29a097bd1218a37d72e2b26133a8
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.1@sha256:e040fe13ac1530703523abd665c5235812b069f60ed78c4037b2fc97b52d45eb
+    image: schjonhaug/canary-backend:v1.6.1@sha256:6218e58605f429a22e2d381fa792891db69f1b1a57e80ac5fdb1edbda1e933ce
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.1@sha256:fec8c795a12e7cc6bfc1ac62e20cca6b32dcd8efa56dda97d7418388debaa56d
+    image: schjonhaug/canary-frontend:v1.6.1@sha256:3df9c674354dff633f1c60e1bf86b8ce6fb2cc7ddc3f4818515cb82b224e25ed
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.1@sha256:1d144f0f20cc1ac19a9af4c9e07abd8ec081b0fb71642ab46604a689b16af083
+    image: schjonhaug/canary-backend:v1.6.1@sha256:6b06991759d7d422589c16f939ce3f444d57203ba398b4bb5c3473e34169f47a
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.1@sha256:be7752194a8c09ab2ca22821318ad65ca5b58d432dd40e97e9dcf8a0c72a8083
+    image: schjonhaug/canary-frontend:v1.6.1@sha256:094830af8f98e422f56e0d06d0f9a31e1dec4d41b4f8d700d412e9f24fa2b578
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: canary
 category: bitcoin
 name: Canary Wallet
-version: "1.6.0"
+version: "1.6.1"
 tagline: Early warning system for Bitcoin cold storage
 description: >-
   A canary in the cold mine. When your bitcoins are in cold storage, you seldom check on them.

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -27,8 +27,7 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  Canary v1.6.0 adds self-hosted Nostr DM and JSON webhook notifications, per-contact privacy and content controls, and simpler notification management. Existing notification contacts and settings are preserved when upgrading from v1.5.2, including a fix for migrated local ntfy delivery.
-  Full release notes can be found at https://github.com/schjonhaug/canary/releases/tag/v1.6.0
+  Fixed self-hosted sign-in failures when a node changes its hostname, protocol, or external port, including dynamic StartOS ports. Login errors now provide clearer guidance, while existing passwords, wallets, contacts, and notification settings remain unchanged.
 path: ""
 deterministicPassword: true
 submitter: schjonhaug


### PR DESCRIPTION
## Summary
Update Canary Umbrel app to v1.6.1.

## Release summary
Fixed self-hosted sign-in failures when a node changes its hostname, protocol, or external port, including dynamic StartOS ports. Login errors now provide clearer guidance, while existing passwords, wallets, contacts, and notification settings remain unchanged.

## Upstream release
https://github.com/schjonhaug/canary/releases/tag/v1.6.1

## Test plan
- [x] Upgraded a local Umbrel installation from its previously published Canary package directly to v1.6.1
- [x] Verified existing wallets, notification contacts, destinations, settings, and history were preserved
- [x] Verified live delivery through Umbrel's detected local ntfy server and inactive-contact non-delivery
- [x] Restarted Canary and verified the migrated data remained intact without duplicate delivery
