### PR TITLE
yuvomi: update to v2.65.2

### DIFF
--- a/yuvomi/docker-compose.yml
+++ b/yuvomi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:2.65.1@sha256:a402530b22758dfca9a0edb4c41082a279c4d7ae7f6583761d5630e8178bda0c
+    image: ghcr.io/ulsklyc/yuvomi:2.65.2@sha256:1d2cd32f316d9ee33cb4432fd0acde3d4b25210eb5ceb774af0a7b5e7e6bcea3
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/yuvomi/umbrel-app.yml
+++ b/yuvomi/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: yuvomi
 category: files
 name: Yuvomi
-version: "2.65.1"
+version: "2.65.2"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -51,39 +51,27 @@ description: >-
   Open Yuvomi from your Umbrel dashboard and create the first account — that
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: >-
-  A small update with one fix you should know about: the search box at the top
-  of the app could show a household member the title and date of another
-  member's private calendar appointment, and of events from a subscribed
-  calendar that was never shared. The calendar itself never showed them; the
-  search did. Search now applies the same visibility rules as the calendar, so
-  the two return the same hits for the same word. This update runs no database
-  migration and starts as quickly as any other; a backup before updating is
-  still a good habit.
+  This is a security release, and it changes nothing about how Yuvomi looks or
+  works day to day. It concerns API tokens that are limited to single modules,
+  such as a token handed to an AI assistant or an MCP client. A token allowed to
+  use the global search could read matching notes, contacts and medications
+  through it, and a token allowed to read the dashboard received the data of
+  every tile, although neither had been given those modules. Both now leave out
+  every module the token was not given. Browser sessions and tokens without
+  module limits see no change.
 
 
-  Leaving the dashboard now really leaves it. Its clock, its quiet refresh, the
-  weather timer and the wall kitchen timer used to keep running in the
-  background after you moved to another page, and could redraw or even chime
-  there. They stop the moment you navigate away, and a dashboard refresh that
-  was overtaken by another one no longer paints an older state over a newer one.
+  One thing to check after updating: a token that was given only the search or
+  the dashboard scope now returns empty results until you add the modules it
+  should be able to read.
 
 
-  In the calendar, birthdays stay visible while you filter by person. They used
-  to disappear with any selection, because a birthday belongs to a contact
-  rather than to a household member. The "Birthdays" switch in the filter sheet
-  remains the way to hide them.
-
-
-  If your Mealie or Tandoor runs on a private address such as 192.168.x.x, the
-  app now tells you which setting to enable instead of blaming your credentials:
-  RECIPE_PROVIDER_ALLOW_PRIVATE_NETWORK=true. That switch has been required for
-  such addresses since 2.64.1 closed a gap in the network guard; the message has
-  caught up with it. The mail library moved to nodemailer 10; password-reset and
-  invitation mails work as before, and the SMTP settings are unchanged.
+  Nothing changes in the database with this update, so it is a plain container
+  swap with no migration to wait for.
 
 
   Full release notes are available at
-  https://github.com/ulsklyc/yuvomi/releases/tag/v2.65.1
+  https://github.com/ulsklyc/yuvomi/releases/tag/v2.65.2
 backupIgnore:
   - data/app/yuvomi.db.plaintext-backup*
   - data/backups/*.db


### PR DESCRIPTION
Automated update of Yuvomi, prepared by the release workflow in `ulsklyc/yuvomi` and following this repo's `AGENTS.md`.

| | |
|---|---|
| Old version | `2.65.1` |
| New version | `2.65.2` |
| Upstream release | https://github.com/ulsklyc/yuvomi/releases/tag/v2.65.2 |
| Image | `ghcr.io/ulsklyc/yuvomi:2.65.2@sha256:1d2cd32f316d9ee33cb4432fd0acde3d4b25210eb5ceb774af0a7b5e7e6bcea3` |
| Architectures | linux/amd64, linux/arm64 |
| Linter | passed (`node .tools/lint-apps.mjs yuvomi --check-images`) |

**Package changes**

- `yuvomi/docker-compose.yml`
- `yuvomi/umbrel-app.yml`

Manifest `version`, `releaseNotes` and the pinned image digest. No changes to compose wiring, env vars, volumes, ports, `app_proxy`, hooks, exports or permissions, so there is nothing for existing installs to migrate.

**Breaking changes**

None. This is a patch/minor upstream release; see the upstream notes above for the user-visible list.

**Testing performed**

- Upstream CI (`npm test`) green on the release commit.
- Image pulled from the public registry and pinned by the multi-arch index digest; `linux/amd64` and `linux/arm64` verified to be present in the manifest list.
- Manifest and compose parsed as YAML after editing.
- Repo linter: passed (`node .tools/lint-apps.mjs yuvomi --check-images`)

**Not tested**: the update path was not exercised through umbrelOS itself - this workflow has no Umbrel instance. The package change is limited to the manifest version, the release notes and the image digest.
