### PR TITLE
Fix ONLYOFFICE Docs internal address rejected by Nextcloud

### DIFF
--- a/onlyoffice-nextcloud/docker-compose.yml
+++ b/onlyoffice-nextcloud/docker-compose.yml
@@ -10,12 +10,13 @@ services:
     restart: on-failure
     environment:
       - DOCS_ADDRESS=http://$DEVICE_DOMAIN_NAME:$DOCSERVER_PORT
-      - DOCS_INTERNAL_ADDRESS=http://onlyoffice-nextcloud_documentserver_1
+      - DOCS_INTERNAL_ADDRESS=http://onlyoffice-nextcloud-documentserver-1
       - NEXTCLOUD_INTERNAL_ADDRESS=http://nextcloud_web_1
       - NEXTCLOUD_WEB_URL=http://$DEVICE_DOMAIN_NAME:$APP_NEXTCLOUD_PORT
 
   documentserver:
     image: onlyoffice/documentserver:9.4.0@sha256:e3da62a847b9a5d51a11f73cfea1d9c13c3be3809614490d4edddcf01dcf919b
+    container_name: onlyoffice-nextcloud-documentserver-1 # Avoid underscores in the hostname: Document Server percent-escapes them in the signed URLs it returns
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/onlyoffice-nextcloud/docker-compose.yml
+++ b/onlyoffice-nextcloud/docker-compose.yml
@@ -10,13 +10,17 @@ services:
     restart: on-failure
     environment:
       - DOCS_ADDRESS=http://$DEVICE_DOMAIN_NAME:$DOCSERVER_PORT
-      - DOCS_INTERNAL_ADDRESS=http://onlyoffice-nextcloud-documentserver-1
+      - DOCS_INTERNAL_ADDRESS=http://onlyoffice-nextcloud-documentserver
       - NEXTCLOUD_INTERNAL_ADDRESS=http://nextcloud_web_1
       - NEXTCLOUD_WEB_URL=http://$DEVICE_DOMAIN_NAME:$APP_NEXTCLOUD_PORT
 
   documentserver:
     image: onlyoffice/documentserver:9.4.0@sha256:e3da62a847b9a5d51a11f73cfea1d9c13c3be3809614490d4edddcf01dcf919b
-    container_name: onlyoffice-nextcloud-documentserver-1 # Avoid underscores in the hostname: Document Server percent-escapes them in the signed URLs it returns
+    # Avoid underscores in signed URLs while preserving Umbrel's generated container name.
+    networks:
+      default:
+        aliases:
+          - onlyoffice-nextcloud-documentserver
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/onlyoffice-nextcloud/docker-compose.yml
+++ b/onlyoffice-nextcloud/docker-compose.yml
@@ -16,7 +16,9 @@ services:
 
   documentserver:
     image: onlyoffice/documentserver:9.4.0@sha256:e3da62a847b9a5d51a11f73cfea1d9c13c3be3809614490d4edddcf01dcf919b
-    # Avoid underscores in signed URLs while preserving Umbrel's generated container name.
+    # ONLYOFFICE escapes hostname underscores as %5f, rejected by Guzzle since 7.15.2 (2026-07-26).
+    # https://github.com/guzzle/guzzle/releases/tag/7.15.2
+    # Use an alias to preserve Umbrel's generated container name.
     networks:
       default:
         aliases:

--- a/onlyoffice-nextcloud/umbrel-app.yml
+++ b/onlyoffice-nextcloud/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: onlyoffice-nextcloud
 category: files
 name: ONLYOFFICE Docs
-version: "9.4.0"
+version: "9.4.0-1"
 tagline: Online office for Nextcloud
 description: >-
   An online office suite for Nextcloud that enables you to create, edit and collaborate on text documents, spreadsheets and presentations in real time.
@@ -10,13 +10,10 @@ description: >-
 
   Simply install ONLYOFFICE Docs and follow the in-app instructions to connect it to Nextcloud running on your Umbrel.
 releaseNotes: >-
-  This release adds Dark mode support for spreadsheets, new presentation themes and transitions, a new Chart design tab, and the ability to add horizontal lines in documents.
+  This update fixes ONLYOFFICE Docs failing to connect to Nextcloud, which broke document previews, file conversion and saving older .doc, .xls and .ppt files.
 
 
-  It also includes security fixes for document conversion, XSS, GUID generation, macro sandboxing, and PDF processing, plus back-end resource usage improvements.
-
-
-  Full release notes can be found at https://github.com/ONLYOFFICE/DocumentServer/blob/master/CHANGELOG.md#940
+  After updating, open Nextcloud's ONLYOFFICE admin settings and set "ONLYOFFICE Docs address for internal requests from the server" to the new address shown on the ONLYOFFICE Docs setup page: http://onlyoffice-nextcloud-documentserver-1
 developer: Ascensio System SIA
 website: https://www.onlyoffice.com/
 dependencies:

--- a/onlyoffice-nextcloud/umbrel-app.yml
+++ b/onlyoffice-nextcloud/umbrel-app.yml
@@ -10,10 +10,19 @@ description: >-
 
   Simply install ONLYOFFICE Docs and follow the in-app instructions to connect it to Nextcloud running on your Umbrel.
 releaseNotes: >-
-  This update fixes ONLYOFFICE Docs failing to connect to Nextcloud, which broke document previews, file conversion and saving older .doc, .xls and .ppt files.
+  This update fixes an issue that could prevent document previews, file conversion, and saving older Office files in Nextcloud.
 
 
-  After updating, open Nextcloud's ONLYOFFICE admin settings and set "ONLYOFFICE Docs address for internal requests from the server" to the new address shown on the ONLYOFFICE Docs setup page: http://onlyoffice-nextcloud-documentserver
+  ⚠️ Action required after updating: Change the following setting in Nextcloud to complete the fix.
+
+
+  1. Sign in to Nextcloud as an administrator, then open Administration settings → ONLYOFFICE.
+
+
+  2. Under "Advanced server settings" (expand it if needed), set "ONLYOFFICE Docs address for internal requests from the server" to http://onlyoffice-nextcloud-documentserver
+
+
+  3. Click Save.
 developer: Ascensio System SIA
 website: https://www.onlyoffice.com/
 dependencies:

--- a/onlyoffice-nextcloud/umbrel-app.yml
+++ b/onlyoffice-nextcloud/umbrel-app.yml
@@ -13,7 +13,7 @@ releaseNotes: >-
   This update fixes ONLYOFFICE Docs failing to connect to Nextcloud, which broke document previews, file conversion and saving older .doc, .xls and .ppt files.
 
 
-  After updating, open Nextcloud's ONLYOFFICE admin settings and set "ONLYOFFICE Docs address for internal requests from the server" to the new address shown on the ONLYOFFICE Docs setup page: http://onlyoffice-nextcloud-documentserver-1
+  After updating, open Nextcloud's ONLYOFFICE admin settings and set "ONLYOFFICE Docs address for internal requests from the server" to the new address shown on the ONLYOFFICE Docs setup page: http://onlyoffice-nextcloud-documentserver
 developer: Ascensio System SIA
 website: https://www.onlyoffice.com/
 dependencies:


### PR DESCRIPTION
## Type

App update — package fix. No image change; manifest `version` bumped `9.4.0` → `9.4.0-1`.

## App

App ID: `onlyoffice-nextcloud`
Upstream project: https://github.com/ONLYOFFICE/DocumentServer
Version: 9.4.0-1 (image unchanged at 9.4.0)

## Summary

The app points Nextcloud at Document Server by its injected container name,
`onlyoffice-nextcloud_documentserver_1`. Document Server percent-escapes
underscores in the host of every signed URL it returns
([`storage-base.js:179`](https://github.com/ONLYOFFICE/server/blob/master/Common/sources/storage/storage-base.js)),
and Nextcloud's HTTP client rejects a percent escape in a host (guzzle 7.15.2,
GHSA-v5mv-p594-2x33):

```
Error when trying to connect (The request URI host
"onlyoffice-nextcloud%5fdocumentserver%5f1" must not contain a percent escape,
because a handler can decode it and then connect to a host that differs from
the one the request names.) (version 9.4.0.129)
```

On a stock install that means no office previews, failed conversions, `.doc`/
`.xls`/`.ppt` failing to save, and that error on the ONLYOFFICE admin page.

Fix: give the service a hostname with no underscore in it.

```diff
-      - DOCS_INTERNAL_ADDRESS=http://onlyoffice-nextcloud_documentserver_1
+      - DOCS_INTERNAL_ADDRESS=http://onlyoffice-nextcloud-documentserver-1

   documentserver:
     image: onlyoffice/documentserver:9.4.0@sha256:…
+    container_name: onlyoffice-nextcloud-documentserver-1
```

Same resolution mechanism as before, same name shape as the injected one, just
`-` instead of `_`. Reported upstream too, but that fix needs a Document Server
release; this works today.

Manifest `version` is bumped to `9.4.0-1` with matching release notes, so
existing installs are offered the update — without it the fix would reach new
installs only.

## Verification

Umbrel testing performed: not yet. Static checks only —
`npm run lint:apps -- onlyoffice-nextcloud --check-images` and
`git diff --check`. Per `.claude/skills/umbrel-test-app` that is not Umbrel
verification, so the update path still needs a runtime test on a device.

Environment tested:
- [ ] Umbrel device
- [ ] Local umbrelOS test environment
- [x] Not runtime tested

Architecture tested:
- [ ] amd64
- [ ] arm64

Known lint warnings or caveats:

```
WARNING service.container_name onlyoffice-nextcloud/docker-compose.yml:19
  Service `documentserver` sets `container_name`; Umbrel injects container names automatically.
```

`0 error(s)`. Same advisory `searxng`, `adventurelog`, `seafile` and
`rustdesk-server` already carry — `searxng` for this exact reason.

## Notes

Existing installs keep the address stored in Nextcloud's app config and need to
paste the new one once (Admin → ONLYOFFICE → Advanced server settings), or:

```bash
occ config:app:set onlyoffice DocumentServerInternalUrl --value="http://onlyoffice-nextcloud-documentserver-1/"
```

They are broken today regardless. No new permissions or dependencies.

