### PR TITLE
Update PeerSwap to v7.0.1

### DIFF
--- a/peerswap/docker-compose.yml
+++ b/peerswap/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 1984
 
   web:
-    image: ghcr.io/impa10r/peerswap-web:v7.0.0@sha256:1d53f4409506772c3d030e2280af0f7dc3e61440326e94d964158200589241b3
+    image: ghcr.io/impa10r/peerswap-web:v7.0.1@sha256:a57c4863e0c55c954b82b91ddf5f2a6b780ffe11233cb0bca87e0b3d14c2120e
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/peerswap/umbrel-app.yml
+++ b/peerswap/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: peerswap
 category: bitcoin
 name: PeerSwap
-version: "7.0.0"
+version: "7.0.1"
 tagline: Balance your lightning channels with Liquid BTC
 description: PeerSwap enables Lightning Network nodes to balance their channels by facilitating atomic swaps with direct peers. PeerSwap enhances decentralization of the Lightning Network by enabling all nodes to be their own swap provider. No centralized coordinator, no 3rd party rent collector, and lowest cost channel balancing means small nodes can better compete with large nodes. Includes channel AutoFees, Liquid Peg-in and BTC send with coin select + fee bump functionality.
 developer: PeerSwap Project
@@ -22,7 +22,13 @@ path: ""
 submitter: Impa10r
 submission: https://github.com/getumbrel/umbrel-apps/pull/932
 releaseNotes: >-
-  Bump protocol to v7, all peers must upgrade
+  🚨 Important security update. We recommend all users update immediately.
+
+
+  This release upgrades PeerSwap to 7.0.1 that disables incoming and outgoing new L-BTC swaps but doesn't fully disable L-BTC to allow for recovery of past swaps
+
+
+  Security announcement: https://status.blockstream.com/incidents/b8b719f3-db70-4487-9cff-946e69509228
 
 
   Full changelog: https://github.com/Impa10r/peerswap-web/blob/main/CHANGELOG.md


### PR DESCRIPTION
Disable new L-BTC swaps until Liquid Federation resumes peg-outs.

## Verification

Umbrel testing performed:

Environment tested:
- [ ] Umbrel device
- [x] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64
