### PR TITLE
Update mempool to 3.3.1-hotfix-2 - exclude rebuildable data from backups

### DIFF
--- a/mempool/umbrel-app.yml
+++ b/mempool/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: mempool
 category: bitcoin
 name: mempool
-version: "3.3.1-hotfix-1"
+version: "3.3.1-hotfix-2"
 tagline: Be your own explorer
 description: >-
   Run your own instance of The Mempool Open Source Project and trust no one.
@@ -13,13 +13,10 @@ description: >-
 
   This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com
 releaseNotes: >-
-  This update fixes an issue where mempool could repeatedly restart with an out-of-memory error.
+  This update excludes mempool's rebuildable cache and chain-derived database from umbrelOS backups, preventing the explorer index from consuming backup storage.
 
 
-  Mempool now uses memory more appropriately for your device, improving reliability on Raspberry Pi and other low-memory systems.
-
-
-  If a temporary local cache grows too large, it will be safely rebuilt automatically. This does not affect your Bitcoin node, Electrs, wallet data, or transaction history.
+  After a restore, mempool rebuilds this data from your Bitcoin Node and Electrs. Locally accumulated explorer statistics may take time to repopulate. Your Bitcoin wallet and node configuration remain backed up by their respective apps.
 developer: Mempool Holdings S.A. de C.V.
 website: https://mempool.space/about
 dependencies:
@@ -58,5 +55,8 @@ widgets:
         - title: "High priority"
           text: "27"
           subtext: "sat/vB"
+backupIgnore:
+  - data/*
+  - mysql/data
 submitter: Mempool Holdings S.A. de C.V.
 submission: https://github.com/getumbrel/umbrel/pull/470


### PR DESCRIPTION
## Summary
- exclude mempool's persistent backend cache from umbrelOS backups
- exclude the chain-derived MariaDB explorer index from umbrelOS backups
- bump the package to `3.3.1-hotfix-2` so existing installations receive the change
- explain restore behavior in the release notes

## Why
Both excluded paths are derived from Bitcoin Node and Electrs data. Backing them up duplicates rebuildable chain/index data and can consume substantial backup storage.

After a restore, mempool rebuilds these paths from Bitcoin Node and Electrs. Locally accumulated explorer statistics may take time to repopulate. Wallet and node configuration remain owned and backed up by their respective apps.

## Verification
- official image-aware app linter: 0 errors
- exact assertion confirms `backupIgnore` matches `${APP_DATA_DIR}/data:/backend/cache` and `${APP_DATA_DIR}/mysql/data:/var/lib/mysql`
- package directory skeletons remain present for fresh installs/restores
- `git diff --check` passes
- changed-file scope is limited to `mempool/umbrel-app.yml`

## Existing warning
The linter reports that the mutable `mariadb:10.5.12` tag no longer resolves to the digest already pinned by the package. This PR intentionally preserves the existing immutable digest and does not update any images.