### PR TITLE
lightning-terminal: update to `v0.17.4-alpha`

### DIFF
--- a/lightning-terminal/docker-compose.yml
+++ b/lightning-terminal/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3004
 
   web:
-    image: lightninglabs/lightning-terminal:v0.17.3-alpha@sha256:1f2844d20f0abe3effcdb2ff6a3473db92a5671345f0ed0f7fd1107b3220fd63
+    image: lightninglabs/lightning-terminal:v0.17.4-alpha@sha256:3fae6b0e4a645cc5bbd1ca4798c13952cd48915cdc8fbd2336df8e245368f16f
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/lightning-terminal/umbrel-app.yml
+++ b/lightning-terminal/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lightning-terminal
 category: bitcoin
 name: Lightning Terminal
-version: "0.17.3-alpha"
+version: "0.17.4-alpha"
 tagline: The easiest way to manage channel liquidity
 description: >-
   Lightning Terminal is the easiest way to manage inbound and
@@ -58,8 +58,8 @@ deterministicPassword: true
 releaseNotes: >-
   ⚠️ Please update your Lightning Node app to the latest version available in the app store to ensure compatibility with Lightning Terminal.
 
-  This version of Lightning Terminal (LiT) ships lnd v0.21.2-beta, loop v0.35.0-beta, faraday v0.2.18-alpha,
-  pool v0.7.1-beta and tapd v0.8.1.
+  This version of Lightning Terminal (LiT) ships lnd v0.21.3-beta, loop v0.35.0-beta, faraday v0.2.19-alpha,
+  pool v0.7.1-beta and tapd v0.8.3.
 
 
   IMPORTANT NOTE: To avoid loss of funds, it's imperative that you read the
@@ -97,7 +97,7 @@ releaseNotes: >-
   feedback from the community.
 
 
-  This release packages LND v0.21.2-beta, Taproot Assets Daemon v0.8.1,
-  Loop v0.35.0-beta, Pool v0.7.1-beta and Faraday v0.2.18-alpha.
+  This release packages LND v0.21.3-beta, Taproot Assets Daemon v0.8.3,
+  Loop v0.35.0-beta, Pool v0.7.1-beta and Faraday v0.2.19-alpha.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel/pull/348


### PR DESCRIPTION
## Type

In this PR we update Litd to `v0.17.4-alpha`.

## App

`lightning-terminal`

## Summary

This release bumps the integrated `lnd` to `v0.21.3-beta`, `Taproot Assets Daemon` to `v0.8.3`, & `faraday` to `v0.2.19-alpha` + additional updates and fixes within Litd.

See full release notes here:
https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.4-alpha
&
https://github.com/lightninglabs/lightning-terminal/blob/master/docs/release-notes/release-notes-0.17.4.md