### PR TITLE
canary: Update to v1.6.4

### DIFF
--- a/canary/docker-compose.yml
+++ b/canary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_WHITELIST: "/api/*"
 
   backend:
-    image: schjonhaug/canary-backend:v1.6.3@sha256:12270b758c210eedeb0e30ed65377301b80391cdf6976cf3da2dc41d25662779
+    image: schjonhaug/canary-backend:v1.6.4@sha256:b2a0e5561f481afa36aefc68373d39a589ff9fca906c2c3ef4cb5f89ce4b3399
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
@@ -29,7 +29,7 @@ services:
       - ${APP_DATA_DIR}/data:/app/data
 
   web:
-    image: schjonhaug/canary-frontend:v1.6.3@sha256:74da3de670c9a9a387e4eee573af08f435c4de297b2c8d9ab3780fdb91c85f2b
+    image: schjonhaug/canary-frontend:v1.6.4@sha256:7dc1dc2bcf7cc973f683d0ab13b9292b275e8f52363e9e90225bd856d33a042c
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: canary
 category: bitcoin
 name: Canary Wallet
-version: "1.6.3"
+version: "1.6.4"
 tagline: Early warning system for Bitcoin cold storage
 description: >-
   A canary in the cold mine. When your bitcoins are in cold storage, you seldom check on them.

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -27,7 +27,7 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  Fixes self-hosted ntfy so private Docker, LAN, and Tailscale URLs work. Also keeps notification identities and email-provider details out of logs and errors.
+  Fixes self-hosted ntfy so private Docker, LAN, and Tailscale URLs work. Also keeps notification identities and delivery errors out of logs.
 path: ""
 deterministicPassword: true
 submitter: schjonhaug

--- a/canary/umbrel-app.yml
+++ b/canary/umbrel-app.yml
@@ -27,7 +27,7 @@ gallery:
   - 2.jpg
   - 3.jpg
 releaseNotes: >-
-  Improves Sparrow descriptor imports, Nostr relay authentication and test notifications, and Electrum subscription recovery. Fixes local-network webhooks and dark-mode display issues.
+  Fixes self-hosted ntfy so private Docker, LAN, and Tailscale URLs work. Also keeps notification identities and email-provider details out of logs and errors.
 path: ""
 deterministicPassword: true
 submitter: schjonhaug


### PR DESCRIPTION
## Summary
Update Canary Umbrel app to v1.6.4.

## Release summary
Fixes self-hosted ntfy so private Docker, LAN, and Tailscale URLs work. Also keeps notification identities and email-provider details out of logs and errors.

## Upstream release
https://github.com/schjonhaug/canary/releases/tag/v1.6.4

## Test plan
- [x] Upgraded a local Umbrel installation from its previously published Canary package directly to v1.6.4
- [x] Verified existing wallets, notification contacts, destinations, settings, and history were preserved
- [x] Verified live delivery through Umbrel's detected local ntfy server and inactive-contact non-delivery
- [x] Restarted Canary and verified the migrated data remained intact without duplicate delivery
