### PR TITLE
Add Solo Pool RS

### DIFF
--- a/solo-pool-rs/data/config.toml
+++ b/solo-pool-rs/data/config.toml
@@ -1,0 +1,68 @@
+# Solo Pool RS — Umbrel configuration.
+#
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │ REQUIRED: set coinbase_address below to YOUR Bitcoin address, then      │
+# │ restart the app. 100% of every block found pays out to this address.   │
+# │ The pool will not produce work until it is valid.                      │
+# └─────────────────────────────────────────────────────────────────────────┘
+#
+# Bitcoin node connection details (RPC credentials, ZMQ endpoint) are injected
+# by Umbrel through SOLO_POOL_* environment variables in docker-compose.yml —
+# the placeholder values in [bitcoin_rpc] and [zmq] below are overridden at
+# startup and need no editing.
+
+[pool]
+listen_addr = "0.0.0.0:4334"
+
+# ▼▼▼ EDIT THIS ▼▼▼
+coinbase_address = "REPLACE-WITH-YOUR-BITCOIN-ADDRESS"
+# ▲▲▲ EDIT THIS ▲▲▲
+
+coinbase_tag = "/solo-pool-rs/"
+# ~1 TH/s at 15 s/share; vardiff adjusts from here. Raise for bigger fleets.
+initial_difficulty = 4096
+extranonce1_size = 4
+extranonce2_size = 4
+max_connections = 256
+idle_timeout_secs = 300
+found_block_dir = "/app/data/found-blocks"
+
+[sv2]
+enabled = true
+
+[bitcoin_rpc]
+# Overridden by SOLO_POOL_BITCOIN_RPC__* env vars (Umbrel's Bitcoin app).
+url = "http://10.21.21.8:8332"
+user = ""
+password = ""
+timeout_secs = 10
+
+[zmq]
+# Overridden by SOLO_POOL_ZMQ__HASHBLOCK_ENDPOINT.
+hashblock_endpoint = "tcp://10.21.21.8:28334"
+poll_fallback = true
+poll_interval_ms = 1000
+
+[vardiff]
+target_share_time_secs = 15
+retarget_interval_secs = 60
+min_difficulty = 4096
+max_difficulty = 65536
+max_retarget_factor = 4.0
+
+[security]
+max_connections_per_ip = 5
+max_shares_per_sec = 500
+ban_duration_secs = 300
+max_invalid_shares = 5
+max_message_bytes = 4096
+max_worker_name_len = 128
+max_authorizations_per_session = 8
+
+[metrics]
+prometheus_addr = "0.0.0.0:9090"
+stats_db_path = "/app/data/pool_stats.sqlite"
+
+[logging]
+level = "info"
+json = false

--- a/solo-pool-rs/docker-compose.yml
+++ b/solo-pool-rs/docker-compose.yml
@@ -1,0 +1,45 @@
+# Solo Pool RS on umbrelOS.
+#
+# Wiring:
+#  - The dashboard (container port 9090) is served through Umbrel's app_proxy
+#    on the manifest port 4333, behind umbrelOS auth.
+#  - Stratum is raw TCP and bypasses the proxy: published straight to the host
+#    on 4334 (3333 belongs to another App Store app). The pool listens on 4334
+#    inside the container too, so its Connect dialog shows the port miners
+#    actually use. Miners connect to <umbrel-ip>:4334 (SV1 and SV2
+#    auto-detected).
+#  - Bitcoin node access comes from the Bitcoin app's exported env vars (RPC
+#    credentials and the ZMQ hashblock endpoint), injected into the shipped
+#    config through solo-pool-rs's SOLO_POOL_* env overrides. No cookie mount.
+#  - data/ (installed to ${APP_DATA_DIR}/data) holds config.toml, the stats
+#    database, the found-block archive and the SV2 authority key.
+services:
+  app_proxy:
+    environment:
+      APP_HOST: solo-pool-rs_pool_1
+      APP_PORT: 9090
+
+  pool:
+    image: ghcr.io/cbyam/solo-pool-rs:0.6.8@sha256:a41cbb69087f6859e0d409df2c06e16fd76e9df8a899176ced6f523a7d558fcb
+    restart: on-failure
+    # A block found seconds before a stop must reach the node; the pool waits
+    # for an in-flight submitblock on shutdown.
+    stop_grace_period: 1m
+    # The image's built-in user is 10001, but Umbrel's app-data dirs are owned
+    # by 1000. The binary needs no particular uid (RPC auth is user/password,
+    # not the cookie file), so run as 1000 to keep the data volume writable.
+    user: "1000:1000"
+    ports:
+      - "4334:4334/tcp"
+    volumes:
+      - ${APP_DATA_DIR}/data:/app/data
+    command: ["/app/data/config.toml"]
+    environment:
+      - SOLO_POOL_BITCOIN_RPC__URL=http://${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_RPC_PORT}
+      - SOLO_POOL_BITCOIN_RPC__USER=${APP_BITCOIN_RPC_USER}
+      - SOLO_POOL_BITCOIN_RPC__PASSWORD=${APP_BITCOIN_RPC_PASS}
+      - SOLO_POOL_ZMQ__HASHBLOCK_ENDPOINT=tcp://${APP_BITCOIN_NODE_IP}:${APP_BITCOIN_ZMQ_HASHBLOCK_PORT}
+      # The pool persists its SV2 authority key (miner identity pinning) and
+      # refuses to start if it cannot create the file. Keep it in the data
+      # volume so the pool's identity survives container re-creates.
+      - SOLO_POOL_SV2__AUTHORITY_KEY_FILE=/app/data/sv2-authority.key

--- a/solo-pool-rs/umbrel-app.yml
+++ b/solo-pool-rs/umbrel-app.yml
@@ -52,4 +52,4 @@ defaultUsername: ""
 defaultPassword: ""
 
 submitter: Chuck Byam
-submission: https://github.com/getumbrel/umbrel-apps/pull/PENDING
+submission: https://github.com/getumbrel/umbrel-apps/pull/6064

--- a/solo-pool-rs/umbrel-app.yml
+++ b/solo-pool-rs/umbrel-app.yml
@@ -1,0 +1,55 @@
+manifestVersion: 1
+id: solo-pool-rs
+category: bitcoin
+name: Solo Pool RS
+version: "0.6.8"
+tagline: Solo-mine Bitcoin over Stratum V1 and V2, 100% of every block to your address
+description: >-
+  A self-contained solo Bitcoin mining pool for your own ASICs. Point any
+  Stratum V1 miner, or a Noise-encrypted Stratum V2 device such as the
+  NerdQAxe++, at port 4334 on your Umbrel and every block found pays out
+  entirely to the address you configure. The protocol is auto-detected per
+  connection, so V1 and V2 hardware share the same port. It is the only solo
+  pool in the App Store that speaks Stratum V2 to miners directly.
+
+
+  First run: open the app and set your payout address on the Settings page.
+  No SSH needed. The pool stays paused, with the dashboard reachable, until a
+  valid address for your node's network is saved. Every block reward goes to
+  that address and nowhere else.
+
+
+  Highlights:
+
+  - Stratum V1 and Noise-encrypted Stratum V2 on a single port, with optional
+  pool-identity pinning for SV2 miners
+
+  - Loss-proof block submission: every found block is archived to disk and
+  submitted with automatic retries, and any block whose acceptance the pool
+  never saw is resubmitted on the next start
+
+  - Per-miner vardiff, a live dashboard with round effort, blocks found,
+  hashrate history, per-worker stats and node health, plus Prometheus
+  metrics
+
+  - One Rust binary using your Umbrel's Bitcoin node over RPC with instant ZMQ
+  block notifications; the block-acceptance path is proven on regtest in CI
+  on every change
+releaseNotes: ""
+
+developer: Chuck Byam
+website: https://github.com/cbyam/solo-pool-rs
+dependencies:
+  - bitcoin
+repo: https://github.com/cbyam/solo-pool-rs
+support: https://github.com/cbyam/solo-pool-rs/issues
+
+port: 4333
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+submitter: Chuck Byam
+submission: https://github.com/getumbrel/umbrel-apps/pull/PENDING


### PR DESCRIPTION
## Solo Pool RS 0.6.8

A self-contained solo Bitcoin mining pool for the user's own ASICs. It speaks Stratum V1 and Noise-encrypted Stratum V2 on one port (auto-detected per connection) and pays every block reward to the address the user configures. No fees, no accounts, one Rust binary beside the Umbrel Bitcoin node.

- **Upstream:** https://github.com/cbyam/solo-pool-rs (MIT OR Apache-2.0)
- **Image:** `ghcr.io/cbyam/solo-pool-rs:0.6.8@sha256:a41cbb69087f6859e0d409df2c06e16fd76e9df8a899176ced6f523a7d558fcb`, built by the upstream repository's GitHub Actions from the `v0.6.8` tag (Dockerfile in the repo), multi-arch index with `linux/amd64` and `linux/arm64`. Runs as uid 1000.
- **Dependencies:** `bitcoin`. RPC credentials, node IP and the ZMQ hashblock endpoint come from the Bitcoin app's exports and are injected as `SOLO_POOL_*` environment overrides on the shipped config.
- **Ports:** dashboard behind `app_proxy` on manifest port 4333 (container 9090), Umbrel auth on. Stratum is raw TCP on host port **4334** (`4334:4334/tcp`); it is a miner protocol, not HTTP, so it cannot sit behind the proxy. The pool listens on 4334 inside the container too so its Connect dialog shows the port miners use.
- **Permissions / host access:** none beyond the raw Stratum port. No host networking, no Docker socket, no devices.
- **Credentials:** none. The dashboard is behind Umbrel auth. First run: the user opens the app and saves a payout address on its Settings page; the pool stays paused until an address valid for the node's network is saved. The description says this near the top.
- **Persistence:** everything under `${APP_DATA_DIR}/data`: the shipped `config.toml`, the stats database, the found-block archive, and the SV2 authority key (the pool's identity for miners that pin it).

## Testing

- **Static:** `npm run lint:apps -- solo-pool-rs --check-images` reports no issues; `git diff --check` clean.
- **Environment:** umbrelOS 1.7.4, `amd64` (KVM guest). Fresh install path.
- **Dependency:** Bitcoin Node app 1.4.0, switched to regtest in its settings and given 101 blocks with `generatetoaddress` so it can serve templates.
- **Install:** package synced into the official app-store source directory under this id, installed with `umbreld client apps.install.mutate --appId solo-pool-rs`, state `ready`.
- **Open:** dashboard opened through `app_proxy` on port 4333 from the Umbrel home screen, behind Umbrel auth. It starts in "Mining paused" with the Settings page reachable; saving a regtest payout address there cleared the pause and the pool broadcast a job.
- **Main functionality:** a Stratum V1 test miner connected to host port 4334, was issued jobs, and had 12 regtest blocks accepted by the node through the pool (chain advanced to height 196). The app's ZMQ subscription to the Bitcoin app delivered a mined block (no fallback-poll warning in the app log). An earlier run of the same package under a community-store id put 82 blocks through it.
- **Restart and persistence:** `umbreld client apps.restart.mutate --appId solo-pool-rs`, back to `ready`. Afterwards the found-block count (12), the saved payout address, and the SV2 authority key under `data/` were all unchanged, and a new miner connection received a job immediately.
- **Logs:** settled `apps.logs` show the proxy created and the pool building jobs; no errors.
- **Not tested:** `arm64` runtime (the image index carries `linux/arm64` and is built on native ARM runners upstream; verified with `imagetools inspect`). Update path: not applicable for a new package.

## Checklist before marking ready

- [x] Install test with the official app id
- [x] Restart through Umbrel, blocks found, saved address and pool identity persist
- [x] Screenshots and logo added below
- [x] Mark ready for review

## Screenshots and logo

Overview on a mainnet pool with five workers (dashboard at 0.6.6; the layout is unchanged in 0.6.8):

![solo-pool-rs dashboard](https://raw.githubusercontent.com/cbyam/solo-pool-rs/main/docs/dashboard.png)

Logo (256 by 256 SVG, as used by the community store):
https://raw.githubusercontent.com/cbyam/umbrel-app-store/main/cbyam-solo-pool-rs/icon.svg
