### PR TITLE
Update SkyBro to v1.6.2

### DIFF
--- a/skybro/docker-compose.yml
+++ b/skybro/docker-compose.yml
@@ -6,14 +6,14 @@ services:
       APP_PORT: 5000
 
   tracker:
-    image: xdeekay/skybro-tracker:1.5.7@sha256:bdf57d79bd57edab657fc8c87f6699636e381d796228c6e0f545864155b6ecc6
+    image: xdeekay/skybro-tracker:1.6.2@sha256:9425a99b0f1cfbf8a4cf39ee4ca8876496d20750e9b960109fc9d5b1eeaa2c67
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/data
       - /etc/localtime:/etc/localtime:ro
 
   web:
-    image: xdeekay/skybro-dashboard:1.5.7@sha256:4582ab1ca4bd682e4b36631ab9f1ba37ef6d0b7acf17560395835da525c33158
+    image: xdeekay/skybro-dashboard:1.6.2@sha256:83ad07aee074ab3d827db00c081eea0e6bf17e7f104ff6ac635bc7dbe6ce2eea
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/data

--- a/skybro/umbrel-app.yml
+++ b/skybro/umbrel-app.yml
@@ -2,42 +2,53 @@ manifestVersion: 1
 id: skybro
 category: networking
 name: SkyBro
-version: "1.5.7"
+version: "1.6.2"
 tagline: Live aircraft, satellite, weather & astronomy tracker
 description: >-
   SkyBro is a real-time sky tracker for your home. It runs silently in the
   background 24/7 and alerts you the moment something interesting is overhead.
 
 
-  ✈️ Aircraft — Tracks live planes in your vicinity using OpenSky Network's
-  ADS-B data. Get Pushover or Discord alerts (with photo) when a plane enters
-  your configured radius and altitude window. The live map shows per-airframe
-  silhouettes for jets, widebodies, helicopters, light props, and military
-  aircraft. Every alerted plane is saved to history with its full flight path.
+  ✈️ Aircraft - Tracks live planes in your vicinity using OpenSky Network's
+  ADS-B data. Get an alert (with photo) via Apprise (Pushover, Discord,
+  Telegram, email, and 130+ other services) when a plane enters your
+  configured radius and altitude window, with optional filters to include or
+  exclude specific callsigns, countries, models, or airframe types. The live map
+  shows per-airframe silhouettes for jets, widebodies, helicopters, light
+  props, and military aircraft. Every alerted plane is saved to history with
+  its full flight path.
 
 
-  🛰️ Satellites — Monitors upcoming passes for the ISS, Hubble Space
+  🛰️ Satellites - Monitors upcoming passes for the ISS, Hubble Space
   Telescope, and Tiangong CSS. Fires a push alert before each ISS pass so you
   never miss one.
 
 
-  🔭 Astronomy — Full night-sky planner powered by ephem. Shows tonight's dark
+  🔭 Astronomy - Full night-sky planner powered by ephem. Shows tonight's dark
   window, Bortle sky quality, and observation highlights. Browse all 110
   Messier objects with equipment and horizon filters, track all 7 planets with
   rise/set times, and follow 11 annual meteor showers.
 
 
-  ☁️ Weather — Pulls hyperlocal forecasts from Open-Meteo (no API key needed)
+  ☁️ Weather - Pulls hyperlocal forecasts from Open-Meteo (no API key needed)
   including current conditions, 24-hour hourly breakdown, and 7-day forecast.
   Includes a sky visibility score for tonight.
 
 
-  All settings — home coordinates, alert radius, altitude threshold, satellite
-  lead time, and notification credentials are configurable through the built-in
+  All settings (home coordinates, alert radius, altitude threshold, satellite
+  lead time, and notification targets) are configurable through the built-in
   settings page. No config file editing required. Changes apply within 15
   seconds without restarting.
 
-releaseNotes: ""
+releaseNotes: >
+  - Notifications rebuilt on Apprise, supporting Pushover, Discord, Telegram, email, and 130+ other services, with reusable message templates and per-target filters
+  - Added a Daily Digest notification: a scheduled one-line summary of yesterday's aircraft, today's satellite passes, and tonight's astronomy highlights, with a short and a detailed template to choose from
+  - Added independent quiet hours for aircraft and satellite alerts
+  - Settings page redesigned with a tabbed layout, in-app help for filter syntax and template placeholders, and a live rule tester
+  - Switched the map to vector tiles for sharper rendering, with an optional CARTO API key to remove basemap watermarks, and an automatic fallback to the classic tile-based basemap on browsers/devices that can't use hardware-accelerated 3D graphics
+  - Fixed a pinch-to-zoom freeze on iOS
+  - Numerous mobile layout fixes across the dashboard and settings pages
+  - Added a Diagnostics panel and tracker log viewer for troubleshooting
 
 developer: xDeeKay
 website: https://github.com/xDeeKay/SkyBro


### PR DESCRIPTION
## Type

App update

## App

App ID: skybro
Upstream project: https://github.com/xDeeKay/SkyBro
Version: 1.6.2

## Summary

Brings this listing's SkyBro up to date from 1.5.7 to 1.6.2.
Since this fork never picked up the 1.6.0/1.6.1 releases individually, the changelog below is combined across all three.

Major changes since 1.5.7:
- Notifications rebuilt on Apprise (130+ services, reusable templates, per-target filters)
- New Daily Digest notification
- Independent quiet hours
- Redesigned settings page
- Vector-tile basemap (with automatic fallback to raster tiles on devices without WebGL support)
- An iOS pinch-zoom fix, and various mobile layout fixes.

## Verification

Umbrel testing performed:
- Installed via the standard production path on a live Umbrel device (pull digest-pinned images, restart umbrel.service) rather than a fresh install, exercising the actual update path existing users hit.
- Confirmed both containers reach a stable `Up` state (not crash-looping).
- Confirmed the dashboard loads, the version badge reads v1.6.2, and Settings loads and saves correctly.
- Confirmed the live map renders, including the new WebGL-unavailable fallback path (hit and fixed during this same verification pass, see below).
- Locally boot-tested both images directly (`docker run`) prior to push: dashboard returns HTTP 200 with the correct APP_VERSION and gunicorn workers boot cleanly; tracker starts and reaches its normal polling loop.
- Verified both pushed images are genuine multi-arch manifest lists (`docker buildx imagetools inspect`), not single-arch images mislabeled with a multi-arch tag.
- `npm run lint:apps -- skybro --check-images` passes clean.

This version also incorporates two real fixes found via this exact verification process rather than caught earlier: a CRLF line-ending bug that crash-looped both containers on some environments (1.6.1), and a blank map on browsers/GPUs without a working WebGL context (1.6.2's own fix, included here).

Environment tested:
- [x] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64 (local boot test)
- [x] arm64 (live on Umbrel device, Raspberry Pi 5)

Known lint warnings or caveats: none, `npm run lint:apps -- skybro --check-images` passes clean.

## Notes

No new Umbrel app dependencies (manifest `dependencies: []` unchanged) and no new default credentials or host permissions.

Config auto-migrate on first load. The old flat pushover_token/discord_webhook/alerts_enabled/iss_alerts_enabled fields convert automatically to the new Apprise-based notification structure. This is handled entirely in-app (idempotent, gated on whether the new structure already exists), requires no user action, and existing installs keep working unchanged until a user opts into the new notification features.

Also new: both service images add `apprise` as a pip dependency (container-level, not an Umbrel app dependency).