### PR TITLE
Update SimpleTorrent to 1.4.0

### DIFF
--- a/simple-torrent/docker-compose.yml
+++ b/simple-torrent/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8086
 
   server:
-    image: boypt/cloud-torrent:1.3.9@sha256:90cc62869ebaabbdba31535cdff4c66ede98b341956d2ebcd6650610a37e9819
+    image: makrron/simple-torrent:1.4.0@sha256:c1e8c4722ad0a5c60c876ca0c6cd9fa5891df101fe274cedb736957484b8f0de
     user: "1000:1000"
     restart: on-failure
     command: >

--- a/simple-torrent/umbrel-app.yml
+++ b/simple-torrent/umbrel-app.yml
@@ -2,10 +2,10 @@ manifestVersion: 1.1
 id: simple-torrent
 category: networking
 name: SimpleTorrent
-version: "1.3.9-hotfix-1"
+version: "1.4.0"
 tagline: Download torrents with your Umbrel
 description: >-
-  SimpleTorrent is a a self-hosted remote torrent client that starts
+  SimpleTorrent is a self-hosted remote torrent client that starts
   torrents remotely, download sets of files on your Umbrel, which are then
   retrievable or streamable via web browser over HTTP. This project is a
   re-branded fork of cloud-torrent by jpillora. Features:
@@ -32,12 +32,21 @@ description: >-
 
   ⚠️ SimpleTorrent downloads torrents over the Clearnet, not Tor.
 releaseNotes: >-
-  - SimpleTorrent now utilizes the shared downloads folder that can be accessed by other apps on Umbrel, such as Jellyfin, File Browser, Transmission, Plex, and more.
-developer: Preston
-website: https://github.com/boypt
+  - Upgraded SimpleTorrent to v1.4.0 with modernized Go engine and native multi-arch container support.
+
+
+  - Overhauled built-in torrent search engine with modular providers, automatic mirror failovers, and updated scrapers (YTS, 1337X, The Pirate Bay, LimeTorrents, Nyaa, TorrentGalaxy, and more).
+
+
+  - Added clearer error feedback and transparent logging for upstream provider status.
+
+
+  - Full release notes: https://github.com/makrron/simple-torrent/releases/tag/v1.4.0
+developer: Preston & makrron
+website: https://github.com/makrron/simple-torrent
 dependencies: []
-repo: https://github.com/boypt/simple-torrent
-support: https://github.com/boypt/simple-torrent/issues
+repo: https://github.com/makrron/simple-torrent
+support: https://github.com/makrron/simple-torrent/issues
 port: 8086
 gallery:
   - 1.jpg


### PR DESCRIPTION
## Type

  App update

## App

  App ID: simple-torrent
  Upstream project: https://github.com/makrron/simple-torrent
  Version: 1.4.0

## Summary
  - Upgraded SimpleTorrent from legacy `1.3.9-hotfix-1` to `1.4.0`.
  - Switched from unpullable legacy image (`boypt/cloud-torrent:1.3.9` returning HTTP 401) to maintained multi-arch image `makrron/simple-torrent:1.4.0@sha256:c1e8c4722ad0a5c60c876ca0c6cd9fa5891df101fe274cedb736957484b8f0de` supporting `linux/amd64`, `linux/arm64` (Raspberry Pi 4/5), `linux/arm/v7`, and `linux/386`.
  - Overhauled torrent search engine with modular JSON scrapers, automatic mirror failover, and updated scrapers for active providers (YTS, 1337X, The Pirate Bay, LimeTorrents, Nyaa, TorrentGalaxy).
  - Upstream release notes: https://github.com/makrron/simple-torrent/releases/tag/v1.4.0


## Verification

  Umbrel testing performed:
  - Validated with Umbrel linter: `npm run lint:apps -- simple-torrent --check-images`passed with 0 errors and 0 warnings.
  - Code hygiene check: `git diff --check` passed cleanly.
  - Verified Docker execution: starts cleanly with non-root UID `1000:1000`, `--port=8086`, and volume mounts for `/torrents`, `/downloads`, and `/config`.

    Environment tested:
    - [x] Local Docker runtime & static linter verification
    - [x] Umbrel device
    - [x] Local umbrelOS test environment

    Architecture tested:
    - [x] amd64
    - [x] arm64 (verified multi-arch manifest index contains native arm64)

    Known lint warnings or caveats:
    None.

## Notes

  - Preserves existing permissions (`STORAGE_DOWNLOADS`), volumes, and `pre-start`
migration hook.
  - Upstream maintainer and repository updated to `makrron/simple-torrent`.
