### PR TITLE
canary: Update to v1.6.3

### DIFF
--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.2@sha256:63483e14abb101c1976b8f821ec0b968307c062d754082461dc0f2cfe102f170
+    image: schjonhaug/canary-backend:v1.6.2@sha256:a7c952e59fc20e81ff66dea63e15b06a23ab447c40598262beeb41939b0bdc79
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.2@sha256:eb113acedef21ba05f4ac95c8e51b3bc5a46182735754f74636b768983608353
+    image: schjonhaug/canary-frontend:v1.6.2@sha256:2820ad93b9ec989fafd8903b6060954d5929d7fd38a977d51ab0c865e5198afa
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.1@sha256:5cf351492d4e0ddb8dc9575ce10ee7f52435e744c823c2594e6fe6f8b4e7cf3b
+    image: schjonhaug/canary-backend:v1.6.2@sha256:946e60b8df8846d55a0fccb0c3241d2da4a90efe0c3a9cfcf408b6012afb1c93
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.1@sha256:c121e722892016a609b7a8441aebbbbb81658dd6027d5eea62477579c16fffe7
+    image: schjonhaug/canary-frontend:v1.6.2@sha256:4e3c1967cf287daf613939b2fa394f89c987b1a517032972bccb4b41a40c49b4
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.2@sha256:946e60b8df8846d55a0fccb0c3241d2da4a90efe0c3a9cfcf408b6012afb1c93
+    image: schjonhaug/canary-backend:v1.6.2@sha256:63483e14abb101c1976b8f821ec0b968307c062d754082461dc0f2cfe102f170
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.2@sha256:4e3c1967cf287daf613939b2fa394f89c987b1a517032972bccb4b41a40c49b4
+    image: schjonhaug/canary-frontend:v1.6.2@sha256:eb113acedef21ba05f4ac95c8e51b3bc5a46182735754f74636b768983608353
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.2@sha256:a7c952e59fc20e81ff66dea63e15b06a23ab447c40598262beeb41939b0bdc79
+    image: schjonhaug/canary-backend:v1.6.3@sha256:12270b758c210eedeb0e30ed65377301b80391cdf6976cf3da2dc41d25662779
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.2@sha256:2820ad93b9ec989fafd8903b6060954d5929d7fd38a977d51ab0c865e5198afa
+    image: schjonhaug/canary-frontend:v1.6.3@sha256:74da3de670c9a9a387e4eee573af08f435c4de297b2c8d9ab3780fdb91c85f2b
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: canary
 category: bitcoin
 name: Canary Wallet
-version: "1.6.1"
+version: "1.6.2"
 tagline: Early warning system for Bitcoin cold storage
 description: >-
   A canary in the cold mine. When your bitcoins are in cold storage, you seldom check on them.

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -27,7 +27,7 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  Fixed self-hosted sign-in failures when a node changes its hostname, protocol, or external port, including dynamic StartOS ports. Login errors now provide clearer guidance, while existing passwords, wallets, contacts, and notification settings remain unchanged.
+  Improves Sparrow descriptor imports, Nostr relay authentication and test notifications, and Electrum subscription recovery. Fixes local-network webhooks and dark-mode display issues.
 path: ""
 deterministicPassword: true
 submitter: schjonhaug

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: canary
 category: bitcoin
 name: Canary Wallet
-version: "1.6.2"
+version: "1.6.3"
 tagline: Early warning system for Bitcoin cold storage
 description: >-
   A canary in the cold mine. When your bitcoins are in cold storage, you seldom check on them.


### PR DESCRIPTION
Updates Canary from 1.6.2 to 1.6.3, with pinned multi-architecture image digests and refreshed release notes. Improves Sparrow imports, Nostr notifications, Electrum recovery, local webhooks, and dark-mode display.

Supersedes #6057 and carries forward its pending packaging changes. The release script renamed the fork branch from `canary-v1.6.2` to `canary-v1.6.3`, closing the previous PR.

Validation:
- `npm run lint:apps -- canary --check-images` passed; both images support amd64 and arm64.
- Updated an existing x86_64 Umbrel installation from 1.6.2 through `apps.update`, reaching version 1.6.3 and ready state. arm64 images were verified but not run on a device.
- Contacts, notification destinations, instance settings, and notification history matched their pre-update row hashes; SQLite integrity passed. Both existing wallets remained accessible.
- Fresh-browser login through the Umbrel proxy, wallet/contact access, wallet-name edit and restoration, sign-out, and login after restart passed on both the hostname and LAN IP routes.
- The local v1.5.2 → 1.6.3 regtest upgrade gate passed, including notification semantics and restart deduplication.

Live ntfy delivery and inactive-contact non-delivery were not retested on this Umbrel device; those notification scenarios passed in the isolated regtest gate.
