### PR TITLE
openclaw: add authenticated native gateway access

### DIFF
--- a/openclaw/docker-compose.yml
+++ b/openclaw/docker-compose.yml
@@ -16,3 +16,7 @@ services:
       - ${APP_DATA_DIR}/data/linuxbrew:/home/linuxbrew
     environment:
       APP_SEED: ${APP_SEED}
+      UMBREL_OPENCLAW_REMOTE_PASSWORD: ${APP_PASSWORD}
+      NATIVE_GATEWAY_PORT: 18791
+    ports:
+      - "18791:18791/tcp"

--- a/openclaw/umbrel-app.yml
+++ b/openclaw/umbrel-app.yml
@@ -3,9 +3,10 @@ id: openclaw
 name: OpenClaw
 tagline: The AI that actually does things
 category: ai
-version: "2026.9.2"
+version: "2026.9.2-1"
 port: 18789
 path: ""
+deterministicPassword: true
 description: >-
   Clears your inbox, sends emails, manages your calendar, checks you in for flights.
   All from WhatsApp, Telegram, or any chat app you already use.
@@ -20,6 +21,21 @@ description: >-
 
 
   OpenClaw is also running behind the umbrelOS app proxy, so only you can securely access your OpenClaw instance.
+
+
+  ## Connect desktop apps and nodes
+
+    - In the client, choose **Remote (another host) → Direct (ws/wss)**.
+
+    - Use `ws://umbrel.local:18791`, `ws://<LAN-IP>:18791`, or `ws://<Tailscale-IP>:18791`.
+
+    - Copy the password from OpenClaw's app settings in Umbrel and enter it in the client's **Gateway token** field.
+
+    - Approve the new device or node in OpenClaw.
+
+
+  Port 18791 is intended for a trusted private LAN or Tailnet. Do not forward it directly to the public internet;
+  use a properly configured `wss://` endpoint over untrusted networks.
 
 
   ## What It Does
@@ -39,20 +55,19 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  This update adds support for GPT-6 Astra, faster chat and dashboard loading,
-  and easier switching between connected accounts. Agents can work on tasks in
-  parallel with live progress, and dashboards offer more flexible layouts.
+  This package update adds an authenticated connection endpoint for OpenClaw
+  desktop apps and nodes while keeping browser access protected by umbrelOS.
 
 
-  It also improves scheduled automations, messaging reliability, and recovery
-  of in-progress replies after restarts.
+  Connect over a trusted local network or Tailnet using
+  `ws://umbrel.local:18791` and the password shown in OpenClaw's app settings.
+  New clients must be approved in OpenClaw before they can connect.
 
 
-  If you use OpenProse, its bundled plugin and /prose command have been removed.
-  Your existing .prose source files are kept. To continue using OpenProse as a
-  skill, follow the migration guide at https://docs.openclaw.ai/prose
+  Do not forward port 18791 directly to the public internet because `ws://` is
+  unencrypted. Use a properly configured `wss://` endpoint over untrusted networks.
 
 
-  Full release notes can be found at https://github.com/openclaw/openclaw/releases/tag/v2026.9.2
+  Existing OpenClaw settings and provider credentials are preserved.
 submitter: Umbrel
 submission: https://github.com/getumbrel/umbrel-apps/pull/4649


### PR DESCRIPTION
## Summary

- publish a dedicated WebSocket-only Gateway endpoint on port `18791` for native OpenClaw clients and nodes
- use Umbrel's deterministic app password for direct-client authentication
- document LAN and Tailnet connection details in the App Store description and release notes
- keep the existing browser UI on port `18789` behind Umbrel's authenticated `app_proxy`

Closes #6072.

## Security model

This does not bypass Umbrel authentication for the browser UI or whitelist the Gateway through `app_proxy`. Native clients use a separate listener implemented by the companion wrapper change in getumbrel/openclaw-umbrel#92.

That listener accepts WebSocket upgrades only, strips ambient proxy identity, forwarding, cookie, HTTP authorization, and spoofable handshake headers, maps OpenClaw's current macOS token field to password authentication, and requires explicit OpenClaw device/node pairing. The description warns users not to expose plaintext `ws://` directly to the public internet; untrusted networks require a properly configured `wss://` endpoint.

No host networking, elevated privileges, host mounts, Tailscale integration, or umbrelOS system changes are added.

## Compatibility

- existing browser URL and port remain unchanged: `http://umbrel.local:18789`
- native clients use `ws://umbrel.local:18791`, a LAN IP, or a Tailscale IP
- existing `/data` persistence and provider credentials are unchanged
- Tailscale is optional; the endpoint also works on an ordinary private LAN

## Draft dependency

This PR intentionally remains a draft until getumbrel/openclaw-umbrel#92 is accepted and an official public multi-architecture image is published. The image reference in this branch is still the currently released image and must be updated to the new tag and immutable manifest-list digest before this PR is marked ready or merged.

## Validation

- [x] `npm run lint:apps -- openclaw --check-images` — no issues
- [x] `git diff --check`
- [x] companion wrapper unit/security suite — 15 passed, 1 image-only check skipped outside the image
- [x] disposable wrapper integration suite on an `amd64` image — dashboard, trusted-proxy auth, signed-device enrollment, stale/spoofed header handling, TLS proxy handling, and cross-origin rejection passed
- [x] native-listener smoke test on that image — password authentication reached explicit pairing, spoofed ambient identity was stripped, approval through the authenticated browser succeeded, and the approved client completed a health RPC
- [ ] update package to the official multi-architecture wrapper image and immutable digest
- [ ] verify both `linux/amd64` and `linux/arm64` in that published image index
- [ ] repeat the real update path on an existing `amd64` Umbrel installation, including browser access, native connection, pairing, restart, persistence, and settled logs

The current local test image was built from wrapper commit `dec7af5cdc3de17c38f0213386b384adbfdb1231`; it is not referenced by this package and is not proposed as a release artifact.
