### PR TITLE
canary: Update to v1.6.2

### DIFF
--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.2@sha256:63483e14abb101c1976b8f821ec0b968307c062d754082461dc0f2cfe102f170
+    image: schjonhaug/canary-backend:v1.6.2@sha256:a7c952e59fc20e81ff66dea63e15b06a23ab447c40598262beeb41939b0bdc79
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.2@sha256:eb113acedef21ba05f4ac95c8e51b3bc5a46182735754f74636b768983608353
+    image: schjonhaug/canary-frontend:v1.6.2@sha256:2820ad93b9ec989fafd8903b6060954d5929d7fd38a977d51ab0c865e5198afa
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.1@sha256:5cf351492d4e0ddb8dc9575ce10ee7f52435e744c823c2594e6fe6f8b4e7cf3b
+    image: schjonhaug/canary-backend:v1.6.2@sha256:946e60b8df8846d55a0fccb0c3241d2da4a90efe0c3a9cfcf408b6012afb1c93
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.1@sha256:c121e722892016a609b7a8441aebbbbb81658dd6027d5eea62477579c16fffe7
+    image: schjonhaug/canary-frontend:v1.6.2@sha256:4e3c1967cf287daf613939b2fa394f89c987b1a517032972bccb4b41a40c49b4
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.2@sha256:946e60b8df8846d55a0fccb0c3241d2da4a90efe0c3a9cfcf408b6012afb1c93
+    image: schjonhaug/canary-backend:v1.6.2@sha256:63483e14abb101c1976b8f821ec0b968307c062d754082461dc0f2cfe102f170
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.2@sha256:4e3c1967cf287daf613939b2fa394f89c987b1a517032972bccb4b41a40c49b4
+    image: schjonhaug/canary-frontend:v1.6.2@sha256:eb113acedef21ba05f4ac95c8e51b3bc5a46182735754f74636b768983608353
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: canary
 category: bitcoin
 name: Canary Wallet
-version: "1.6.1"
+version: "1.6.2"
 tagline: Early warning system for Bitcoin cold storage
 description: >-
   A canary in the cold mine. When your bitcoins are in cold storage, you seldom check on them.


### PR DESCRIPTION
## Summary
Update Canary Umbrel app to v1.6.2.

## Release summary
Fixed self-hosted sign-in failures when a node changes its hostname, protocol, or external port, including dynamic StartOS ports. Login errors now provide clearer guidance, while existing passwords, wallets, contacts, and notification settings remain unchanged.

## Upstream release
https://github.com/schjonhaug/canary/releases/tag/v1.6.2

## Test plan
- [x] Upgraded a local Umbrel installation from its previously published Canary package directly to v1.6.2
- [x] Verified existing wallets, notification contacts, destinations, settings, and history were preserved
- [x] Verified live delivery through Umbrel's detected local ntfy server and inactive-contact non-delivery
- [x] Restarted Canary and verified the migrated data remained intact without duplicate delivery
