### PR TITLE
Release Bisq 2 Node 2.1.12.1

### DIFF
--- a/bisq2-node/docker-compose.yml
+++ b/bisq2-node/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       APP_PORT: 8091
 
   server:
-    image: ghcr.io/bisq-network/bisq2-api:2.1.12.0@sha256:beba2f2db5aefca0f4b8d49285b105cb0b29d0eb0ed0f8136712aace0e167906
+    image: ghcr.io/bisq-network/bisq2-api:2.1.12.1@sha256:79fb71d64d23863c8f48d484a9d84754dae40e12cb395bca348f17dcec46b297
     restart: on-failure
     stop_grace_period: 1m
     mem_limit: 2g
@@ -24,7 +24,7 @@ services:
       - ${APP_DATA_DIR}/data:/data
 
   web:
-    image: ghcr.io/bisq-network/bisq2-api-web-ui:2.1.12.0@sha256:d64c335cc21c69dc8d62f360e5d29ab974d0949f320ba1658cab0a4d5cc7f310
+    image: ghcr.io/bisq-network/bisq2-api-web-ui:2.1.12.1@sha256:3819d97d98b12fc4ea7253c1da69ca201b85d500e36c992b8bb71173500036a5
     restart: on-failure
     network_mode: "service:server"
     volumes:

--- a/bisq2-node/umbrel-app.yml
+++ b/bisq2-node/umbrel-app.yml
@@ -34,4 +34,8 @@ defaultUsername: ""
 defaultPassword: ""
 submitter: rodvar
 submission: https://github.com/getumbrel/umbrel-apps/pull/5850
-releaseNotes: "Update to Bisq 2 API 2.1.12 (bisq2 @ fb9849b). Full changes: https://github.com/bisq-network/bisq2/compare/v2.1.12...fb9849b"
+releaseNotes: >-
+  Adds support for public and private chats and My Contacts in Bisq Connect. This update also improves permissions for existing paired devices and fixes handling of trading restrictions.
+
+
+  Full changes can be found at https://github.com/bisq-network/bisq2/compare/a1f8db129d2a1a473d249ff19120f701c1a3be58...fb9849bd5dd83174d11806e8d404141464d4911e

--- a/bisq2-node/umbrel-app.yml
+++ b/bisq2-node/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bisq2-node
 category: bitcoin
 name: Bisq 2 Node
-version: "2.1.12.0"
+version: "2.1.12.1"
 tagline: Run your own Bisq 2 node for private Bitcoin trading
 description: >-
   Bisq Connect lets you buy and sell Bitcoin peer-to-peer from your phone. This
@@ -34,8 +34,4 @@ defaultUsername: ""
 defaultPassword: ""
 submitter: rodvar
 submission: https://github.com/getumbrel/umbrel-apps/pull/5850
-releaseNotes: >-
-  Important security update that fixes vulnerabilities identified during Bisq's recent security audit. Updating to this version is required to continue trading.
-
-
-  Full release notes can be found at https://github.com/bisq-network/bisq2/releases/tag/v2.1.12
+releaseNotes: "Update to Bisq 2 API 2.1.12 (bisq2 @ fb9849b). Full changes: https://github.com/bisq-network/bisq2/compare/v2.1.12...fb9849b"


### PR DESCRIPTION
Automated by the Release Umbrel images workflow (channel: official), opened from fork `rodvar/umbrel-apps` (we have pull-only access to `getumbrel/umbrel-apps`). Digest-pins the freshly-built images and bumps the manifest version to `2.1.12.1`. Merge to publish.