### PR TITLE
Add SubsiMail

### DIFF
--- a/subsimail/docker-compose.yml
+++ b/subsimail/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  app_proxy:
+    environment:
+      APP_HOST: subsimail_web_1
+      APP_PORT: 3000
+
+  web:
+    image: subsimail/subsimail:2.0.0@sha256:aa825794bd2a171a2f663cdcc9ea56943a90b2200c4e94459f5a8dcc7523edc5
+    restart: on-failure
+    volumes:
+      - ${APP_DATA_DIR}/data:/app/data
+    environment:
+      DATABASE_URL: sqlite:///app/data/subsimail.db

--- a/subsimail/umbrel-app.yml
+++ b/subsimail/umbrel-app.yml
@@ -1,0 +1,50 @@
+manifestVersion: 1
+id: subsimail
+category: networking
+name: SubsiMail
+version: "2.0.0"
+tagline: Self-hosted cold email outreach that runs on your own server
+description: >-
+  Note: after install, SubsiMail needs a free license token to activate. Sign
+  up at subsimail.com (no credit card) and either paste the token it gives
+  you, or use "Connect your account" to fetch it automatically — both happen
+  from the setup screen in your browser. The first connected mailbox is free
+  forever.
+
+
+  SubsiMail is a self-hosted cold email sequencing platform. Prospect lists,
+  templates, connected inboxes, and all campaign data live in your own
+  SQLite database on your own server, never in a third party's cloud.
+
+
+  It's built as a self-hosted alternative to tools like Instantly, Smartlead,
+  lemlist, and Apollo, with flat, per-inbox pricing instead of per-seat fees,
+  full data ownership and export, no content review of what you send, and no
+  third-party access to your contacts or campaigns.
+
+
+  - Connect Gmail, Outlook, or any SMTP/IMAP inbox
+
+  - Multi-step sequences with merge fields and reply detection
+
+  - Per-user roles (admin/manager/view-only) and a full audit trail
+
+  - A REST API with personal API keys for your own integrations
+
+releaseNotes: ""
+
+developer: SubsiMail
+website: https://subsimail.com
+dependencies: []
+repo: https://subsimail.com
+support: https://subsimail.com/docs
+
+port: 3860
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+submitter: SubsiMail
+submission: ""


### PR DESCRIPTION
## App

**SubsiMail** v2.0.0 — self-hosted cold email sequencing platform. Prospect lists, templates, connected inboxes, and campaign data are stored in the user's own SQLite database on their own server, not a third-party SaaS. Positioned as a self-hosted alternative to Instantly / Smartlead / lemlist / Apollo, with flat per-inbox pricing instead of per-seat fees.

- Website: https://subsimail.com
- Docs/support: https://subsimail.com/docs

## Image source

- `docker.io/subsimail/subsimail`, tag `2.0.0`, pinned to the multi-arch manifest-list digest.
- Verified `linux/amd64` and `linux/arm64` both present via `docker buildx imagetools inspect subsimail/subsimail:2.0.0`.

## Notable setup behavior

- **The app requires a free license token from subsimail.com before it's usable**, even on the free tier (first connected mailbox is free forever, no card required). From the in-browser setup screen, the user either pastes a token or uses a "Connect your account" button that goes through subsimail.com OAuth. This is called out at the top of the manifest `description` so it isn't a surprise mid-install. There is no way to use the app fully offline/local-only — flagging this plainly since I know it's a departure from most App Store packages.
- No default username/password — account creation happens in-browser after the license step.
- Single `web` service behind `app_proxy`, SQLite data persisted under `${APP_DATA_DIR}/data`, migrations run automatically and idempotently on startup.
- No host access, no privileged mode, no extra permissions needed.
- `repo:` in the manifest points at the docs site rather than a source repo — the application source is closed, so there's no public repo to link.

## Testing performed

- Built and pushed the multi-arch image myself (amd64 native + arm64 via buildx/QEMU), confirmed both platforms resolve under one digest.
- Ran the arm64 image directly (`docker run --platform linux/arm64`), confirmed it boots, prints its normal startup banner, and runs its embedded SQLite migrations without error.
- Have not yet run a full install through a live Umbrel instance — happy to do that as a follow-up if a maintainer wants it before merge.

## Assets for review

Logo: https://subsimail.com/static/apple-touch-icon.png

Screenshot: https://subsimail.com/static/img/marketing/dashboard-hero.png
