### PR TITLE
Update Bitcoin Regtest Dashboard to v1.1.0

### DIFF
--- a/bitcoin-regtest-dashboard/docker-compose.yml
+++ b/bitcoin-regtest-dashboard/docker-compose.yml
@@ -5,6 +5,12 @@ services:
     environment:
       APP_HOST: bitcoin-regtest-dashboard_dashboard_1
       APP_PORT: 3000
+      # The dashboard UI stays behind umbrelOS authentication. The HTTP API is
+      # exempt so scripts, test suites and agents running on other machines can
+      # reach it without umbrelOS credentials, which is the point of the API.
+      # Both rules are needed: "/api/*" does not match the bare /api index.
+      # Set API_TOKEN on the dashboard service below to require a bearer token.
+      PROXY_AUTH_WHITELIST: "/api,/api/*"
 
   # Bitcoin Core in regtest mode (self-contained, no dependencies)
   bitcoin:

--- a/bitcoin-regtest-dashboard/docker-compose.yml
+++ b/bitcoin-regtest-dashboard/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   # Bitcoin Core in regtest mode (self-contained, no dependencies)
   bitcoin:
-    image: ghcr.io/getumbrel/docker-bitcoind:v31.0@sha256:89185fc2792a9824cbe18f7ad4ead02a3a9a14adf5b34eb42f60ebec36201fa0
+    image: ghcr.io/getumbrel/docker-bitcoind:v31.1@sha256:e0a94f8390f4fee796faba306719860a1ba61e8fa841416bca26fd4e1e94cb8c
     user: "1000:1000"
     restart: on-failure
     entrypoint: ["/bin/sh", "-c"]
@@ -29,6 +29,7 @@ services:
         while [ ! -f /data/.bitcoin/regtest/.cookie ]; do sleep 1; done
         chmod 755 /data/.bitcoin/regtest
         chmod 644 /data/.bitcoin/regtest/.cookie
+        chmod 644 /data/.bitcoin/regtest/debug.log 2>/dev/null || true
         sleep 2
         bitcoin-cli -regtest -rpccookiefile=/data/.bitcoin/regtest/.cookie createwallet "regtest_wallet" 2>/dev/null || \
           bitcoin-cli -regtest -rpccookiefile=/data/.bitcoin/regtest/.cookie loadwallet "regtest_wallet" 2>/dev/null || true
@@ -37,6 +38,7 @@ services:
         while kill -0 $$BITCOIND_PID 2>/dev/null; do
           chmod 755 /data/.bitcoin/regtest 2>/dev/null
           chmod 644 /data/.bitcoin/regtest/.cookie 2>/dev/null
+          chmod 644 /data/.bitcoin/regtest/debug.log 2>/dev/null
           sleep 5
         done &
         wait $$BITCOIND_PID
@@ -71,7 +73,7 @@ services:
 
   # Bitcoin Regtest Dashboard
   dashboard:
-    image: coreylphillips/bitcoin-regtest-dashboard:v1.0.4@sha256:d71e099ec53426cecd05899a7f8efe2b73bfc1d0c21750ac53dc2b2dad107820
+    image: coreylphillips/bitcoin-regtest-dashboard:v1.1.0@sha256:41835f0f891ecaf7a581f89adac2c6c305669b30618973fab5a7aac251e0d677
     user: "1000:1000"
     restart: on-failure
     environment:
@@ -82,6 +84,7 @@ services:
       ELECTRS_HOST: bitcoin-regtest-dashboard_electrs_1
       ELECTRS_PORT: 50001
       ELECTRS_EXTERNAL_PORT: 60401
+      BITCOIN_DEBUG_LOG: /bitcoin/.bitcoin/regtest/debug.log
     volumes:
       - ${APP_DATA_DIR}/data/bitcoin:/bitcoin/.bitcoin:ro
     depends_on:

--- a/bitcoin-regtest-dashboard/umbrel-app.yml
+++ b/bitcoin-regtest-dashboard/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: bitcoin-regtest-dashboard
 category: bitcoin
 name: Bitcoin Regtest Dashboard
-version: "1.0.4"
+version: "1.1.0"
 tagline: Development toolkit for Bitcoin regtest
 description: >-
   A self-contained development dashboard with its own Bitcoin Core regtest node and Electrs instance. No external dependencies required.
@@ -19,14 +19,26 @@ description: >-
     - Browse mempool and blocks
     - Decode and broadcast raw transactions
     - Full RPC console for advanced commands
+    - Live log viewer for Bitcoin Core and the dashboard
+    - Local HTTP API with an OpenAPI spec, for driving regtest from your own apps and scripts
 
 
   Perfect for Bitcoin developers who need quick access to regtest node functionality
   for testing wallets, applications, and Bitcoin integrations.
 releaseNotes: >-
-  - Added an auto-mine feature to mine blocks at a set interval, either until stopped or for a chosen duration
+  - Added a documented local HTTP API so test suites, scripts and AI agents can drive the regtest network from other apps
 
-  - Upgraded Bitcoin Core to v31.0
+  - Added a Logs tab that tails Bitcoin Core and dashboard logs live, with filtering and debug category control
+
+  - Added an API tab with connection details, copyable commands and a searchable endpoint reference
+
+  - Added a faucet endpoint that funds an address and confirms it in one call
+
+  - Added reorg and wait endpoints for testing how wallets handle chain changes
+
+  - Added optional API token authentication, off by default
+
+  - Upgraded Bitcoin Core to v31.1
 developer: Corey Phillips
 website: https://github.com/coreyphillips/bitcoin-regtest-dashboard
 dependencies: []


### PR DESCRIPTION
## Type

App update

## App

App ID: bitcoin-regtest-dashboard
Upstream project: https://github.com/coreyphillips/bitcoin-regtest-dashboard
Version: 1.1.0 (from 1.0.4)

## Summary

Updates Bitcoin Regtest Dashboard to v1.1.0. The theme of this release is making the app usable from outside its own browser tab, so other projects on the same machine can drive the regtest network.

- Adds a documented local HTTP API. The app already spoke JSON over HTTP, but only to feed its own frontend. It now publishes an index at `/api`, an OpenAPI 3.1 spec at `/api/openapi.json`, and a compact plain text reference at `/api/llms.txt`, so a test suite or an AI agent can discover and drive it.
- Adds a Logs tab that tails Bitcoin Core's `debug.log` and the dashboard's own output live, with filtering, pause and download, plus runtime control of Bitcoin Core's logging categories. The same logs are available over the API, which means troubleshooting no longer requires shell access to the host.
- Adds an API tab with connection details, copyable commands, and a searchable endpoint reference rendered from the served OpenAPI document.
- Adds higher level endpoints for testing: a faucet that funds an address and confirms it in one call (mining first when the wallet has no mature balance, since regtest coinbase needs 100 confirmations), a chain reorg endpoint, and long polling wait helpers.
- Adds optional API token authentication via `API_TOKEN`. It is off by default, so behavior is unchanged for existing installs.
- Upgrades the bundled Bitcoin Core node from v31.0 to v31.1, a bugfix release.

Image changes:

- dashboard: `coreylphillips/bitcoin-regtest-dashboard` v1.0.4 to v1.1.0 (built for amd64 and arm64)
- bitcoin: `ghcr.io/getumbrel/docker-bitcoind` v31.0 to v31.1

Compose changes beyond the image pins:

- The permission maintenance loop now also keeps `debug.log` readable, alongside the cookie it already handled. Bitcoin Core writes that file mode 0600 and the new log viewer needs to read it.
- Adds `BITCOIN_DEBUG_LOG` to the dashboard environment to make the log path explicit. The app derives it from the cookie path when unset, so this is documentation rather than a functional change.
- Adds `PROXY_AUTH_WHITELIST: "/api,/api/*"` to the app proxy. See below.

## On the auth whitelist

The dashboard UI stays behind umbrelOS authentication. Only the HTTP API is exempt.

The whole point of this release is that another machine can drive the regtest node, so requiring umbrelOS credentials on the API would mean handing a wallet test suite or an agent the user's umbrelOS password just to mine a block. This follows the established pattern in this repo; 23 apps already whitelist `/api/*`.

Two notes for reviewers:

- Both rules are needed. Reading `pathMatches` in `app-gateway.ts`, a `/api/*` rule takes the `endsWith('/*')` branch and matches only `requestPath.startsWith('/api/')`, so it does not match the bare `/api` index, which is the discovery endpoint a client reads first. `"/api*"` would cover both but also matches unrelated paths like `/apifoo`, so the explicit pair is used instead.
- This is a regtest-only app. The coins are worthless by construction and the node is disposable. For anyone who still wants the API locked down, this release adds `API_TOKEN` on the dashboard service, which requires a bearer token on every API route except the three discovery endpoints.

## Verification

Umbrel testing performed: Verified against a fresh self-contained stack built from the app repo. The node reports `/Satoshi:31.1.0/`. A smoke suite covering all 78 endpoints passes with and without an API token, starting from an empty chain so the faucet's mining path is exercised. Separately pulled the published multi-arch image and ran it as `user: "1000:1000"` against the same node, matching how this compose file runs it, and confirmed it boots, serves the frontend, and can read `debug.log` under that uid. The Logs and API tabs were exercised in a browser, including confirming a block mined over the API appears in the live log stream. Not yet installed and tested as an app on umbrelOS.

Environment tested:
- [x] Umbrel device
- [ ] Local umbrelOS test environment
- [x] Not runtime tested on umbrelOS (runtime tested via docker compose only)

Architecture tested:
- [x] amd64
- [ ] arm64 (built, not runtime tested)

Known lint warnings or caveats: None.

## Notes

No new permissions, dependencies, migrations, or default credentials. The app stays self-contained, bundling its own Bitcoin Core regtest node and Electrs instance.

The only behavioral change for an existing install is the auth whitelist described above, which is scoped to `/api` and leaves the UI gated as before.

