### PR TITLE
Update Roboats  to  v0.8.7-alpha

### DIFF
--- a/robosats/docker-compose.yml
+++ b/robosats/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 12596
 
   web:
-    image: recksato/robosats-client:v0.8.6-alpha@sha256:071634c1a73aa5eecdb4e7f84419319888fa10d238ae3ad2433a984301727fbe
+    image: recksato/robosats-client:v0.8.7-alpha@sha256:87b377ac3bde6fb5067fa64fd31ffbcf8861167f0e0a7f1d0d9bcc3c38cc75cb
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/robosats/umbrel-app.yml
+++ b/robosats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: robosats
 category: bitcoin
 name: RoboSats
-version: "v0.8.6-alpha"
+version: "v0.8.7-alpha"
 tagline: Simple and Private Bitcoin P2P Exchange
 description: >-
   RoboSats is a simple and private app to exchange bitcoin for national currencies. 
@@ -36,30 +36,30 @@ description: >-
 releaseNotes: >-
   After updating, hard-refresh RoboSats once (Ctrl/Cmd + Shift + R) to load the new client.
 
+  TL;DR
+  Security hardening across the full stack, live coordinator ranking by DevFund donations, federation consensus mechanism, image upload in encrypted chat, 3 new payment methods, and new coordinators (Eleuteria, Freeport, Ammanaya).
 
-  Highlights:
+  For Users
 
-    - Visual warning for orders with bonds below the default 3%
-    - Libraries security updates
-    - Removed 3 coordinators
+    - New coordinators joined the federation: Eleuteria, Freeport, Ammanaya — FreedomSats removed
+    - Image uploads in encrypted chat — Users can now upload E2E encrypted images in the order chat via Blossom. Only available on coordinators that opt in.
+    - Federation consensus mechanism
+    - Live coordinator ranking — coordinators are now sorted by their actual real-time DevFund donation value (devfund% × fee rate), falling back to the static federation.json value when unreachable
 
-  New payment methods:
+  New payment methods
 
-    - Doordash USA giftcard
-    - Wero
+    - eBay Gift Card
+    - MobilePay
+    - PYUSD
 
+  Bugs
 
-  Bugs:
+    - Fixed PGP armor blank line being stripped when escaping robot key headers, which broke PGP verification
+    - Fixed null premium default blocking order creation in the maker form
+    - Fixed sensitive data exposure on password-protected orders — location and description are now redacted from non-participants; password-protected orders are also excluded from the public order book
+    - Fixed Server-Side Request Forgery vector in the Android WebView interface
+    - Fixed Redis 8.x channel layer timeout causing WebSocket disconnections
 
-    - Infinite loading when reloading/renewing orders now properly catch up
-    - When loading any specific path different from root the app failed.
-    - Crash on mobile devices when switching between Fiat/Swap modes with a payment method selected
-    - Coordinator ratings showed different counts in the list view vs. the detail dialog
-    - UI overlap issue where the bond percentage was displayed simultaneously in both the Bond column and the Premium column on certain screen sizes
-    - Return OK on successful order cancel
-
-
-  Full release notes are available at https://github.com/RoboSats/robosats/releases/tag/v0.8.6-alpha
 developer: RoboSats
 website: https://learn.robosats.org
 dependencies: []


### PR DESCRIPTION
## Type

App update

## App

App ID: robosats
Upstream project: Robosats
Version: v0.8.7-alpha

## Summary

Full changelog here: https://github.com/RoboSats/robosats/releases/tag/v0.8.7-alpha

## Verification

Umbrel testing performed:

Environment tested:
- [ ] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [ ] amd64
- [ ] arm64

Known lint warnings or caveats:

## Notes

Permissions, dependencies, migrations, default credentials, or caveats:

For new apps, include screenshots and a logo reference. Umbrel will create the final App Store gallery assets.
