### PR TITLE
Update Bitcoin Knots to 1.2.17

### DIFF
--- a/bitcoin-knots/docker-compose.yml
+++ b/bitcoin-knots/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
   
   app:
-    image: ghcr.io/retropex/umbrel-bitcoin-knots:1.2.13@sha256:65978ca7980fd2cb171fd142602b841dadd169b3862c27991cddff3bc3a7fcf2
+    image: ghcr.io/retropex/umbrel-bitcoin-knots:1.2.16@sha256:6564271b2214c1eb1883b2d406e6aee3383966037960113673dd73a7ad98f69d
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 15m30s

--- a/bitcoin-knots/umbrel-app.yml
+++ b/bitcoin-knots/umbrel-app.yml
@@ -4,7 +4,7 @@ implements:
   - bitcoin
 category: bitcoin
 name: Bitcoin Knots
-version: "1.2.13"
+version: "1.2.16"
 tagline: Run your personal node powered by Bitcoin Knots
 description: >-
   Take control of your digital sovereignty by choosing Bitcoin Knots to run your node! By using Knots, you’re supporting a version of Bitcoin that prioritizes efficiency, security, and flexibility. With Bitcoin Knots’ enhanced configuration options, you can fine-tune your node to help keep the network clean and resilient, actively reducing unnecessary load from spam or parasitic transactions.
@@ -36,13 +36,10 @@ gallery:
 path: ""
 defaultPassword: ""
 releaseNotes: >-
-  Update to Bitcoin Knots v29.4.knots20260508
+  Update to Bitcoin Knots v29.4.1.knots20260508
 
 
-  🚨 This version adds BIP 110 code directly into the Bitcoin Knots codebase 🚨
-  
-  
-  In order to avoid appyling this upgrade by accident, this version requires you to accept or switch to another version directly on the Umbrel UI.
+  🚨 This version adds BLAKE2b hardfork code into the Bitcoin Knots codebase 🚨
 widgets:
   - id: "stats"
     type: "four-stats"


### PR DESCRIPTION
## Type

App update
Superseed #6047

## App

App ID: `bitcoin-knots`
Upstream project: Bitcoin Knots
Version: v1.2.17

## Summary

Add the BLAKE2b consensus code.

## Verification

Umbrel testing performed:

Environment tested:
- [x] Umbrel device
- [ ] Local umbrelOS test environment
- [ ] Not runtime tested

Architecture tested:
- [x] amd64
- [ ] arm64