### PR TITLE
Update electrumx to 1.16.0-patch.4 - exclude utxo database from backups

### DIFF
--- a/electrumx/umbrel-app.yml
+++ b/electrumx/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - electrs
 category: bitcoin
 name: ElectrumX
-version: "1.16.0-patch.3"
+version: "1.16.0-patch.4"
 tagline: A lightweight Electrum server
 description: >
   Run your personal Electrum server and connect your Electrum-compatible wallet,
@@ -31,12 +31,10 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >
-  This security update upgrades the bundled Tor sidecar to 0.4.9.11, restoring Tor connectivity and including the latest Tor security fixes. The primary app version is unchanged.
-
-
-  This update adds support for Backups in umbrelOS 1.5.
+  This update excludes the ElectrumX UTXO database from umbrelOS backups. The database is rebuilt from your Bitcoin node when ElectrumX resyncs and doesn't need to be backed up. Because it is rewritten frequently, including it caused backups to grow rapidly and fill up backup drives.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/1813
 backupIgnore:
   - data/electrumx/meta
   - data/electrumx/hist
+  - data/electrumx/utxo


### PR DESCRIPTION
ElectrumX stores its database as three LevelDB directories under `data/electrumx`: `meta`, `hist` and `utxo`. #3657 excluded `meta` and `hist` from backups but left `utxo` in.

On a synced node the `utxo` database is rewritten almost entirely every hour by LevelDB compaction. Measured on a device running umbrelOS 1.7.4, a `kopia diff` between two consecutive hourly snapshots showed ~10GB of changed files, essentially all of them in `data/electrumx/utxo` (the directory itself is ~8.7GB). That adds 100GB+ per day of unique data to the backup repository, which filled a 4TB backup drive in about three weeks.

Backing up `utxo` on its own also protects nothing: without `meta` and `hist` a restored ElectrumX has to resync from the Bitcoin node anyway, and the resync rebuilds `utxo` too. This brings ElectrumX in line with electrs and Fulcrum, which already exclude their whole database.

`backupIgnore` is read from the installed app's manifest copy, so the version bump is needed for existing installs to pick up the change.