### PR TITLE
yuvomi: update to v2.65.1

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:2.65.0@sha256:3f9b861ac4a71a96007e5345bbfbaebf90398a03654454c522b061da0c18d82b
+    image: ghcr.io/ulsklyc/yuvomi:2.65.1@sha256:a402530b22758dfca9a0edb4c41082a279c4d7ae7f6583761d5630e8178bda0c
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "2.65.0"
+version: "2.65.1"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -51,57 +51,39 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  This is the first of the Tuesday interface releases, and it is a large one:
-  everything the interface gathered over the last week ships together here. Take
-  a backup before you update. On its first start the app runs sixteen database
-  migrations; let it finish on its own and wait until it answers again before
-  you open it. Migrations only run forward, so the way back is the backup you
-  took before the update, not an older image.
+  A small update with one fix you should know about: the search box at the top
+  of the app could show a household member the title and date of another
+  member's private calendar appointment, and of events from a subscribed
+  calendar that was never shared. The calendar itself never showed them; the
+  search did. Search now applies the same visibility rules as the calendar, so
+  the two return the same hits for the same word. This update runs no database
+  migration and starts as quickly as any other; a backup before updating is
+  still a good habit.
 
 
-  The Schedule module grew the most. A shift type can carry its own icon and
-  custom fields such as a room or a client, a member can be on call alongside a
-  regular shift, a weekly-hours target flags overtime and prints, a personal
-  read-only calendar feed lets you subscribe to your own shifts from any
-  calendar app, and an optional reminder can fire before a shift starts. A new
-  Overview tab puts several household members side by side for a week or a day,
-  and the quick start now offers work, school and university templates, which an
-  admin can hide per household.
+  Leaving the dashboard now really leaves it. Its clock, its quiet refresh, the
+  weather timer and the wall kitchen timer used to keep running in the
+  background after you moved to another page, and could redraw or even chime
+  there. They stop the moment you navigate away, and a dashboard refresh that
+  was overtaken by another one no longer paints an older state over a newer one.
 
 
-  Health follows the caregiver rule through: a caregiver an admin has entered
-  for a person now receives that person's medication reminders too, with the
-  name in front of the medication, and can correct the person's medication log.
-  The cycle tracker gains optional period and log-today reminders, graded
-  symptoms, basal body temperature with ovulation confirmation, a trends
-  section, symptom predictions on the calendar and a personal read-only feed of
-  predicted cycles.
+  In the calendar, birthdays stay visible while you filter by person. They used
+  to disappear with any selection, because a birthday belongs to a contact
+  rather than to a household member. The "Birthdays" switch in the filter sheet
+  remains the way to hide them.
 
 
-  Around the house: the shopping list is more compact and its categories fold
-  away and remember it. Documents can be shared from the viewer through the
-  device's own share sheet, whole folders can be uploaded in one go, and
-  deleting a folder can be undone for five seconds or take its documents with it
-  on purpose. The phone's month view can show event titles instead of dots,
-  recurring events carry a repeat icon, a deleted calendar entry no longer
-  reappears while its Undo is pending, and the person filter now applies to
-  shifts as well. Tasks can be filtered by category on the Board and in the
-  List, the add-subtask button stays put, a person can have a name day beside
-  the birthday, notes take personal and household categories, and the countdown
-  tile's grace period for overdue dates is now a household setting.
-
-
-  Two fixes are worth knowing about if you use the budget: a recurring entry now
-  keeps its account from the second month on, and months you already opened are
-  repaired once during this update; editing a series for all future occurrences
-  updates them in place instead of rebuilding them. The desktop sidebar has its
-  scrollbar back, Inventory and Schedule are properly translated in all 24
-  languages, and an older Yuvomi started on a newer database now says so instead
-  of running silently.
+  If your Mealie or Tandoor runs on a private address such as 192.168.x.x, the
+  app now tells you which setting to enable instead of blaming your credentials:
+  RECIPE_PROVIDER_ALLOW_PRIVATE_NETWORK=true. That switch has been required for
+  such addresses since 2.64.1 closed a gap in the network guard; the message has
+  caught up with it. The mail library moved to nodemailer 10; password-reset and
+  invitation mails work as before, and the SMTP settings are unchanged.
 
 
   Full release notes are available at
-  https://github.com/ulsklyc/yuvomi/releases/tag/v2.65.0
+  https://github.com/ulsklyc/yuvomi/releases/tag/v2.65.1
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db


### PR DESCRIPTION
Automated update of Yuvomi, prepared by the release workflow in `ulsklyc/yuvomi` and following this repo's `AGENTS.md`.

| | |
|---|---|
| Old version | `2.65.0` |
| New version | `2.65.1` |
| Upstream release | https://github.com/ulsklyc/yuvomi/releases/tag/v2.65.1 |
| Image | `ghcr.io/ulsklyc/yuvomi:2.65.1@sha256:a402530b22758dfca9a0edb4c41082a279c4d7ae7f6583761d5630e8178bda0c` |
| Architectures | linux/amd64, linux/arm64 |
| Linter | passed (`node .tools/lint-apps.mjs yuvomi --check-images`) |

**Package changes**

- `yuvomi/docker-compose.yml`
- `yuvomi/umbrel-app.yml`

Manifest `version`, `releaseNotes` and the pinned image digest. No changes to compose wiring, env vars, volumes, ports, `app_proxy`, hooks, exports or permissions, so there is nothing for existing installs to migrate.

**Breaking changes**

None. This is a patch/minor upstream release; see the upstream notes above for the user-visible list.

**Testing performed**

- Upstream CI (`npm test`) green on the release commit.
- Image pulled from the public registry and pinned by the multi-arch index digest; `linux/amd64` and `linux/arm64` verified to be present in the manifest list.
- Manifest and compose parsed as YAML after editing.
- Repo linter: passed (`node .tools/lint-apps.mjs yuvomi --check-images`)

**Not tested**: the update path was not exercised through umbrelOS itself - this workflow has no Umbrel instance. The package change is limited to the manifest version, the release notes and the image digest.
