### PR TITLE
yuvomi: update to v2.64.1

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:2.64.0@sha256:1fa9e57aeedb299c0016e2e55fe7db7c65b8ed052345bc26ac30d86a9426636d
+    image: ghcr.io/ulsklyc/yuvomi:2.64.1@sha256:61292e0c5d045dcc6844680ddd89578b005705206ed22bac13d477e92b18c344
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "2.64.0"
+version: "2.64.1"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -51,21 +51,21 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  This release fixes something the budget plan got wrong about the past. Your
-  plan is one steady amount per category, and nothing recorded what it said in
-  earlier months - so lowering a budget today could turn a month that closed
-  long ago red, for spending that was well inside the plan you actually had at
-  the time. From now on Yuvomi only calls a month over or under budget while
-  that month is still running. For every earlier month it still shows what was
-  planned and what was spent, and says plainly that it is measuring against your
-  current plan instead of declaring a winner.
+  This is a security release, and it changes nothing about how Yuvomi looks or
+  works day to day. Four reports from security researchers are fixed: a family
+  member could edit or delete another member's private calendar event; the
+  Webhook, Gotify and ntfy notification channels could be pointed at addresses
+  inside your own network; a redirect could steer a calendar feed fetch to an
+  internal address; and a shared expense could be attributed to someone outside
+  its group, while a paid housekeeping visit could be changed by anyone.
 
 
-  The project also now publishes what it will not build. If you have ever
-  wondered whether a direct bank connection or a particular third-party
-  integration is coming, there is a short document that answers it, says which
-  parts are still open, and explains the reasoning - so an idea gets the same
-  answer no matter where you ask it.
+  One thing to check after updating: if your Gotify or ntfy server, or a webhook
+  target such as Home Assistant, runs in the same Docker network or on your LAN,
+  notification delivery to it now stops until you set
+  NOTIFICATION_ALLOW_PRIVATE_NETWORK=true in the app's environment. The channel
+  shows the reason in its status, and the setting is described in the
+  installation guide.
 
 
   Nothing changes in the database with this update, so it is a plain container
@@ -73,7 +73,7 @@ releaseNotes: >-
 
 
   Full release notes are available at
-  https://github.com/ulsklyc/yuvomi/releases/tag/v2.64.0
+  https://github.com/ulsklyc/yuvomi/releases/tag/v2.64.1
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db


### PR DESCRIPTION
Automated update of Yuvomi, prepared by the release workflow in `ulsklyc/yuvomi` and following this repo's `AGENTS.md`.

| | |
|---|---|
| Old version | `2.64.0` |
| New version | `2.64.1` |
| Upstream release | https://github.com/ulsklyc/yuvomi/releases/tag/v2.64.1 |
| Image | `ghcr.io/ulsklyc/yuvomi:2.64.1@sha256:61292e0c5d045dcc6844680ddd89578b005705206ed22bac13d477e92b18c344` |
| Architectures | linux/amd64, linux/arm64 |
| Linter | passed (`node .tools/lint-apps.mjs yuvomi --check-images`) |

**Package changes**

- `yuvomi/docker-compose.yml`
- `yuvomi/umbrel-app.yml`

Manifest `version`, `releaseNotes` and the pinned image digest. No changes to compose wiring, env vars, volumes, ports, `app_proxy`, hooks, exports or permissions, so there is nothing for existing installs to migrate.

**Breaking changes**

None. This is a patch/minor upstream release; see the upstream notes above for the user-visible list.

**Testing performed**

- Upstream CI (`npm test`) green on the release commit.
- Image pulled from the public registry and pinned by the multi-arch index digest; `linux/amd64` and `linux/arm64` verified to be present in the manifest list.
- Manifest and compose parsed as YAML after editing.
- Repo linter: passed (`node .tools/lint-apps.mjs yuvomi --check-images`)

**Not tested**: the update path was not exercised through umbrelOS itself - this workflow has no Umbrel instance. The package change is limited to the manifest version, the release notes and the image digest.
