### PR TITLE
Update PeerSwap to v7.0.0.1

### DIFF
--- a/peerswap/docker-compose.yml
+++ b/peerswap/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 1984
 
   web:
-    image: ghcr.io/impa10r/peerswap-web:v7.0.0@sha256:1d53f4409506772c3d030e2280af0f7dc3e61440326e94d964158200589241b3
+    image: ghcr.io/impa10r/peerswap-web:v7.0.0.1@sha256:f63b4dc6d305602b65df9ed6b63ae179063afc687decc6fd8176c2e5fce7ca74
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/peerswap/umbrel-app.yml
+++ b/peerswap/umbrel-app.yml
@@ -2,14 +2,13 @@ manifestVersion: 1
 id: peerswap
 category: bitcoin
 name: PeerSwap
-version: "7.0.0"
+version: "7.0.0.1"
 tagline: Balance your lightning channels with Liquid BTC
 description: PeerSwap enables Lightning Network nodes to balance their channels by facilitating atomic swaps with direct peers. PeerSwap enhances decentralization of the Lightning Network by enabling all nodes to be their own swap provider. No centralized coordinator, no 3rd party rent collector, and lowest cost channel balancing means small nodes can better compete with large nodes. Includes channel AutoFees, Liquid Peg-in and BTC send with coin select + fee bump functionality.
 developer: PeerSwap Project
 website: https://peerswap.dev
 dependencies:
   - lightning
-  - elements
   - bitcoin
 repo: https://github.com/Impa10r/peerswap-web
 support: https://discord.com/invite/wpNv3PG8G2
@@ -22,7 +21,7 @@ path: ""
 submitter: Impa10r
 submission: https://github.com/getumbrel/umbrel-apps/pull/932
 releaseNotes: >-
-  Bump protocol to v7, all peers must upgrade
+  Remove Elements dependency and allow running with BTC-only swaps.
 
 
   Full changelog: https://github.com/Impa10r/peerswap-web/blob/main/CHANGELOG.md


### PR DESCRIPTION
## Summary

Allows running PeerSwap without Liquid Network

## Verification

Umbrel testing performed:

Environment tested:
- [ ] Umbrel device
- [x] Local umbrelOS test environment 1.7.4 only
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64


