### PR TITLE
Fix SkyBro releaseNotes rendering as one unbroken paragraph

### DIFF
--- a/skybro/umbrel-app.yml
+++ b/skybro/umbrel-app.yml
@@ -40,7 +40,7 @@ description: >-
   settings page. No config file editing required. Changes apply within 15
   seconds without restarting.
 
-releaseNotes: >
+releaseNotes: |
   - Notifications rebuilt on Apprise, supporting Pushover, Discord, Telegram, email, and 130+ other services, with reusable message templates and per-target filters
   - Added a Daily Digest notification: a scheduled one-line summary of yesterday's aircraft, today's satellite passes, and tonight's astronomy highlights, with a short and a detailed template to choose from
   - Added independent quiet hours for aircraft and satellite alerts


### PR DESCRIPTION
## Type

Metadata only

## App

App ID: skybro
Upstream project: https://github.com/xDeeKay/SkyBro
Version: 1.6.2

## Summary

The folded block scalar (>) collapses single newlines into spaces, so consecutive bullet lines with no blank line between them merge into one continuous paragraph instead of a line-broken list. Switch to a literal block scalar (|) to preserve the line breaks. This fixes the 1.6.2 release notes rendering as one unbroken paragraph on the app store's Update card (merged in #6066).

## Verification

Umbrel testing performed: none needed, this only changes a YAML block scalar style for a text field and doesn't touch the app's containers, config, or version.

Environment tested: Not runtime tested

Architecture tested: n/a

Known lint warnings or caveats: none. | and > are both standard YAML block scalar indicators; this is a one-line syntax change with no effect on any other field.

## Notes

No permissions, dependencies, migrations, or default credentials affected.