### PR TITLE
Update Bassin to 2.1.4

### DIFF
--- a/bassin/docker-compose.yml
+++ b/bassin/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - ${APP_DATA_DIR}/data/www:/www
 
   ui:
-    image: ghcr.io/blockdyor/bassin-ui:8dd4962@sha256:44422f070f47c8129febe02ec99a3f28a11b8c770c563754aa4db449e5d13966
+    image: ghcr.io/blockdyor/bassin-ui:0e779e6@sha256:d8febed17f9b63f85227f3168ff2d7b15f9c430402866ad06237cebb4dc9dc68
     entrypoint: /bin/sh -c "cp -r /ui/* /www/"
     user: "1000:1000"
     volumes:

--- a/bassin/umbrel-app.yml
+++ b/bassin/umbrel-app.yml
@@ -1,5 +1,5 @@
 manifestVersion: 1
-version: "2.1.3"
+version: "2.1.4"
 id: bassin
 name: Bassin
 tagline: Solo Bitcoin Mining Pool (ckPool)
@@ -21,10 +21,12 @@ category: bitcoin
 dependencies:
   - bitcoin
 releaseNotes: >-
-  Show precise UTC timestamps in tooltips for pool/user
-  last-update and last-share times; change hover cursors
-  to help where tooltips are available. This
-  update does not change the underlying ckpool service.
+  Sanitize user directory parsing against path traversal and autoindex
+  parent links. Add safe localStorage parsing to prevent UI crashes from
+  corrupted browser storage. Update build dependencies to resolve all
+  audit vulnerabilities. Update footer repository link to point to
+  blockdyor/bassin with safe new-tab attributes. This update does not
+  change the underlying ckpool service.
 port: 5008
 submitter: duckaxe
 developer: blockdyor

--- a/bassin/umbrel-app.yml
+++ b/bassin/umbrel-app.yml
@@ -21,12 +21,16 @@ category: bitcoin
 dependencies:
   - bitcoin
 releaseNotes: >-
-  Sanitize user directory parsing against path traversal and autoindex
-  parent links. Add safe localStorage parsing to prevent UI crashes from
-  corrupted browser storage. Update build dependencies to resolve all
-  audit vulnerabilities. Update footer repository link to point to
-  blockdyor/bassin with safe new-tab attributes. This update does not
-  change the underlying ckpool service.
+  This update improves the reliability of the Bassin UI.
+
+
+  Improvements:
+    - Prevent UI crashes caused by corrupted browser storage
+    - Ignore invalid, duplicate, and parent directory links when loading user data
+    - Update the footer link to the current Bassin repository and open it in a new tab
+
+
+  The underlying ckpool service is unchanged.
 port: 5008
 submitter: duckaxe
 developer: blockdyor


### PR DESCRIPTION
## Type

App update

## App

App ID: bassin
Upstream project: blockdyor/bassin
Version: 2.1.4

## Summary

This update brings stability, security, and maintenance improvements to the Bassin UI:
- Sanitizes user directory parsing against path traversal and web server autoindex parent links (such as `../`).
- Adds resilient error handling around `localStorage` parsing to prevent UI crashes from corrupted browser storage.
- Updates build dependencies to resolve all audit vulnerabilities.
- Updates the footer repository link to point to `blockdyor/bassin` with safe new-tab navigation.

The underlying ckpool service is unchanged.

## Verification

**Environment tested:**
- [x] Umbrel device
- [x] Local umbrelOS test environment
- [ ] Not runtime tested

**Architecture tested:**
- [ ] amd64
- [x] arm64

**Known lint warnings or caveats:**
- None expected

## Notes

**Permissions, dependencies, migrations, default credentials, or caveats:**
- No permission changes
- No dependency changes
- No migrations
- No default credential changes
- No known caveats